### PR TITLE
Invalidates decimal reportback quantities.

### DIFF
--- a/config/lib/helpers/reportback.js
+++ b/config/lib/helpers/reportback.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  minTextLength: 3,
+  maxTextLength: 255,
+  ellipsis: '...',
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -36,34 +36,6 @@ module.exports.getFirstWord = function (message) {
 };
 
 /**
- * @param {string} message
- * @return {boolean}
- */
-module.exports.hasLetters = function (message) {
-  return RegExp(/[a-zA-Z]/g).test(message);
-};
-
-/**
- * Checks if given input string contains a valid Reportback quantity.
- * @param {string} input
- * @return {boolean}
- */
-module.exports.isValidReportbackQuantity = function (input) {
-  // TODO: Make this much better!
-  // @see https://github.com/DoSomething/gambit/issues/608
-  return (Number(input) && !this.hasLetters(input));
-};
-
-/**
- * Checks if given input string contains a valid Reportback text field.
- * @param {string} input
- * @return {boolean}
- */
-module.exports.isValidReportbackText = function (input) {
-  return !!(input && input.trim().length > 3 && this.hasLetters(input));
-};
-
-/**
  * Replaces mustache tags used in raw Campaign Template strings with given variables.
  * @param {string} input
  * @param {object} phoenixCampaign
@@ -222,17 +194,4 @@ module.exports.isCommand = function isCommand(incomingMessage, commandType) {
   const result = firstWord === configValue.toUpperCase();
 
   return result;
-};
-
-/**
- * Trims given input with an ellipsis if its length is greater than 255 characters.
- * @param {string} input
- * @return {string}
- */
-module.exports.trimReportbackText = function (input) {
-  if (input.length > 255) {
-    return `${input.substring(0, 252)}...`;
-  }
-
-  return input;
 };

