### PR TITLE
botConfig - part 1 [pr]

### DIFF
--- a/config/lib/helpers/botConfig.js
+++ b/config/lib/helpers/botConfig.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  default: {
+    postType: 'photo',
+  },
+  postTemplatePostTypes: {
+    textPostTemplate: 'text',
+    photoPostTemplate: 'photo',
+  },
+};

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -209,3 +209,22 @@ module.exports.formatKeywordFromResponse = function formatKeywordFromResponse(co
 module.exports.getFieldNameForCampaignMessageTemplate = function (messageTemplate) {
   return config.campaignFields[messageTemplate];
 };
+
+/**
+ * @param {object} botConfig
+ * @param {object} - Contentful entry set for the botConfig.postTemplate reference field.
+ */
+module.exports.getPostTemplateFromBotConfig = function (botConfig) {
+  if (!botConfig.fields.postTemplate) {
+    return null;
+  }
+  return botConfig.fields.postTemplate;
+};
+
+/**
+ * @param {entry}
+ * @return {string}
+ */
+module.exports.parseTypeFromContentfulEntry = function parseTypeFromContentfulEntry(entry) {
+  return entry.sys.contentType.sys.id;
+};

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -78,6 +78,18 @@ module.exports.fetchSingleEntry = function fetchSingleEntry(query) {
 };
 
 /**
+ * @return {Promise}
+ */
+module.exports.fetchBotConfigByCampaignId = function (campaignId) {
+  const query = exports.getQueryBuilder()
+    .contentType('campaign')
+    .campaignId(campaignId)
+    .build();
+
+  return exports.fetchSingleEntry(query);
+};
+
+/**
  * Fetches a list of Contentful Campaigns by given array of campaignId field values
  * Although Phoenix Campaign ID's are numeric, the Contentful campaignId is a string.
  * @param {array} campaignIds

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,6 +6,12 @@
 const logger = require('winston');
 const newrelic = require('newrelic');
 const stathat = require('./stathat');
+const helpers = require('./helpers/index');
+
+// register helpers
+Object.keys(helpers).forEach((helperName) => {
+  module.exports[helperName] = helpers[helperName];
+});
 
 /**
  * addBlinkSuppressHeaders

--- a/lib/helpers/botConfig.js
+++ b/lib/helpers/botConfig.js
@@ -1,9 +1,18 @@
 'use strict';
 
 const contentful = require('../contentful');
+const config = require('../../config/lib/helpers/botConfig');
 
 module.exports = {
   fetchByCampaignId: function fetchByCampaignId(campaignId) {
     return contentful.fetchBotConfigByCampaignId(campaignId);
+  },
+  parsePostTypeFromBotConfig: function parsePostTypeFromBotConfig(botConfig) {
+    const postTemplateEntry = contentful.getPostTemplateFromBotConfig(botConfig);
+    if (!postTemplateEntry) {
+      return config.default.postType;
+    }
+    const postTemplateType = contentful.parseTypeFromContentfulEntry(postTemplateEntry);
+    return config.postTemplatePostTypes[postTemplateType];
   },
 };

--- a/lib/helpers/botConfig.js
+++ b/lib/helpers/botConfig.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const contentful = require('../contentful');
+
+module.exports = {
+  fetchByCampaignId: function fetchByCampaignId(campaignId) {
+    return contentful.fetchBotConfigByCampaignId(campaignId);
+  },
+};

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -2,10 +2,41 @@
 
 const dateFns = require('date-fns');
 const logger = require('winston');
+const Promise = require('bluebird');
+const cacheHelper = require('./cache');
+const phoenix = require('../phoenix');
 const config = require('../../config/lib/helpers/campaign');
 const phoenixConfig = require('../../config/lib/phoenix');
 
 module.exports = {
+  fetchById: function fetchById(campaignId) {
+    return new Promise((resolve, reject) => {
+      phoenix.fetchCampaignById(campaignId)
+        .then((res) => {
+          const campaignData = this.parseCampaign(res.data);
+          return cacheHelper.campaigns.set(`${campaignId}`, campaignData);
+        })
+        .then(campaign => resolve(JSON.parse(campaign)))
+        .catch(err => reject(err));
+    });
+  },
+  fetchByIds: function fetchByIds(campaignIds) {
+    const promises = [];
+    campaignIds.forEach(campaignId => promises.push(this.getById(campaignId)));
+    return Promise.all(promises);
+  },
+  getById: function getById(campaignId) {
+    return cacheHelper.campaigns.get(`${campaignId}`)
+      .then((campaign) => {
+        if (campaign) {
+          logger.debug(`Campaigns cache hit:${campaignId}`);
+          return Promise.resolve(campaign);
+        }
+        logger.debug(`Campaigns cache miss:${campaignId}`);
+        return this.fetchById(campaignId);
+      })
+      .catch(err => Promise.reject(err));
+  },
   /**
    * @param {Object} campaign
    * @return {Boolean}

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const cache = require('./cache');
+const campaign = require('./campaign');
+const reportback = require('./reportback');
+
+module.exports = {
+  cache,
+  campaign,
+  reportback,
+};

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const botConfig = require('./botConfig');
 const cache = require('./cache');
 const campaign = require('./campaign');
 const reportback = require('./reportback');
 
 module.exports = {
+  botConfig,
   cache,
   campaign,
   reportback,

--- a/lib/middleware/campaigns-index/phoenix-campaigns.js
+++ b/lib/middleware/campaigns-index/phoenix-campaigns.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const phoenix = require('../../phoenix');
 const helpers = require('../../helpers');
 
 module.exports = function getPhoenixCampaigns() {
   return (req, res, next) => {
     const campaignIds = Object.keys(req.keywordsByCampaignId);
 
-    return phoenix.fetchCampaigns(campaignIds)
+    return helpers.campaign.fetchByIds(campaignIds)
       .then((phoenixRes) => {
         req.phoenixCampaigns = phoenixRes;
         return next();

--- a/lib/middleware/campaigns-single/contentful-keywords.js
+++ b/lib/middleware/campaigns-single/contentful-keywords.js
@@ -5,7 +5,7 @@ const helpers = require('../../helpers');
 
 module.exports = function getKeywords() {
   return (req, res, next) => {
-    contentful.fetchKeywordsForCampaignId(req.campaign.id)
+    contentful.fetchKeywordsForCampaignId(req.campaignId)
       .then((contentfulRes) => {
         req.campaign.keywords = contentfulRes;
         return next();

--- a/lib/middleware/campaigns-single/phoenix-campaign.js
+++ b/lib/middleware/campaigns-single/phoenix-campaign.js
@@ -7,12 +7,14 @@ module.exports = function getPhoenixCampaign() {
     req.campaignId = req.params.campaignId;
 
     return helpers.campaign.getById(req.campaignId)
-      .then((phoenixRes) => {
-        req.campaign = phoenixRes;
+      .then((campaign) => {
+        req.campaign = campaign;
         return helpers.botConfig.fetchByCampaignId(req.campaignId);
       })
-      .then((contentfulRes) => {
-        req.campaign.botConfig = contentfulRes;
+      .then((botConfig) => {
+        req.campaign.botConfig = {
+          postType: helpers.botConfig.parsePostTypeFromBotConfig(botConfig),
+        };
         return next();
       })
       .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/campaigns-single/phoenix-campaign.js
+++ b/lib/middleware/campaigns-single/phoenix-campaign.js
@@ -9,6 +9,10 @@ module.exports = function getPhoenixCampaign() {
     return helpers.campaign.getById(req.campaignId)
       .then((phoenixRes) => {
         req.campaign = phoenixRes;
+        return helpers.botConfig.fetchByCampaignId(req.campaignId);
+      })
+      .then((contentfulRes) => {
+        req.campaign.botConfig = contentfulRes;
         return next();
       })
       .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/campaigns-single/phoenix-campaign.js
+++ b/lib/middleware/campaigns-single/phoenix-campaign.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const phoenix = require('../../phoenix');
 const helpers = require('../../helpers');
 
 module.exports = function getPhoenixCampaign() {
   return (req, res, next) => {
     req.campaignId = req.params.campaignId;
 
-    return phoenix.getCampaignById(req.campaignId)
+    return helpers.campaign.getById(req.campaignId)
       .then((phoenixRes) => {
         req.campaign = phoenixRes;
         return next();

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -6,8 +6,6 @@
 const superagent = require('superagent');
 const logger = require('winston');
 const Promise = require('bluebird');
-const cacheHelper = require('./helpers/cache');
-const campaignHelper = require('./helpers/campaign');
 const config = require('../config/lib/phoenix');
 
 /**
@@ -16,14 +14,16 @@ const config = require('../config/lib/phoenix');
  * @param {object} data
  */
 function executeGet(endpoint, query = {}) {
-  const baseUri = config.clientOptions.baseUri;
-  const url = `${baseUri}/${endpoint}`;
-  logger.debug('executeGet', { url });
+  const url = `${config.clientOptions.baseUri}/${endpoint}`;
 
-  return superagent
-    .get(url)
-    .query(query)
-    .then(res => res.body);
+  return new Promise((resolve, reject) => {
+    logger.debug('executeGet', { url });
+    return superagent
+      .get(url)
+      .query(query)
+      .then(res => resolve(res.body))
+      .catch(err => reject(module.exports.parsePhoenixError(err)));
+  });
 }
 
 /**
@@ -33,7 +33,6 @@ function executeGet(endpoint, query = {}) {
 module.exports.parsePhoenixError = function (err, campaignId) {
   const scope = err;
   scope.message = `phoenix campaignId=${campaignId} error=${err.message}`;
-
   return scope;
 };
 
@@ -57,48 +56,5 @@ module.exports.isClosedCampaign = function (phoenixCampaign) {
 module.exports.fetchCampaignById = function (campaignId) {
   logger.debug(`phoenix.fetchCampaignById:${campaignId}`);
   const endpoint = `campaigns/${campaignId}`;
-
-  return new Promise((resolve, reject) => {
-    executeGet(endpoint)
-      .then((res) => {
-        const campaignData = campaignHelper.parseCampaign(res.data);
-        return cacheHelper.campaigns.set(`${campaignId}`, campaignData);
-      })
-      .then(campaign => resolve(JSON.parse(campaign)))
-      .catch(err => reject(exports.parsePhoenixError(err, campaignId)));
-  });
-};
-
-/**
- * getCampaignById - Attemps to get the cached campaign by id, if its not
- *                   cached, it fetches it from Phoenix.
- *
- * @param  {Number} campaignId
- * @return {Promise}
- */
-module.exports.getCampaignById = function getCampaignById(campaignId) {
-  logger.debug(`phoenix.getCampaignById:${campaignId}`);
-
-  return cacheHelper.campaigns.get(`${campaignId}`)
-    .then((campaign) => {
-      if (campaign) {
-        logger.debug(`Campaigns cache hit:${campaignId}`);
-        return Promise.resolve(campaign);
-      }
-      logger.debug(`Campaigns cache miss:${campaignId}`);
-      return exports.fetchCampaignById(campaignId);
-    })
-    .catch(err => Promise.reject(err));
-};
-
-/**
- * @param {Array} campaignIds
- * @return {Promise}
- */
-module.exports.fetchCampaigns = function (campaignIds) {
-  const promises = [];
-  campaignIds.forEach((campaignId) => {
-    promises.push(module.exports.getCampaignById(campaignId));
-  });
-  return Promise.all(promises);
+  return executeGet(endpoint);
 };

--- a/test/lib/phoenix.test.js
+++ b/test/lib/phoenix.test.js
@@ -36,22 +36,8 @@ test('phoenix should respond to fetchCampaignById', () => {
   phoenix.should.respondTo('fetchCampaignById');
 });
 
-test('phoenix should respond to getCampaignById', () => {
-  phoenix.should.respondTo('getCampaignById');
-});
-
 test('phoenix should respond to isClosedCampaign', () => {
   phoenix.should.respondTo('isClosedCampaign');
-});
-
-test('phoenix.fetchCampaignById should call parsePhoenixCampaign on success', async () => {
-  const campaignStub = stubs.phoenix.getCampaign();
-  nock(baseUri)
-    .get(/$/)
-    .reply(200, campaignStub);
-
-  await phoenix.fetchCampaignById(campaignId);
-  campaignHelper.parseCampaign.should.have.been.calledWith(campaignStub.data);
 });
 
 test('phoenix.fetchCampaignById should call parsePhoenixError on error', async () => {


### PR DESCRIPTION
#### What's this PR do?

Starts on renaming and refactoring a Phoenix campaign's corresponding Gambini campaign entry as `botConfig` property on the campaign.  Our Gambini Contentful data will eventually be migrated and sourced from Phoenix.

* Adds a botConfig helper with a `parsePostTypeFromBotConfig` function to return the botConfig's post type, either `'text'` or `'photo'`. 

* Adds functions to the campaign helper to get and fetch campaigns, extracting the cache logic out of the Phoenix helper (see #1024). Our source of campaigns could potentially change one day, e.g. [GraphQL](https://github.com/dosomething/graphqll) 

* For now, adds an extra call to Contentful to set the `req.campaign.botConfig` -- but that'd be silly to ship to production. What I should have done was stopped here, feature flagged this, and then added tests. But I sorta 🐇 💻 and then refactored to make a single Contentful call, stay tuned for part 2 📺 

#### How should this be reviewed?
Verify the campaign's Contentful campaign is returned as a `botConfig`  property in a `GET /campaigns/:id` response, and contains a `postType` property. Campaign 2900 should return `'text'` on Staging, otherwise all other campaigns should be set to `'photo'`.

#### Any background context you want to provide?

Removing the documentation checklist item for now as the `postTemplate` field on a botConfig isn't used anywhere yet.

#### Relevant tickets
Corresponds to Contentful tasks in https://github.com/DoSomething/gambit-campaigns/issues/1021

#### Checklist
- [x] Tested on staging.
