### PR TITLE
fix non en language campaigns

### DIFF
--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -46,12 +46,13 @@ function executeGet(endpoint, query = {}) {
  */
 module.exports.parsePhoenixCampaign = function (data) {
   const result = {};
+  const languageCode = data.language.language_code;
   result.id = Number(data.id);
   result.title = data.title;
   result.tagline = data.tagline;
   result.status = data.status;
   result.currentCampaignRun = {
-    id: Number(data.campaign_runs.current.en.id),
+    id: Number(data.campaign_runs.current[languageCode].id),
   };
   const rbInfo = data.reportback_info;
   result.reportbackInfo = {


### PR DESCRIPTION
#### What's this PR do?
Allows non english campaigns to be properly rendered in the `/campaigns` route.

#### How should this be reviewed?
- 👀 
- `http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns/7177` should return the correct campaign info.

#### Any background context you want to provide?
what else?

#### Relevant tickets
Slack thread: https://dosomething.slack.com/archives/C4VN7J0SE/p1514485870000401

#### Checklist
- [x] Tested on staging.