--- a/lib/helpers/reportback.js
+++ b/lib/helpers/reportback.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const config = require('../../config/lib/helpers/reportback');
+
+/**
+ * @param {string} message
+ * @return {boolean}
+ */
+function hasLetters(message) {
+  return RegExp(/[a-zA-Z]/g).test(message);
+}
+
+/**
+ * TODO: Make this much better!
+ * @see https://github.com/DoSomething/gambit/issues/608
+ *
+ * Checks if given input string contains a valid Reportback quantity.
+ * @param {string} input
+ * @return {boolean}
+ */
+function validateQuantity(quantity) {
+  // Letters are invalid
+  if (hasLetters(quantity)) return false;
+
+  const numericQuantity = Number(quantity);
+
+  if (numericQuantity && numericQuantity === parseInt(numericQuantity, 10)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Checks if given input string contains a valid Reportback text field.
+ * @param {string} input
+ * @return {boolean}
+ */
+function validateText(input) {
+  return !!(input && input.trim().length > config.minTextLength && hasLetters(input));
+}
+
+/**
+ * Trims given input with an ellipsis if its length is greater than 255|maxTextLength characters.
+ * @param {string} input
+ * @return {string}
+ */
+function trimText(input) {
+  const maxLength = config.maxTextLength;
+  const ellipsis = config.ellipsis;
+  const keepLength = maxLength - ellipsis.length;
+  let text = input.trim();
+
+  if (text.length > maxLength) {
+    text = `${text.substring(0, keepLength)}${ellipsis}`;
+  }
+
+  return text;
+}
+
+module.exports = {
+  isValidQuantity: qty => validateQuantity(qty),
+  isValidText: txt => validateText(txt),
+  trimText: txt => trimText(txt),
+};

--- a/lib/middleware/receive-message/draft-caption.js
+++ b/lib/middleware/receive-message/draft-caption.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const helpers = require('../../helpers');
+const reportbackHelper = require('../../helpers/reportback');
 const replies = require('../../replies');
 
 module.exports = function draftSubmissionCaption() {
@@ -15,11 +16,11 @@ module.exports = function draftSubmissionCaption() {
 
     const input = req.incoming_message;
 
-    if (!helpers.isValidReportbackText(input)) {
+    if (!reportbackHelper.isValidText(input)) {
       return replies.invalidCaption(req, res);
     }
 
-    req.draftSubmission.caption = helpers.trimReportbackText(input);
+    req.draftSubmission.caption = reportbackHelper.trimText(input);
 
     return req.draftSubmission.save()
       .then(() => {

--- a/lib/middleware/receive-message/draft-quantity.js
+++ b/lib/middleware/receive-message/draft-quantity.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const helpers = require('../../helpers');
+const reportbackHelper = require('../../helpers/reportback');
 const replies = require('../../replies');
 
 module.exports = function draftSubmissionQuantity() {
@@ -13,7 +14,8 @@ module.exports = function draftSubmissionQuantity() {
       return replies.askQuantity(req, res);
     }
 
-    if (!helpers.isValidReportbackQuantity(req.incoming_message)) {
+    // TODO: Round up/down based on remainder on Numeric quantity
+    if (!reportbackHelper.isValidQuantity(req.incoming_message)) {
       return replies.invalidQuantity(req, res);
     }
 

--- a/lib/middleware/receive-message/draft-why-participated.js
+++ b/lib/middleware/receive-message/draft-why-participated.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const helpers = require('../../helpers');
+const reportbackHelper = require('../../helpers/reportback');
 const replies = require('../../replies');
 
 module.exports = function draftSubmissionWhyParticipated() {
@@ -16,11 +17,11 @@ module.exports = function draftSubmissionWhyParticipated() {
 
     const input = req.incoming_message;
 
-    if (!helpers.isValidReportbackText(input)) {
+    if (!reportbackHelper.isValidText(input)) {
       return replies.invalidWhyParticipated(req, res);
     }
 
-    req.draftSubmission.why_participated = helpers.trimReportbackText(input);
+    req.draftSubmission.why_participated = reportbackHelper.trimText(input);
 
     return req.draftSubmission.save()
       .then(() => next())

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -154,23 +154,6 @@ test('getFirstWord should return null if no message is passed', () => {
   expect(result).to.be.null;
 });
 
-// isValidReportbackQuantity
-test('isValidReportbackQuantity', () => {
-  helpers.isValidReportbackQuantity(2).should.be.true;
-  helpers.isValidReportbackQuantity('2').should.be.true;
-  helpers.isValidReportbackQuantity('2 ').should.be.true;
-  helpers.isValidReportbackQuantity('a2').should.be.NaN;
-});
-
-// isValidReportbackText
-test('isValidReportbackText', () => {
-  helpers.isValidReportbackText('i am valid').should.be.true;
-  helpers.isValidReportbackText('no').should.be.false;
-  helpers.isValidReportbackText('123').should.be.false;
-  helpers.isValidReportbackText('hi     ').should.be.false;
-  helpers.isValidReportbackText('').should.be.false;
-});
-
 // isCommand
 test('isCommand should return true when incoming message and command are valid Gambit commands', () => {
   const commandsObject = stubs.helpers.getValidCommandValues();
@@ -233,14 +216,4 @@ test('upsertOptions helper', () => {
   const opts = helpers.upsertOptions();
   opts.upsert.should.be.true;
   opts.new.should.be.true;
-});
-
-// trimReportbackText
-test('trimReportbackText', () => {
-  const text = 'This is a caption';
-  helpers.trimReportbackText(text).should.be.equal(text);
-
-  const longText = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.';
-  const trimmed = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium qu...';
-  helpers.trimReportbackText(longText).should.be.equal(trimmed);
 });

--- a/test/lib/lib-helpers/reportback.test.js
+++ b/test/lib/lib-helpers/reportback.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+// env variables
+require('dotenv').config();
+
+// Libraries
+const test = require('ava');
+const chai = require('chai');
+const logger = require('winston');
+const sinonChai = require('sinon-chai');
+const sinon = require('sinon');
+
+// App Modules
+const stubs = require('../../utils/stubs');
+
+// Config
+const config = require('../../../config/lib/helpers/reportback');
+
+// Module to test
+const reportbackHelper = require('../../../lib/helpers/reportback');
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+const sandbox = sinon.sandbox.create();
+
+// Setup!
+test.beforeEach(() => {
+  stubs.stubLogger(sandbox, logger);
+});
+
+// Cleanup!
+test.afterEach(() => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+});
+
+/**
+ * Tests
+ */
+
+// isValidQuantity
+test('isValidQuantity() validations', () => {
+  // non decimal number should pass
+  reportbackHelper.isValidQuantity('1').should.be.true;
+  reportbackHelper.isValidQuantity(' 1').should.be.true;
+  reportbackHelper.isValidQuantity(' 1 ').should.be.true;
+  // decimal number should not pass
+  reportbackHelper.isValidQuantity('1.1').should.be.false;
+  reportbackHelper.isValidQuantity(' 1.1').should.be.false;
+  reportbackHelper.isValidQuantity(' 1.1 ').should.be.false;
+  // any text should not pass
+  reportbackHelper.isValidQuantity('a').should.be.false;
+  reportbackHelper.isValidQuantity(' 1a').should.be.false;
+  reportbackHelper.isValidQuantity('1,').should.be.false;
+  reportbackHelper.isValidQuantity('1 hundred').should.be.false;
+});
+
+// isValidText
+test('isValidText() validations', () => {
+  // Text can't be empty
+  reportbackHelper.isValidText('').should.be.false;
+  reportbackHelper.isValidText('       ').should.be.false;
+  // Text must meet length requirements
+  reportbackHelper.isValidText(stubs.getRandomString(config.minTextLength + 1)).should.be.true;
+  reportbackHelper.isValidText(stubs.getRandomString(config.minTextLength)).should.be.false;
+});
+
+// trimText
+test('trimText() validations', () => {
+  // It should trim spaces out of text
+  const text1 = stubs.getRandomString();
+  reportbackHelper.trimText(`   ${text1}   `).should.be.equal(text1);
+  // If longer that maxTextLength it should ellipsify
+  const text2 = stubs.getRandomString(config.maxTextLength + 10);
+  const result2 = reportbackHelper.trimText(text2);
+  result2.indexOf(config.ellipsis).should.be.equal(result2.length - config.ellipsis.length);
+  // Text shouldn't be longer than 255|maxTextLength
+  const text3 = stubs.getRandomString(config.maxTextLength + 100);
+  const result3 = reportbackHelper.trimText(text3);
+  result3.length.should.be.equal(config.maxTextLength);
+});

--- a/test/lib/lib-helpers/reportback.test.js
+++ b/test/lib/lib-helpers/reportback.test.js
@@ -50,6 +50,7 @@ test('isValidQuantity() validations', () => {
   reportbackHelper.isValidQuantity('1.1').should.be.false;
   reportbackHelper.isValidQuantity(' 1.1').should.be.false;
   reportbackHelper.isValidQuantity(' 1.1 ').should.be.false;
+  reportbackHelper.isValidQuantity(' 0.9 ').should.be.false;
   // any text should not pass
   reportbackHelper.isValidQuantity('a').should.be.false;
   reportbackHelper.isValidQuantity(' 1a').should.be.false;

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -4,8 +4,14 @@
 /* eslint-disable import/no-dynamic-require */
 
 const underscore = require('underscore');
+const Chance = require('chance');
+
+const chance = new Chance();
 
 module.exports = {
+  getRandomString: function getRandomString(length) {
+    return chance.string({ length: length || 5 });
+  },
   getNorthstarAPIBaseUri: function getNorthstarAPIBaseUri() {
     return process.env.DS_NORTHSTAR_API_BASEURI || 'https://northstar-fake.dosomething.org/v1';
   },


### PR DESCRIPTION
#### What's this PR do?
##### Part 1
- Refactors reportback specific methods out of the `helpers.js` file into its own helper `/helpers/reportback.js`.
- Makes decimal reportback quantities invalid.

##### Part 2 - in future PR
It will round up/down based on decimal quantity remainder when a valid Numeric quantity is received.

#### How should this be reviewed?
- 👀 
- Run `npm run all-tests`

#### Relevant tickets
Task 1 - https://github.com/DoSomething/gambit-campaigns/issues/1012

#### Checklist
- [x] Tested on staging.
