### PR TITLE
Rename repo + remove Winston MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![wercker status](https://app.wercker.com/status/3e08a89169eeafef8ec020a9ceafe204/s/master "wercker status")](https://app.wercker.com/project/byKey/3e08a89169eeafef8ec020a9ceafe204) [![codecov](https://codecov.io/gh/DoSomething/gambit/branch/develop/graph/badge.svg)](https://codecov.io/gh/DoSomething/gambit)
+[![wercker status](https://app.wercker.com/status/3e08a89169eeafef8ec020a9ceafe204/s/master "wercker status")](https://app.wercker.com/project/byKey/3e08a89169eeafef8ec020a9ceafe204) [![codecov](https://codecov.io/gh/DoSomething/gambit-campaigns/branch/master/graph/badge.svg)](https://codecov.io/gh/DoSomething/gambit-campaigns)
 
 # Gambit Campaigns
 Gambit Campaigns is an internal DoSomething.org service for completing Campaigns via [Gambit Conversations](https://github.com/dosomething/gambit-conversations). Gambit Campaigns is built using [Express](http://expressjs.com/) and [MongoDB](https://www.mongodb.com).
@@ -21,5 +21,5 @@ Next, fork and clone this repository. To run Gambit Campaigns locally:
 
 ### License
 &copy;2017 DoSomething.org. Gambit Campaigns is free software, and may be redistributed under the terms specified
-in the [LICENSE](https://github.com/DoSomething/gambit/blob/dev/LICENSE) file. The name and logo for
+in the [LICENSE](https://github.com/DoSomething/gambit-campaigns/blob/dev/LICENSE) file. The name and logo for
 DoSomething.org are trademarks of Do Something, Inc and may not be used without permission.

--- a/config/logger.js
+++ b/config/logger.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const logger = require('winston');
-require('winston-mongodb').MongoDB; // eslint-disable-line no-unused-expressions
 
 const WINSTON_LEVEL = process.env.LOGGING_LEVEL || 'info';
 
@@ -11,10 +10,6 @@ module.exports = function init(options) {
       new logger.transports.Console({
         prettyPrint: true,
         colorize: true,
-        level: WINSTON_LEVEL,
-      }),
-      new logger.transports.MongoDB({
-        db: options.dbUri,
         level: WINSTON_LEVEL,
       }),
     ],

--- a/config/logger.js
+++ b/config/logger.js
@@ -4,7 +4,7 @@ const logger = require('winston');
 
 const WINSTON_LEVEL = process.env.LOGGING_LEVEL || 'info';
 
-module.exports = function init(options) {
+module.exports = function init() {
   logger.configure({
     transports: [
       new logger.transports.Console({

--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
     "throng": "^4.0.0",
     "underscore": "^1.8.3",
     "v8-profiler": "5.7.0",
-    "winston": "2.3.x",
-    "winston-mongodb": "^2.0.0"
+    "winston": "2.3.x"
   },
   "devDependencies": {
     "@dosomething/eslint-config": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DoSomething/gambit.git"
+    "url": "git+https://github.com/DoSomething/gambit-campaigns.git"
   },
   "scripts": {
     "test": "NODE_ENV=test ava --serial",


### PR DESCRIPTION
#### What's this PR do?
* Changes Github URL's to `gambit-campaigns` - closes #942 
* Removes Winston MongoDB, I don't think I've ever queried this - it was added from the legacy days. Logstash should deprecate?

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Ideally our logger should be refactored in the future, to DRY Gambit Conversations and Blink sharing the same Request Id's (#900, https://github.com/DoSomething/gambit-conversations/pull/228)

#### Relevant tickets
Fixes #989 

#### Checklist
- [x] Tested on staging.
