### PR TITLE
Rename postTemplate as postConfig, textPostTemplate as textPostConfig [pr]

### DIFF
--- a/config/lib/helpers/botConfig.js
+++ b/config/lib/helpers/botConfig.js
@@ -27,89 +27,91 @@ module.exports = {
    * the default text to use when a field value doesn't exist.
    */
   templates: {
-    gambitSignupMenu: {
-      fieldName: 'gambitSignupMenuMessage',
-      default: defaultText.signupMenu,
-    },
-    externalSignupMenu: {
-      fieldName: 'externalSignupMenuMessage',
-      default: `Hi its Freddie from DoSomething! ${defaultText.signupMenu}`,
-    },
-    invalidSignupMenuCommand: {
-      fieldName: 'invalidSignupMenuCommandMessage',
-      default: `${defaultText.invalidInput} Text {{cmd_reportback}} to a submit a post for {{campaign.title}}.`,
-    },
-    askQuantity: {
-      fieldName: 'askQuantityMessage',
-      default: defaultText.askQuantity,
-    },
-    invalidQuantity: {
-      fieldName: 'invalidQuantityMessage',
-      default: `Sorry, that isnt a valid number. ${defaultText.askQuantity}`,
-    },
-    askPhoto: {
-      fieldName: 'askPhotoMessage',
-      default: defaultText.askPhoto,
-    },
-    invalidPhoto: {
-      fieldName: 'invalidPhotoMessage',
-      default: `${defaultText.invalidInput}\n\n${defaultText.askPhoto}`,
-    },
-    askCaption: {
-      fieldName: 'askCaptionMessage',
-      default: 'Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.',
-    },
-    invalidCaption: {
-      fieldName: 'invalidCaptionMessage',
-      default: `${defaultText.invalidInput}\n\nText back a caption for your photo -- keep it short & sweet, under 60 characters please. (but more than 3!)`,
-    },
-    askWhyParticipated: {
-      fieldName: 'askWhyParticipatedMessage',
-      default: defaultText.askWhyParticipated,
-    },
-    invalidWhyParticipated: {
-      fieldName: 'invalidWhyParticipatedMessage',
-      default: `${defaultText.invalidInput}\n\n${defaultText.askWhyParticipated}`,
-    },
-    completedMenu: {
-      fieldName: 'completedMenuMessage',
-      default: `Great! We've got you down for {{quantity}}.\n\n${defaultText.completedMenu}`,
-    },
-    invalidCompletedMenuCommand: {
-      fieldName: 'invalidCompletedMenuCommandMessage',
-      default: `${defaultText.invalidInput}\n\n${defaultText.completedMenu}.`,
-    },
-    memberSupport: {
-      fieldName: 'memberSupportMessage',
-      default: 'Text back your question and I\'ll try to get back to you within 24 hrs.\n\nIf you want to continue {{title}}, text back {{keyword}}',
-    },
-    campaignClosed: {
-      fieldName: 'campaignClosedMessage',
-      default: 'Sorry, {{title}} is no longer available.\n\nText {{cmd_member_support}} for help.',
-    },
-    askSignup: {
-      fieldName: 'askSignupMessage',
-      default: `{{tagline}}\n\nWant to join {{title}}?${defaultText.yesNo}`,
-    },
-    declinedSignup: {
-      fieldName: 'declinedSignupMessage',
-      default: `Ok! ${defaultText.declined}`,
-    },
-    invalidAskSignupResponse: {
-      fieldName: 'invalidSignupResponseMessage',
-      default: `${defaultText.invalidInput} Did you want to join {{title}}${defaultText.yesNo}`,
-    },
-    askContinue: {
-      fieldName: 'askContinueMessage',
-      default: `Ready to get back to {{title}}?${defaultText.yesNo}`,
-    },
-    declinedContinue: {
-      fieldName: 'declinedContinueMessage',
-      default: `Right on, we'll check in with you about {{title}} later.\n\n${defaultText.declined}`,
-    },
-    invalidAskContinueResponse: {
-      fieldName: 'invalidContinueResponseMessage',
-      default: `${defaultText.invalidInput} Did you want to join {{title}}?${defaultText.yesNo}`,
+    botConfig: {
+      gambitSignupMenu: {
+        fieldName: 'gambitSignupMenuMessage',
+        default: defaultText.signupMenu,
+      },
+      externalSignupMenu: {
+        fieldName: 'externalSignupMenuMessage',
+        default: `Hi its Freddie from DoSomething! ${defaultText.signupMenu}`,
+      },
+      invalidSignupMenuCommand: {
+        fieldName: 'invalidSignupMenuCommandMessage',
+        default: `${defaultText.invalidInput} Text {{cmd_reportback}} to a submit a post for {{campaign.title}}.`,
+      },
+      askQuantity: {
+        fieldName: 'askQuantityMessage',
+        default: defaultText.askQuantity,
+      },
+      invalidQuantity: {
+        fieldName: 'invalidQuantityMessage',
+        default: `Sorry, that isnt a valid number. ${defaultText.askQuantity}`,
+      },
+      askPhoto: {
+        fieldName: 'askPhotoMessage',
+        default: defaultText.askPhoto,
+      },
+      invalidPhoto: {
+        fieldName: 'invalidPhotoMessage',
+        default: `${defaultText.invalidInput}\n\n${defaultText.askPhoto}`,
+      },
+      askCaption: {
+        fieldName: 'askCaptionMessage',
+        default: 'Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.',
+      },
+      invalidCaption: {
+        fieldName: 'invalidCaptionMessage',
+        default: `${defaultText.invalidInput}\n\nText back a caption for your photo -- keep it short & sweet, under 60 characters please. (but more than 3!)`,
+      },
+      askWhyParticipated: {
+        fieldName: 'askWhyParticipatedMessage',
+        default: defaultText.askWhyParticipated,
+      },
+      invalidWhyParticipated: {
+        fieldName: 'invalidWhyParticipatedMessage',
+        default: `${defaultText.invalidInput}\n\n${defaultText.askWhyParticipated}`,
+      },
+      completedMenu: {
+        fieldName: 'completedMenuMessage',
+        default: `Great! We've got you down for {{quantity}}.\n\n${defaultText.completedMenu}`,
+      },
+      invalidCompletedMenuCommand: {
+        fieldName: 'invalidCompletedMenuCommandMessage',
+        default: `${defaultText.invalidInput}\n\n${defaultText.completedMenu}.`,
+      },
+      memberSupport: {
+        fieldName: 'memberSupportMessage',
+        default: 'Text back your question and I\'ll try to get back to you within 24 hrs.\n\nIf you want to continue {{title}}, text back {{keyword}}',
+      },
+      campaignClosed: {
+        fieldName: 'campaignClosedMessage',
+        default: 'Sorry, {{title}} is no longer available.\n\nText {{cmd_member_support}} for help.',
+      },
+      askSignup: {
+        fieldName: 'askSignupMessage',
+        default: `{{tagline}}\n\nWant to join {{title}}?${defaultText.yesNo}`,
+      },
+      declinedSignup: {
+        fieldName: 'declinedSignupMessage',
+        default: `Ok! ${defaultText.declined}`,
+      },
+      invalidAskSignupResponse: {
+        fieldName: 'invalidSignupResponseMessage',
+        default: `${defaultText.invalidInput} Did you want to join {{title}}${defaultText.yesNo}`,
+      },
+      askContinue: {
+        fieldName: 'askContinueMessage',
+        default: `Ready to get back to {{title}}?${defaultText.yesNo}`,
+      },
+      declinedContinue: {
+        fieldName: 'declinedContinueMessage',
+        default: `Right on, we'll check in with you about {{title}} later.\n\n${defaultText.declined}`,
+      },
+      invalidAskContinueResponse: {
+        fieldName: 'invalidContinueResponseMessage',
+        default: `${defaultText.invalidInput} Did you want to join {{title}}?${defaultText.yesNo}`,
+      },
     },
   },
 };

--- a/config/lib/helpers/botConfig.js
+++ b/config/lib/helpers/botConfig.js
@@ -18,7 +18,7 @@ module.exports = {
    *
    * { contentTypeName: 'postType' }
    */
-  contentTypePostType: {
+  postTypesByContentType: {
     textPostConfig: 'text',
     photoPostConfig: 'photo',
   },

--- a/config/lib/helpers/botConfig.js
+++ b/config/lib/helpers/botConfig.js
@@ -14,13 +14,13 @@ const defaultText = {
 module.exports = {
   defaultPostType: 'photo',
   /**
-   * Maps each content type that's available as a postTemplate to the Post type it should create.
+   * Maps each content type that's available as a postConfig to the Post type it should create.
    *
    * { contentTypeName: 'postType' }
    */
-  postTemplatePostTypes: {
-    textPostTemplate: 'text',
-    photoPostTemplate: 'photo',
+  contentTypePostType: {
+    textPostConfig: 'text',
+    photoPostConfig: 'photo',
   },
   /*
    * Maps a conversation message template name with its Contentful field that stores its text, or

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -146,13 +146,22 @@ module.exports.formatKeywordFromResponse = function formatKeywordFromResponse(co
 
 /**
  * @param {object} botConfig
- * @param {object} - Contentful entry set for the botConfig.postTemplate reference field.
+ * @param {object} - Contentful entry set for the botConfig.postConfig reference field.
  */
-module.exports.getPostTemplateFromBotConfig = function (botConfig) {
+module.exports.getPostConfigFromBotConfig = function (botConfig) {
   if (botConfig && botConfig.fields) {
-    return botConfig.fields.postTemplate;
+    return botConfig.fields.postConfig;
   }
   return null;
+};
+
+/**
+ * @param {Object} botConfig
+ * @return {String} - Name of the Contentful content type of entry saved as for postConfig field.
+ */
+module.exports.parsePostConfigContentTypeFromBotConfig = function (botConfig) {
+  const postConfig = contentful.getPostConfigFromBotConfig(botConfig);
+  return postConfig ? contentful.parseContentTypeFromEntry(postConfig) : null;
 };
 
 /**

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -160,8 +160,8 @@ module.exports.getPostConfigFromBotConfig = function (botConfig) {
  * @return {String} - Name of the Contentful content type of entry saved as for postConfig field.
  */
 module.exports.parsePostConfigContentTypeFromBotConfig = function (botConfig) {
-  const postConfig = contentful.getPostConfigFromBotConfig(botConfig);
-  return postConfig ? contentful.parseContentTypeFromEntry(postConfig) : null;
+  const postConfig = module.exports.getPostConfigFromBotConfig(botConfig);
+  return postConfig ? module.exports.parseContentTypeFromEntry(postConfig) : null;
 };
 
 /**

--- a/lib/helpers/botConfig.js
+++ b/lib/helpers/botConfig.js
@@ -47,6 +47,7 @@ function getTemplateFromBotConfigAndTemplateName(botConfig, templateName) {
 function getTemplatesFromBotConfig(botConfig) {
   const result = {};
   const botConfigTemplates = Object.keys(config.templates.botConfig);
+
   botConfigTemplates.forEach((templateName) => {
     result[templateName] = this.getTemplateFromBotConfigAndTemplateName(botConfig, templateName);
   });
@@ -66,23 +67,23 @@ function getTemplateTextFromBotConfigAndTemplateName(botConfig, templateName) {
   return botConfig.fields[fieldName];
 }
 
+/**
+ * @param {Object} botConfig
+ * @return {String}
+ */
+function getPostTypeFromBotConfig(botConfig) {
+  const postConfigContentType = contentful.parsePostConfigContentTypeFromBotConfig(botConfig);
+  if (!postConfigContentType) {
+    return config.defaultPostType;
+  }
+  return config.contentTypePostTypes[postConfigContentType];
+}
+
 module.exports = {
   fetchByCampaignId,
   getDefaultTextForBotConfigTemplateName,
   getTemplateFromBotConfigAndTemplateName,
   getTemplateTextFromBotConfigAndTemplateName,
   getTemplatesFromBotConfig,
-  /**
-   * @param {Object} botConfig
-   * @return {String}
-   */
-  parsePostTypeFromBotConfig: function parsePostTypeFromBotConfig(botConfig) {
-    const postTemplate = contentful.getPostTemplateFromBotConfig(botConfig);
-    if (!postTemplate) {
-      return config.defaultPostType;
-    }
-    const postTemplateType = contentful.parseContentTypeFromEntry(postTemplate);
-    return config.postTemplatePostTypes[postTemplateType];
-  },
+  getPostTypeFromBotConfig,
 };
-

--- a/lib/helpers/botConfig.js
+++ b/lib/helpers/botConfig.js
@@ -3,60 +3,75 @@
 const contentful = require('../contentful');
 const config = require('../../config/lib/helpers/botConfig');
 
-module.exports = {
-  /**
-   * Query Contentful to get the botConfig entry for given campaignId.
-   * TODO: Add a botConfig cache helper to cache Contentful requests.
-   *
-   * @param {Number} campaignId
-   * @return {Promise}
-   */
-  fetchByCampaignId: function fetchByCampaignId(campaignId) {
-    return contentful.fetchBotConfigByCampaignId(campaignId);
-  },
-  /**
-   * @param {String} templateName
-   * @return {String}
-   */
-  getDefaultTemplateText: function getDefaultTemplateText(templateName) {
-    return config.templates[templateName].default;
-  },
-  /**
-   * @param {Object} botConfig
-   * @param {String} templateName
-   * @return {Object}
-   */
-  getTemplateDataFromBotConfig: function getTemplateDataFromBotConfig(botConfig, templateName) {
-    const botConfigValue = this.getTemplateTextFromBotConfig(botConfig, templateName);
-    if (botConfig && botConfigValue) {
-      return {
-        raw: botConfigValue,
-        override: true,
-      };
-    }
+/**
+ * Query Contentful to get the botConfig entry for given campaignId.
+ * TODO: Add a botConfig cache helper to cache Contentful requests.
+ *
+ * @param {Number} campaignId
+ * @return {Promise}
+ */
+function fetchByCampaignId(campaignId) {
+  return contentful.fetchBotConfigByCampaignId(campaignId);
+}
+
+/**
+ * @param {String} templateName
+ * @return {String}
+ */
+function getDefaultTextForBotConfigTemplateName(templateName) {
+  return config.templates.botConfig[templateName].default;
+}
+
+/**
+ * @param {Object} botConfig
+ * @param {String} templateName
+ * @return {Object}
+ */
+function getTemplateFromBotConfigAndTemplateName(botConfig, templateName) {
+  const botConfigValue = this.getTemplateTextFromBotConfigAndTemplateName(botConfig, templateName);
+  if (botConfig && botConfigValue) {
     return {
-      raw: this.getDefaultTemplateText(templateName),
-      override: false,
+      raw: botConfigValue,
+      override: true,
     };
-  },
-  /**
-   * @return {Array}
-   */
-  getTemplateNames: function getTemplateNames() {
-    return Object.keys(config.templates);
-  },
-  /**
-   * @param {Object} botConfig
-   * @param {String} templateName
-   * @return {String}
-   */
-  getTemplateTextFromBotConfig: function getTemplateTextFromBotConfig(botConfig, templateName) {
-    if (!botConfig) {
-      return null;
-    }
-    const fieldName = config.templates[templateName].fieldName;
-    return botConfig.fields[fieldName];
-  },
+  }
+  return {
+    raw: this.getDefaultTextForBotConfigTemplateName(templateName),
+    override: false,
+  };
+}
+
+/**
+ * @return {Array}
+ */
+function getTemplatesFromBotConfig(botConfig) {
+  const result = {};
+  const botConfigTemplates = Object.keys(config.templates.botConfig);
+  botConfigTemplates.forEach((templateName) => {
+    result[templateName] = this.getTemplateFromBotConfigAndTemplateName(botConfig, templateName);
+  });
+  return result;
+}
+
+/**
+ * @param {Object} botConfig
+ * @param {String} templateName
+ * @return {String}
+ */
+function getTemplateTextFromBotConfigAndTemplateName(botConfig, templateName) {
+  if (!botConfig) {
+    return null;
+  }
+  const fieldName = config.templates.botConfig[templateName].fieldName;
+  return botConfig.fields[fieldName];
+}
+
+module.exports = {
+  fetchByCampaignId,
+  getDefaultTextForBotConfigTemplateName,
+  getTemplateFromBotConfigAndTemplateName,
+  getTemplateTextFromBotConfigAndTemplateName,
+  getTemplatesFromBotConfig,
   /**
    * @param {Object} botConfig
    * @return {String}
@@ -70,3 +85,4 @@ module.exports = {
     return config.postTemplatePostTypes[postTemplateType];
   },
 };
+

--- a/lib/helpers/botConfig.js
+++ b/lib/helpers/botConfig.js
@@ -76,7 +76,7 @@ function getPostTypeFromBotConfig(botConfig) {
   if (!postConfigContentType) {
     return config.defaultPostType;
   }
-  return config.contentTypePostTypes[postConfigContentType];
+  return config.postTypesByContentType[postConfigContentType];
 }
 
 module.exports = {

--- a/lib/middleware/campaigns/single/bot-config-parse.js
+++ b/lib/middleware/campaigns/single/bot-config-parse.js
@@ -8,17 +8,16 @@ module.exports = function parseBotConfig() {
       req.campaign.botConfig = {
         postType: helpers.botConfig.parsePostTypeFromBotConfig(req.botConfig),
       };
-      const templateNames = helpers.botConfig.getTemplateNames();
-      const templatesObj = {};
+      const templates = helpers.botConfig.getTemplatesFromBotConfig(req.botConfig);
+      const templateNames = Object.keys(templates);
       templateNames.forEach((templateName) => {
-        const data = helpers.botConfig.getTemplateDataFromBotConfig(req.botConfig, templateName);
-        data.rendered = helpers.replacePhoenixCampaignVars(data.raw, req.campaign);
-        templatesObj[templateName] = data;
+        const template = templates[templateName];
+        template.rendered = helpers.replacePhoenixCampaignVars(template.raw, req.campaign);
       });
-      req.campaign.botConfig.templates = templatesObj;
+      req.campaign.botConfig.templates = templates;
       // Adding this for backwards-compatability.
       // TODO: remove this property once we make change on Conversations side to inspect botConfig.
-      req.campaign.templates = templatesObj;
+      req.campaign.templates = templates;
     } catch (err) {
       return helpers.sendErrorResponse(res, err);
     }

--- a/lib/middleware/campaigns/single/bot-config-parse.js
+++ b/lib/middleware/campaigns/single/bot-config-parse.js
@@ -6,7 +6,7 @@ module.exports = function parseBotConfig() {
   return (req, res) => {
     try {
       req.campaign.botConfig = {
-        postType: helpers.botConfig.parsePostTypeFromBotConfig(req.botConfig),
+        postType: helpers.botConfig.getPostTypeFromBotConfig(req.botConfig),
       };
       const templates = helpers.botConfig.getTemplatesFromBotConfig(req.botConfig);
       const templateNames = Object.keys(templates);

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -28,8 +28,10 @@ const sandbox = sinon.sandbox.create();
 
 // Stubs
 const allKeywordsStub = Promise.resolve(stubs.contentful.getEntries('keywords'));
+const botConfigStub = stubs.contentful.getEntries('default-campaign').items[0];
 const keywordStub = Promise.resolve(stubs.contentful.getEntries('keyword'));
 const failStub = Promise.reject({ status: 500 });
+const postConfigContentTypeStub = stubs.getPostConfigContentType();
 const contentfulAPIStub = {
   getEntries: () => {},
 };
@@ -147,4 +149,27 @@ test('fetchKeywords should call contentfulError when it fails', async () => {
   // test
   await contentful.fetchKeywords();
   contentful.contentfulError.should.have.been.called;
+});
+
+// parsePostConfigContentTypeFromBotConfig
+test('parsePostConfigContentTypeFromBotConfig returns content type if botConfig has postConfig', () => {
+  sandbox.stub(contentful, 'getPostConfigFromBotConfig')
+    .returns({});
+  sandbox.stub(contentful, 'parseContentTypeFromEntry')
+    .returns(postConfigContentTypeStub);
+  const result = contentful.parsePostConfigContentTypeFromBotConfig(botConfigStub);
+  result.should.equal(postConfigContentTypeStub);
+});
+
+test('parsePostConfigContentTypeFromBotConfig returns falsy if botConfig does not have postConfig', (t) => {
+  sandbox.stub(contentful, 'getPostConfigFromBotConfig')
+    .returns(null);
+  const result = contentful.parsePostConfigContentTypeFromBotConfig(botConfigStub);
+  t.falsy(result);
+});
+
+// parseContentTypeFromEntry
+test('parseContentTypeFromEntry returns content type name of given entry', () => {
+  const result = contentful.parseContentTypeFromEntry(botConfigStub);
+  result.should.equal('campaign');
 });

--- a/test/lib/lib-helpers/botConfig.test.js
+++ b/test/lib/lib-helpers/botConfig.test.js
@@ -7,10 +7,14 @@ const sinon = require('sinon');
 
 const contentful = require('../../../lib/contentful');
 const stubs = require('../../utils/stubs');
+const config = require('../../../config/lib/helpers/botConfig');
 
-const mockBotConfig = stubs.contentful.getEntries('default-campaign').items[0];
-const mockTemplateName = stubs.getTemplateName();
-const mockTemplateText = stubs.getRandomString();
+const botConfig = stubs.contentful.getEntries('default-campaign').items[0];
+const botConfigTemplates = config.templates.botConfig;
+const postConfigContentType = 'textPostConfig';
+const postType = config.postTypesByContentType[postConfigContentType];
+const templateName = stubs.getTemplateName();
+const templateText = stubs.getRandomString();
 
 // Module to test
 const botConfigHelper = require('../../../lib/helpers/botConfig');
@@ -27,44 +31,69 @@ test.afterEach(() => {
 // fetchByCampaignId
 test('fetchByCampaignId returns contentful.fetchBotConfigByCampaignId', async () => {
   sandbox.stub(contentful, 'fetchBotConfigByCampaignId')
-    .returns(mockBotConfig);
+    .returns(botConfig);
 
   const result = await botConfigHelper.fetchByCampaignId(stubs.getCampaignId());
   contentful.fetchBotConfigByCampaignId.should.have.been.called;
-  result.should.equal(mockBotConfig);
+  result.should.equal(botConfig);
+});
+
+// getDefaultTextForBotConfigTemplateName
+test('getDefaultTextForBotConfigTemplateName returns default for templateName', () => {
+  const result = botConfigHelper.getDefaultTextForBotConfigTemplateName(templateName);
+  result.should.equal(botConfigTemplates[templateName].default);
 });
 
 // getTemplateDataFromBotConfig
 test('getTemplateFromBotConfigAndTemplateName returns default text when botConfig undefined', () => {
   sandbox.stub(botConfigHelper, 'getDefaultTextForBotConfigTemplateName')
-    .returns(mockTemplateText);
+    .returns(templateText);
   sandbox.stub(botConfigHelper, 'getTemplateTextFromBotConfigAndTemplateName')
     .returns(stubs.getRandomString());
 
-  const result = botConfigHelper.getTemplateFromBotConfigAndTemplateName(null, mockTemplateName);
+  const result = botConfigHelper.getTemplateFromBotConfigAndTemplateName(null, templateName);
   botConfigHelper.getDefaultTextForBotConfigTemplateName.should.have.been.called;
   botConfigHelper.getTemplateTextFromBotConfigAndTemplateName.should.have.been.called;
   result.override.should.equal(false);
-  result.raw.should.equal(mockTemplateText);
+  result.raw.should.equal(templateText);
 });
 
-test('getTemplateFromBotConfigAndTemplateName returns botConfig text when botConfig override exists', () => {
+test('getTemplateFromBotConfigAndTemplateName returns template text when botConfig value exists', () => {
   sandbox.stub(botConfigHelper, 'getDefaultTextForBotConfigTemplateName')
     .returns(stubs.getRandomString());
   sandbox.stub(botConfigHelper, 'getTemplateTextFromBotConfigAndTemplateName')
-    .returns(mockTemplateText);
+    .returns(templateText);
 
   const result = botConfigHelper
-    .getTemplateFromBotConfigAndTemplateName(mockBotConfig, mockTemplateName);
+    .getTemplateFromBotConfigAndTemplateName(botConfig, templateName);
   botConfigHelper.getDefaultTextForBotConfigTemplateName.should.not.have.been.called;
   botConfigHelper.getTemplateTextFromBotConfigAndTemplateName.should.have.been.called;
   result.override.should.equal(true);
-  result.raw.should.equal(mockTemplateText);
+  result.raw.should.equal(templateText);
 });
 
 // getTemplateTextFromBotConfigAndTemplateName
 test('getTemplateTextFromBotConfigAndTemplateName returns the botConfig field value for templateName arg', () => {
   const result = botConfigHelper
-    .getTemplateTextFromBotConfigAndTemplateName(mockBotConfig, mockTemplateName);
-  result.should.deep.equal(mockBotConfig.fields.completedMenuMessage);
+    .getTemplateTextFromBotConfigAndTemplateName(botConfig, templateName);
+  result.should.deep.equal(botConfig.fields.completedMenuMessage);
+});
+
+// getTemplatesFromBotConfig
+test('getTemplatesFromBotConfig returns an object with template names as properties', () => {
+  const templateData = { raw: templateText };
+  sandbox.stub(botConfigHelper, 'getTemplateFromBotConfigAndTemplateName')
+    .returns(templateData);
+  const result = botConfigHelper.getTemplatesFromBotConfig(botConfig);
+  Object.keys(botConfigTemplates).forEach((name) => {
+    result[name].should.deep.equal(templateData);
+  });
+});
+
+// getPostTypeFromBotConfig
+test('getPostTypeFromBotConfig returns the botConfig field value for templateName arg', () => {
+  sandbox.stub(contentful, 'parsePostConfigContentTypeFromBotConfig')
+    .returns(postConfigContentType);
+  const result = botConfigHelper.getPostTypeFromBotConfig(botConfig);
+  result.should.equal(postType);
 });

--- a/test/lib/lib-helpers/botConfig.test.js
+++ b/test/lib/lib-helpers/botConfig.test.js
@@ -8,12 +8,9 @@ const sinon = require('sinon');
 const contentful = require('../../../lib/contentful');
 const stubs = require('../../utils/stubs');
 
+const mockBotConfig = stubs.contentful.getEntries('default-campaign').items[0];
 const mockTemplateName = stubs.getTemplateName();
 const mockTemplateText = stubs.getRandomString();
-
-const config = require('../../../config/lib/helpers/botConfig');
-
-const botConfigStub = stubs.contentful.getEntries('default-campaign').items[0];
 
 // Module to test
 const botConfigHelper = require('../../../lib/helpers/botConfig');
@@ -30,48 +27,44 @@ test.afterEach(() => {
 // fetchByCampaignId
 test('fetchByCampaignId returns contentful.fetchBotConfigByCampaignId', async () => {
   sandbox.stub(contentful, 'fetchBotConfigByCampaignId')
-    .returns(botConfigStub);
+    .returns(mockBotConfig);
 
   const result = await botConfigHelper.fetchByCampaignId(stubs.getCampaignId());
   contentful.fetchBotConfigByCampaignId.should.have.been.called;
-  result.should.equal(botConfigStub);
+  result.should.equal(mockBotConfig);
 });
 
 // getTemplateDataFromBotConfig
-test('getTemplateDataFromBotConfig returns default text when botConfig arg undefined', () => {
-  sandbox.stub(botConfigHelper, 'getDefaultTemplateText')
+test('getTemplateFromBotConfigAndTemplateName returns default text when botConfig undefined', () => {
+  sandbox.stub(botConfigHelper, 'getDefaultTextForBotConfigTemplateName')
     .returns(mockTemplateText);
-  sandbox.stub(botConfigHelper, 'getTemplateTextFromBotConfig')
+  sandbox.stub(botConfigHelper, 'getTemplateTextFromBotConfigAndTemplateName')
     .returns(stubs.getRandomString());
 
-  const result = botConfigHelper.getTemplateDataFromBotConfig(null, mockTemplateName);
-  botConfigHelper.getDefaultTemplateText.should.have.been.called;
-  botConfigHelper.getTemplateTextFromBotConfig.should.have.been.called;
+  const result = botConfigHelper.getTemplateFromBotConfigAndTemplateName(null, mockTemplateName);
+  botConfigHelper.getDefaultTextForBotConfigTemplateName.should.have.been.called;
+  botConfigHelper.getTemplateTextFromBotConfigAndTemplateName.should.have.been.called;
   result.override.should.equal(false);
   result.raw.should.equal(mockTemplateText);
 });
 
-test('getTemplateDataFromBotConfig returns botConfig text when botConfig override exists', () => {
-  sandbox.stub(botConfigHelper, 'getDefaultTemplateText')
+test('getTemplateFromBotConfigAndTemplateName returns botConfig text when botConfig override exists', () => {
+  sandbox.stub(botConfigHelper, 'getDefaultTextForBotConfigTemplateName')
     .returns(stubs.getRandomString());
-  sandbox.stub(botConfigHelper, 'getTemplateTextFromBotConfig')
+  sandbox.stub(botConfigHelper, 'getTemplateTextFromBotConfigAndTemplateName')
     .returns(mockTemplateText);
 
-  const result = botConfigHelper.getTemplateDataFromBotConfig(botConfigStub, mockTemplateName);
-  botConfigHelper.getDefaultTemplateText.should.not.have.been.called;
-  botConfigHelper.getTemplateTextFromBotConfig.should.have.been.called;
+  const result = botConfigHelper
+    .getTemplateFromBotConfigAndTemplateName(mockBotConfig, mockTemplateName);
+  botConfigHelper.getDefaultTextForBotConfigTemplateName.should.not.have.been.called;
+  botConfigHelper.getTemplateTextFromBotConfigAndTemplateName.should.have.been.called;
   result.override.should.equal(true);
   result.raw.should.equal(mockTemplateText);
 });
 
-// getTemplateNames
-test('getTemplateNames returns the keys of config.templates', () => {
-  const result = botConfigHelper.getTemplateNames();
-  result.should.deep.equal(Object.keys(config.templates));
-});
-
-// getTemplateTextFromBotConfig
-test('getTemplateTextFromBotConfig returns the botConfig field value for templateName arg', () => {
-  const result = botConfigHelper.getTemplateTextFromBotConfig(botConfigStub, mockTemplateName);
-  result.should.deep.equal(botConfigStub.fields.completedMenuMessage);
+// getTemplateTextFromBotConfigAndTemplateName
+test('getTemplateTextFromBotConfigAndTemplateName returns the botConfig field value for templateName arg', () => {
+  const result = botConfigHelper
+    .getTemplateTextFromBotConfigAndTemplateName(mockBotConfig, mockTemplateName);
+  result.should.deep.equal(mockBotConfig.fields.completedMenuMessage);
 });

--- a/test/lib/lib-helpers/botConfig.test.js
+++ b/test/lib/lib-helpers/botConfig.test.js
@@ -79,6 +79,10 @@ test('getTemplateTextFromBotConfigAndTemplateName returns the botConfig field va
   result.should.deep.equal(botConfig.fields.completedMenuMessage);
 });
 
+test('getTemplateTextFromBotConfigAndTemplateName returns null if botConfig undefined', (t) => {
+  t.falsy(botConfigHelper.getTemplateTextFromBotConfigAndTemplateName(null, templateName));
+});
+
 // getTemplatesFromBotConfig
 test('getTemplatesFromBotConfig returns an object with template names as properties', () => {
   const templateData = { raw: templateText };

--- a/test/lib/middleware/campaigns/single/bot-config-parse.test.js
+++ b/test/lib/middleware/campaigns/single/bot-config-parse.test.js
@@ -41,13 +41,12 @@ test.afterEach((t) => {
 
 test('renderTemplates injects a templates object, where properties are objects with template data', (t) => {
   const middleware = renderTemplates();
-  const templateNames = helpers.botConfig.getTemplateNames();
+  const templateNames = [stubs.getTemplateName()];
   const mockPostType = 'photo';
   const mockRawText = stubs.getRandomString();
   const mockRenderedText = stubs.getRandomString();
   sandbox.spy(t.context.res, 'send');
-  sandbox.spy(helpers.botConfig, 'getTemplateNames');
-  sandbox.stub(helpers.botConfig, 'getTemplateDataFromBotConfig')
+  sandbox.stub(helpers.botConfig, 'getTemplateFromBotConfigAndTemplateName')
     .returns({ raw: mockRawText });
   sandbox.stub(helpers, 'replacePhoenixCampaignVars')
     .returns(mockRenderedText);
@@ -69,7 +68,7 @@ test('renderTemplates injects a templates object, where properties are objects w
 
 test('renderTemplates calls sendErrorResponse if an error is caught', (t) => {
   const middleware = renderTemplates();
-  sandbox.stub(helpers.botConfig, 'getTemplateNames')
+  sandbox.stub(helpers.botConfig, 'getTemplatesFromBotConfig')
     .throws();
 
   middleware(t.context.req, t.context.res);

--- a/test/lib/middleware/campaigns/single/bot-config-parse.test.js
+++ b/test/lib/middleware/campaigns/single/bot-config-parse.test.js
@@ -50,7 +50,7 @@ test('renderTemplates injects a templates object, where properties are objects w
     .returns({ raw: mockRawText });
   sandbox.stub(helpers, 'replacePhoenixCampaignVars')
     .returns(mockRenderedText);
-  sandbox.stub(helpers.botConfig, 'parsePostTypeFromBotConfig')
+  sandbox.stub(helpers.botConfig, 'getPostTypeFromBotConfig')
     .returns(mockPostType);
 
 

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -45,6 +45,9 @@ module.exports = {
   getPost: function getPost() {
     return { id: this.getPostId() };
   },
+  getPostConfigContentType: function getPostConfigContentType() {
+    return 'textPostConfig';
+  },
   getPostId: function getPostId() {
     return 9040481;
   },


### PR DESCRIPTION
#### What's this PR do?
Makes code updates per Contentful changes described in the title ☝️ , because it was getting too confusing having the word `template` in the field and content type names. This is prep work for the last remaining item in #1021, where we need to pull fields like `askText` and `invalidText` from the campaign `postConfig` reference entry to render as properties within the `templates` object of a `GET /campaigns/:id` response.

* Moves the template data defined in `config.templates` into `config.templates.botConfig`. The template data from other content types like `textPostConfig` and `photoPostConfig` will be defined here too as properties -- e.g.`config.templates.textPostConfig`, `config.templates.photoPostConfig`

* Adds a `getTemplatesFromBotConfig` botConfig helper function, that returns a `templates` object. It's currently looping through all templates defined in `config.templates.botConfig`, but eventually will loop through the relevant `config.template.textPostConfig` object keys to add our `askText` and `invalidText` template properties.
   * Updates `lib/middleware/campaigns/single/bot-config-parse` middleware accordingly
    * Moves `module.exports` to the bottom of `lib/helpers.botConfig` per https://github.com/DoSomething/gambit-campaigns/pull/1028#discussion_r179258770

#### How should this be reviewed?
I've made the relevant changes in Contentful for Get Lucky (created a `textPostConfig` and set it to the botConfig's `postConfig` reference field).  Upon staging deploy, verify:

Get Lucky returns a `botConfig.postType` set to `'text'`: https://ds-mdata-responder-staging.herokuapp.com/v1/campaigns/2900

And other campaigns return `botConfig.postType` set to `'photo'`: https://ds-mdata-responder-staging.herokuapp.com/v1/campaigns/2299

#### Any background context you want to provide?
what else?

#### Relevant tickets
#1021  #1026, #1027

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
