### PR TITLE
Text Post middleware [pr]

### DIFF
--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -12,6 +12,7 @@ const mapRequestParamsMiddleware = require('../../lib/middleware/receive-message
 const getSignupMiddleware = require('../../lib/middleware/receive-message/signup-get');
 const createNewSignupIfNotFoundMiddleware = require('../../lib/middleware/receive-message/signup-create');
 const validateRequestMiddleware = require('../../lib/middleware/receive-message/validate');
+const textPostMiddleware = require('../../lib/middleware/receive-message/text-post');
 const createDraftSubmissionMiddleware = require('../../lib/middleware/receive-message/draft-create');
 const completedMenuMiddleware = require('../../lib/middleware/receive-message/menu-completed');
 const doingMenuMiddleware = require('../../lib/middleware/receive-message/menu-doing');
@@ -45,6 +46,11 @@ router.use(
  * Run sanity checks
  */
 router.use(validateRequestMiddleware());
+
+/**
+ * Create a text post if this is a text postType request.
+ */
+router.use(textPostMiddleware());
 
 /**
  * Checks Signup for existing draft, or creates draft when User has completed the Campaign.

--- a/lib/helpers/campaignActivity.js
+++ b/lib/helpers/campaignActivity.js
@@ -14,6 +14,10 @@ module.exports = {
         return rogue.createPost(data);
       });
   },
+  createTextPostFromReq: function createTextPostFromReq(req) {
+    const data = this.getCreateTextPostPayloadFromReq(req);
+    return rogue.createPost(data);
+  },
   createSignupFromReq: function createSignupFromReq(req) {
     const data = this.getDefaultCreatePayloadFromReq(req);
     return rogue.createSignup(data);
@@ -47,6 +51,14 @@ module.exports = {
       data.why_participated = draft.why_participated;
     }
     data.photoUrl = draft.photo;
+    logger.debug('getCreatePhotoPostPayloadFromReq', data);
+    return data;
+  },
+  getCreateTextPostPayloadFromReq: function getCreatePhotoPostPayloadFromReq(req) {
+    const data = this.getDefaultCreatePayloadFromReq(req);
+    data.type = 'text';
+    data.text = req.incoming_message;
+    logger.debug('getCreateTextPostPayloadFromReq', data);
     return data;
   },
   fetchFileStringFromPhotoUrl: function fetchFileStringFromPhotoUrl(url) {

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -3,8 +3,9 @@
 const botConfig = require('./botConfig');
 const cache = require('./cache');
 const campaign = require('./campaign');
-const reportback = require('./reportback');
 const campaignActivity = require('./campaignActivity');
+const reportback = require('./reportback');
+const request = require('./request');
 
 module.exports = {
   botConfig,
@@ -12,4 +13,5 @@ module.exports = {
   campaign,
   campaignActivity,
   reportback,
+  request,
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function isTextPost(req) {
+  return req.postType === 'text';
+}
+
+module.exports = {
+  isTextPost,
+};

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -1,9 +1,37 @@
 'use strict';
 
+const util = require('./reportback');
+
+/**
+ * @return {String}
+ */
+function messageText(req) {
+  return req.incoming_message;
+}
+
+/**
+ * @return {Boolean}
+ */
 function isTextPost(req) {
   return req.postType === 'text';
 }
 
+/**
+ * @return {Boolean}
+ */
+function isValidReportbackText(req) {
+  return util.isValidText(messageText(req));
+}
+
+/**
+ * @return {Boolean}
+ */
+function shouldAskNextQuestion(req) {
+  return req.keyword || req.broadcast_id;
+}
+
 module.exports = {
   isTextPost,
+  isValidReportbackText,
+  shouldAskNextQuestion,
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -24,14 +24,14 @@ function isValidReportbackText(req) {
 }
 
 /**
- * @return {Boolean}
+ * @return {String}
  */
-function shouldAskNextQuestion(req) {
-  return req.keyword || req.broadcast_id;
+function isKeyword(req) {
+  return req.keyword;
 }
 
 module.exports = {
+  isKeyword,
   isTextPost,
   isValidReportbackText,
-  shouldAskNextQuestion,
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -23,15 +23,7 @@ function isValidReportbackText(req) {
   return util.isValidText(messageText(req));
 }
 
-/**
- * @return {String}
- */
-function isKeyword(req) {
-  return req.keyword;
-}
-
 module.exports = {
-  isKeyword,
   isTextPost,
   isValidReportbackText,
 };

--- a/lib/middleware/receive-message/map-request-params.js
+++ b/lib/middleware/receive-message/map-request-params.js
@@ -8,6 +8,7 @@ function logParams(req) {
     userId: req.userId,
     campaignId: req.campaignId,
     campaignRunId: req.campaignRunId,
+    postType: req.postType,
     messageMediaUrl: req.incoming_image_url,
     messageText: req.incoming_message,
     keyword: req.keyword,

--- a/lib/middleware/receive-message/text-post.js
+++ b/lib/middleware/receive-message/text-post.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const helpers = require('../../helpers');
+const replies = require('../../replies');
+
+module.exports = function textPost() {
+  return (req, res, next) => {
+    if (!helpers.request.isTextPost(req)) {
+      return next();
+    }
+    return replies.menuCompleted(req, res);
+  };
+};

--- a/lib/middleware/receive-message/text-post.js
+++ b/lib/middleware/receive-message/text-post.js
@@ -10,7 +10,7 @@ module.exports = function textPost() {
       return next();
     }
 
-    if (helpers.request.isKeyword(req)) {
+    if (req.keyword) {
       // TODO: Send a new askText reply, sending askCaption for now.
       return replies.askCaption(req, res);
     }

--- a/lib/middleware/receive-message/text-post.js
+++ b/lib/middleware/receive-message/text-post.js
@@ -10,13 +10,13 @@ module.exports = function textPost() {
       return next();
     }
 
-    // TODO: Send a new askText reply, sending askCaption for now.
-    if (helpers.request.shouldAskNextQuestion(req)) {
+    if (helpers.request.isKeyword(req)) {
+      // TODO: Send a new askText reply, sending askCaption for now.
       return replies.askCaption(req, res);
     }
 
-    // TODO: Send a new invalidText reply, sending invalidCaption for now.
     if (!helpers.request.isValidReportbackText(req)) {
+      // TODO: Send a new invalidText reply.
       return replies.invalidCaption(req, res);
     }
 

--- a/lib/middleware/receive-message/text-post.js
+++ b/lib/middleware/receive-message/text-post.js
@@ -10,9 +10,19 @@ module.exports = function textPost() {
       return next();
     }
 
+    // TODO: Send a new askText reply, sending askCaption for now.
+    if (helpers.request.shouldAskNextQuestion(req)) {
+      return replies.askCaption(req, res);
+    }
+
+    // TODO: Send a new invalidText reply, sending invalidCaption for now.
+    if (!helpers.request.isValidReportbackText(req)) {
+      return replies.invalidCaption(req, res);
+    }
+
     return helpers.campaignActivity.createTextPostFromReq(req)
       .then((textPostRes) => {
-        logger.debug('textPost response', textPostRes);
+        logger.debug('createTextPostFromReq response', textPostRes);
         return replies.menuCompleted(req, res);
       })
       .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/receive-message/text-post.js
+++ b/lib/middleware/receive-message/text-post.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const logger = require('winston');
 const helpers = require('../../helpers');
 const replies = require('../../replies');
 
@@ -8,6 +9,12 @@ module.exports = function textPost() {
     if (!helpers.request.isTextPost(req)) {
       return next();
     }
-    return replies.menuCompleted(req, res);
+
+    return helpers.campaignActivity.createTextPostFromReq(req)
+      .then((textPostRes) => {
+        logger.debug('textPost response', textPostRes);
+        return replies.menuCompleted(req, res);
+      })
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -41,6 +41,7 @@ function executePost(endpoint, data) {
  * @return {Promise}
  */
 module.exports.createPost = function (data) {
+  logger.debug('rogue.createPost');
   return executePost('posts', data);
 };
 

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -41,7 +41,6 @@ function executePost(endpoint, data) {
  * @return {Promise}
  */
 module.exports.createPost = function (data) {
-  logger.debug('rogue.createPost');
   return executePost('posts', data);
 };
 

--- a/test/lib/lib-helpers/campaignActivity.test.js
+++ b/test/lib/lib-helpers/campaignActivity.test.js
@@ -25,6 +25,7 @@ test.beforeEach((t) => {
   stubs.stubLogger(sandbox, logger);
   t.context.req = httpMocks.createRequest();
   t.context.req.userId = stubs.getUserId();
+  t.context.req.incoming_message = stubs.getRandomString();
   t.context.req.campaignId = stubs.getCampaignId();
   t.context.req.campaignRunId = stubs.getCampaignRunId();
   t.context.req.platform = stubs.getPlatform();
@@ -52,9 +53,19 @@ test('getCreatePhotoPostPayloadFromReq returns an object', (t) => {
   sandbox.stub(activityHelper, 'getDefaultCreatePayloadFromReq')
     .returns({ userId: stubs.getUserId() });
   const result = activityHelper.getCreatePhotoPostPayloadFromReq(t.context.req);
+  result.type.should.equal('photo');
   activityHelper.getDefaultCreatePayloadFromReq.should.have.been.called;
   result.photoUrl.should.equal(mockDraft.photo);
   result.quantity.should.equal(mockDraft.quantity);
   result.caption.should.equal(mockDraft.caption);
   result.should.not.have.property('why_participated');
+});
+
+// getCreateTextPostPayloadFromReq
+test('getCreateTextPostPayloadFromReq returns an object', (t) => {
+  sandbox.stub(activityHelper, 'getDefaultCreatePayloadFromReq')
+    .returns({ userId: stubs.getUserId() });
+  const result = activityHelper.getCreateTextPostPayloadFromReq(t.context.req);
+  result.type.should.equal('text');
+  result.text.should.equal(t.context.req.incoming_message);
 });

--- a/test/lib/lib-helpers/campaignActivity.test.js
+++ b/test/lib/lib-helpers/campaignActivity.test.js
@@ -9,9 +9,12 @@ const sinonChai = require('sinon-chai');
 const sinon = require('sinon');
 const httpMocks = require('node-mocks-http');
 
+const rogue = require('../../../lib/rogue');
 const stubs = require('../../utils/stubs');
 
 const mockDraft = stubs.getDraft();
+const mockDefaultCreatePayload = { id: stubs.getUserId() };
+const mockPost = stubs.getPost();
 
 // Module to test
 const activityHelper = require('../../../lib/helpers/campaignActivity');
@@ -23,6 +26,8 @@ const sandbox = sinon.sandbox.create();
 
 test.beforeEach((t) => {
   stubs.stubLogger(sandbox, logger);
+  sandbox.stub(rogue, 'createPost')
+    .returns(Promise.resolve(mockPost));
   t.context.req = httpMocks.createRequest();
   t.context.req.userId = stubs.getUserId();
   t.context.req.incoming_message = stubs.getRandomString();
@@ -39,6 +44,17 @@ test.afterEach((t) => {
   t.context = {};
 });
 
+// createPhotoPostFromReq
+test('createTextPostFromReq calls createPost with getCreateTextPostPayloadFromReq', async (t) => {
+  sandbox.stub(activityHelper, 'getDefaultCreatePayloadFromReq')
+    .returns(mockDefaultCreatePayload);
+
+  const result = await activityHelper.createTextPostFromReq(t.context.req);
+  activityHelper.getDefaultCreatePayloadFromReq.should.have.been.called;
+  rogue.createPost.should.have.been.calledWith(mockDefaultCreatePayload);
+  result.should.equal(mockPost);
+});
+
 // getDefaultCreatePayloadFromReq
 test('getDefaultCreatePayloadFromReq returns an object', (t) => {
   const result = activityHelper.getDefaultCreatePayloadFromReq(t.context.req);
@@ -51,7 +67,7 @@ test('getDefaultCreatePayloadFromReq returns an object', (t) => {
 // getCreatePhotoPostPayloadFromReq
 test('getCreatePhotoPostPayloadFromReq returns an object', (t) => {
   sandbox.stub(activityHelper, 'getDefaultCreatePayloadFromReq')
-    .returns({ userId: stubs.getUserId() });
+    .returns(mockDefaultCreatePayload);
   const result = activityHelper.getCreatePhotoPostPayloadFromReq(t.context.req);
   result.type.should.equal('photo');
   activityHelper.getDefaultCreatePayloadFromReq.should.have.been.called;
@@ -64,7 +80,7 @@ test('getCreatePhotoPostPayloadFromReq returns an object', (t) => {
 // getCreateTextPostPayloadFromReq
 test('getCreateTextPostPayloadFromReq returns an object', (t) => {
   sandbox.stub(activityHelper, 'getDefaultCreatePayloadFromReq')
-    .returns({ userId: stubs.getUserId() });
+    .returns(mockDefaultCreatePayload);
   const result = activityHelper.getCreateTextPostPayloadFromReq(t.context.req);
   result.type.should.equal('text');
   result.text.should.equal(t.context.req.incoming_message);

--- a/test/lib/lib-helpers/request.test.js
+++ b/test/lib/lib-helpers/request.test.js
@@ -8,6 +8,8 @@ const sinonChai = require('sinon-chai');
 const sinon = require('sinon');
 const httpMocks = require('node-mocks-http');
 
+const helpers = require('../../../lib/helpers');
+
 // Module to test
 const requestHelper = require('../../../lib/helpers/request');
 
@@ -26,10 +28,24 @@ test.afterEach((t) => {
 });
 
 // isTextPost
-test('isTextPost returns whether req.postType is text', (t) => {
+test('isTextPost returns whether req.keyword', (t) => {
   t.context.req.postType = 'text';
   t.truthy(requestHelper.isTextPost(t.context.req));
   t.context.req.postType = 'photo';
   t.falsy(requestHelper.isTextPost(t.context.req));
 });
 
+// isValidReportbackText
+test('isValidReportbackText returns true if incoming_message is valid text', (t) => {
+  t.context.req.incoming_message = 'text';
+  sandbox.stub(helpers.reportback, 'isValidText')
+    .returns(true);
+  t.truthy(requestHelper.isValidReportbackText(t.context.req));
+});
+
+test('isValidReportbackText returns false is incoming_message is not valid text', (t) => {
+  t.context.req.incoming_message = 'text';
+  sandbox.stub(helpers.reportback, 'isValidText')
+    .returns(false);
+  t.falsy(requestHelper.isValidReportbackText(t.context.req));
+});

--- a/test/lib/lib-helpers/request.test.js
+++ b/test/lib/lib-helpers/request.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const sinon = require('sinon');
+const httpMocks = require('node-mocks-http');
+
+// Module to test
+const requestHelper = require('../../../lib/helpers/request');
+
+chai.should();
+chai.use(sinonChai);
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  t.context.req = httpMocks.createRequest();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+// isTextPost
+test('isTextPost returns whether req.postType is text', (t) => {
+  t.context.req.postType = 'text';
+  t.truthy(requestHelper.isTextPost(t.context.req));
+  t.context.req.postType = 'photo';
+  t.falsy(requestHelper.isTextPost(t.context.req));
+});
+

--- a/test/lib/middleware/receive-message/text-post.test.js
+++ b/test/lib/middleware/receive-message/text-post.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../lib/helpers');
+const replies = require('../../../../lib/replies');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const textPost = require('../../../../lib/middleware/receive-message/text-post');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(replies, 'menuCompleted')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('textPost returns next if not a textPost request', async (t) => {
+  const next = sinon.stub();
+  const middleware = textPost();
+  sandbox.stub(helpers.request, 'isTextPost')
+    .returns(false);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  next.should.have.been.called;
+});

--- a/test/lib/middleware/receive-message/text-post.test.js
+++ b/test/lib/middleware/receive-message/text-post.test.js
@@ -52,13 +52,12 @@ test('textPost returns next if not a textPost request', async (t) => {
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('textPost returns askCaption when request.shouldAskNextQuestion', async (t) => {
+test('textPost returns askCaption when request has a keyword', async (t) => {
   const next = sinon.stub();
   const middleware = textPost();
   sandbox.stub(helpers.request, 'isTextPost')
     .returns(true);
-  sandbox.stub(helpers.request, 'isKeyword')
-    .returns(true);
+  t.context.req.keyword = stubs.getKeyword();
 
   await middleware(t.context.req, t.context.res, next);
   next.should.not.have.been.called;
@@ -73,8 +72,6 @@ test('textPost returns invalidCaption when request.isValidReportbackText is fals
   const middleware = textPost();
   sandbox.stub(helpers.request, 'isTextPost')
     .returns(true);
-  sandbox.stub(helpers.request, 'isKeyword')
-    .returns(false);
   sandbox.stub(helpers.request, 'isValidReportbackText')
     .returns(true);
   sandbox.stub(helpers.campaignActivity, 'createTextPostFromReq')
@@ -94,8 +91,6 @@ test('textPost returns completedMenu upon createTextPostFromReq success', async 
   const middleware = textPost();
   sandbox.stub(helpers.request, 'isTextPost')
     .returns(true);
-  sandbox.stub(helpers.request, 'isKeyword')
-    .returns(false);
   sandbox.stub(helpers.request, 'isValidReportbackText')
     .returns(true);
   sandbox.stub(helpers.campaignActivity, 'createTextPostFromReq')
@@ -115,8 +110,6 @@ test('textPost returns sendErrorResponse upon createTextPostFromReq error', asyn
   const middleware = textPost();
   sandbox.stub(helpers.request, 'isTextPost')
     .returns(true);
-  sandbox.stub(helpers.request, 'isKeyword')
-    .returns(false);
   sandbox.stub(helpers.request, 'isValidReportbackText')
     .returns(true);
   const error = new Error('epic fail');

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -42,6 +42,9 @@ module.exports = {
   getPlatform: function getPlatform() {
     return 'sms';
   },
+  getPost: function getPost() {
+    return { id: this.getPostId() };
+  },
   getPostId: function getPostId() {
     return 9040481;
   },

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -42,6 +42,9 @@ module.exports = {
   getPlatform: function getPlatform() {
     return 'sms';
   },
+  getPostId: function getPostId() {
+    return 9040481;
+  },
   getTemplateName: function getTemplateName() {
     return 'completedMenu';
   },


### PR DESCRIPTION
#### What's this PR do?
Adds new middleware to the `receive-message` to handle Text Post conversations if a post type of `text` has been passed from Conversations.

#### How should this be reviewed?
Upon staging deploy, text the LUCKYBOT keyword to join Get Lucky. I've updated its [botConfig](https://gambit-admin-staging.herokuapp.com/campaigns/2900) for text posts.

#### Any background context you want to provide?
* Need to investigate, but I don't seem to see any texts posts created in Rogue. The HTTP response suggests a `photo` post is created, although this branch should be passing `'text'`  as the `type` parameter.

* Using the Contentful campaign fields `askCaption` and `invalidCaption` as replies for now. TODO Use the textPostTemplate fields defined on the campaign `postTemplate` reference.

#### Relevant tickets
* #1021 
* This unblocks starting on https://github.com/DoSomething/gambit-conversations/issues/304

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
