### PR TITLE
textPostConfig and photoPostConfig templates [pr]

### DIFF
--- a/config/lib/helpers/botConfig.js
+++ b/config/lib/helpers/botConfig.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const defaultText = {
-  askPhoto: 'Send us your best pic of yourself completing {{title}}.',
   askWhyParticipated: 'Last question: Why was participating in {{title}} important to you? (No need to write an essay, one sentence is good).',
   completedMenu: 'To submit another post for {{title}}, text {{cmd_reportback}}',
   declined: 'Text MENU if you\'d like to find a different action to take.',
@@ -27,50 +26,6 @@ module.exports = {
    */
   templates: {
     botConfig: {
-      gambitSignupMenu: {
-        fieldName: 'gambitSignupMenuMessage',
-        default: defaultText.signupMenu,
-      },
-      externalSignupMenu: {
-        fieldName: 'externalSignupMenuMessage',
-        default: `Hi its Freddie from DoSomething! ${defaultText.signupMenu}`,
-      },
-      invalidSignupMenuCommand: {
-        fieldName: 'invalidSignupMenuCommandMessage',
-        default: `${defaultText.invalidInput} Text {{cmd_reportback}} to a submit a post for {{campaign.title}}.`,
-      },
-      askPhoto: {
-        fieldName: 'askPhotoMessage',
-        default: defaultText.askPhoto,
-      },
-      invalidPhoto: {
-        fieldName: 'invalidPhotoMessage',
-        default: `${defaultText.invalidInput}\n\n${defaultText.askPhoto}`,
-      },
-      askCaption: {
-        fieldName: 'askCaptionMessage',
-        default: 'Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.',
-      },
-      invalidCaption: {
-        fieldName: 'invalidCaptionMessage',
-        default: `${defaultText.invalidInput}\n\nText back a caption for your photo -- keep it short & sweet, under 60 characters please. (but more than 3!)`,
-      },
-      askWhyParticipated: {
-        fieldName: 'askWhyParticipatedMessage',
-        default: defaultText.askWhyParticipated,
-      },
-      invalidWhyParticipated: {
-        fieldName: 'invalidWhyParticipatedMessage',
-        default: `${defaultText.invalidInput}\n\n${defaultText.askWhyParticipated}`,
-      },
-      completedMenu: {
-        fieldName: 'completedMenuMessage',
-        default: `Great! We've got you down for {{quantity}}.\n\n${defaultText.completedMenu}`,
-      },
-      invalidCompletedMenuCommand: {
-        fieldName: 'invalidCompletedMenuCommandMessage',
-        default: `${defaultText.invalidInput}\n\n${defaultText.completedMenu}.`,
-      },
       memberSupport: {
         fieldName: 'memberSupportMessage',
         default: 'Text back your question and I\'ll try to get back to you within 24 hrs.\n\nIf you want to continue {{title}}, text back {{keyword}}',
@@ -105,11 +60,53 @@ module.exports = {
       },
     },
     photoPostConfig: {
+      gambitSignupMenu: {
+        fieldName: 'gambitSignupMenuMessage',
+        default: defaultText.signupMenu,
+      },
+      externalSignupMenu: {
+        fieldName: 'externalSignupMenuMessage',
+        default: `Hi its Freddie from DoSomething! ${defaultText.signupMenu}`,
+      },
+      invalidSignupMenuCommand: {
+        fieldName: 'invalidSignupMenuCommandMessage',
+        default: `${defaultText.invalidInput} Text {{cmd_reportback}} to a submit a post for {{title}}.`,
+      },
       askQuantity: {
         fieldName: 'askQuantityMessage',
       },
       invalidQuantity: {
         fieldName: 'invalidQuantityMessage',
+      },
+      askPhoto: {
+        fieldName: 'askPhotoMessage',
+      },
+      invalidPhoto: {
+        fieldName: 'invalidPhotoMessage',
+      },
+      askCaption: {
+        fieldName: 'askCaptionMessage',
+        default: 'Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.',
+      },
+      invalidCaption: {
+        fieldName: 'invalidCaptionMessage',
+        default: `${defaultText.invalidInput}\n\nText back a caption for your photo -- keep it short & sweet, under 60 characters please. (but more than 3!)`,
+      },
+      askWhyParticipated: {
+        fieldName: 'askWhyParticipatedMessage',
+        default: defaultText.askWhyParticipated,
+      },
+      invalidWhyParticipated: {
+        fieldName: 'invalidWhyParticipatedMessage',
+        default: `${defaultText.invalidInput}\n\n${defaultText.askWhyParticipated}`,
+      },
+      completedMenu: {
+        fieldName: 'completedMenuMessage',
+        default: `Great! We've got you down for {{quantity}}.\n\n${defaultText.completedMenu}`,
+      },
+      invalidCompletedMenuCommand: {
+        fieldName: 'invalidCompletedMenuCommandMessage',
+        default: `${defaultText.invalidInput}\n\n${defaultText.completedMenu}.`,
       },
     },
     textPostConfig: {

--- a/config/lib/helpers/botConfig.js
+++ b/config/lib/helpers/botConfig.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const defaultText = {
-  askQuantity: 'How many have you completed? Be sure to text in a number not a word (i.e. “4”, not “four”)',
   askPhoto: 'Send us your best pic of yourself completing {{title}}.',
   askWhyParticipated: 'Last question: Why was participating in {{title}} important to you? (No need to write an essay, one sentence is good).',
   completedMenu: 'To submit another post for {{title}}, text {{cmd_reportback}}',
@@ -39,14 +38,6 @@ module.exports = {
       invalidSignupMenuCommand: {
         fieldName: 'invalidSignupMenuCommandMessage',
         default: `${defaultText.invalidInput} Text {{cmd_reportback}} to a submit a post for {{campaign.title}}.`,
-      },
-      askQuantity: {
-        fieldName: 'askQuantityMessage',
-        default: defaultText.askQuantity,
-      },
-      invalidQuantity: {
-        fieldName: 'invalidQuantityMessage',
-        default: `Sorry, that isnt a valid number. ${defaultText.askQuantity}`,
       },
       askPhoto: {
         fieldName: 'askPhotoMessage',
@@ -113,9 +104,14 @@ module.exports = {
         default: `${defaultText.invalidInput} Did you want to join {{title}}?${defaultText.yesNo}`,
       },
     },
-    /**
-     * These templates don't contain defaults because they are required fields in Contentful.
-     */
+    photoPostConfig: {
+      askQuantity: {
+        fieldName: 'askQuantityMessage',
+      },
+      invalidQuantity: {
+        fieldName: 'invalidQuantityMessage',
+      },
+    },
     textPostConfig: {
       askText: {
         fieldName: 'askTextMessage',

--- a/config/lib/helpers/botConfig.js
+++ b/config/lib/helpers/botConfig.js
@@ -21,11 +21,11 @@ module.exports = {
     photoPostConfig: 'photo',
   },
   /*
-   * Maps a conversation message template name with its Contentful field that stores its text, or
-   * the default text to use when a field value doesn't exist.
+   * Maps each content type with a map of templateNames and its corresponding field name and
+   * default text to use, if a field value doesn't exist. Fields without defaults are required.
    */
-  templates: {
-    botConfig: {
+  templatesByContentType: {
+    campaign: {
       memberSupport: {
         fieldName: 'memberSupportMessage',
         default: 'Text back your question and I\'ll try to get back to you within 24 hrs.\n\nIf you want to continue {{title}}, text back {{keyword}}',

--- a/config/lib/helpers/botConfig.js
+++ b/config/lib/helpers/botConfig.js
@@ -44,7 +44,7 @@ module.exports = {
       },
       invalidAskSignupResponse: {
         fieldName: 'invalidSignupResponseMessage',
-        default: `${defaultText.invalidInput} Did you want to join {{title}}${defaultText.yesNo}`,
+        default: `${defaultText.invalidInput} Did you want to join {{title}}?${defaultText.yesNo}`,
       },
       askContinue: {
         fieldName: 'askContinueMessage',

--- a/config/lib/helpers/botConfig.js
+++ b/config/lib/helpers/botConfig.js
@@ -113,5 +113,19 @@ module.exports = {
         default: `${defaultText.invalidInput} Did you want to join {{title}}?${defaultText.yesNo}`,
       },
     },
+    /**
+     * These templates don't contain defaults because they are required fields in Contentful.
+     */
+    textPostConfig: {
+      askText: {
+        fieldName: 'askTextMessage',
+      },
+      invalidText: {
+        fieldName: 'invalidTextMessage',
+      },
+      completedMenu: {
+        fieldName: 'completedMenuMessage',
+      },
+    },
   },
 };

--- a/config/lib/helpers/botConfig.js
+++ b/config/lib/helpers/botConfig.js
@@ -110,14 +110,17 @@ module.exports = {
       },
     },
     textPostConfig: {
-      askText: {
-        fieldName: 'askTextMessage',
+      botSignupConfirmed: {
+        fieldName: 'botSignupConfirmedMessage',
+      },
+      webSignupConfirmed: {
+        fieldName: 'webSignupConfirmedMessage',
       },
       invalidText: {
         fieldName: 'invalidTextMessage',
       },
-      completedMenu: {
-        fieldName: 'completedMenuMessage',
+      textPostCompleted: {
+        fieldName: 'textPostCompletedMessage',
       },
     },
   },

--- a/config/lib/helpers/botConfig.js
+++ b/config/lib/helpers/botConfig.js
@@ -64,9 +64,15 @@ module.exports = {
         fieldName: 'gambitSignupMenuMessage',
         default: defaultText.signupMenu,
       },
+      // This will get removed once Conversations Signup messages sends botSignupConfirmed.
+      // @see textPostConfig property below.
       externalSignupMenu: {
         fieldName: 'externalSignupMenuMessage',
         default: `Hi its Freddie from DoSomething! ${defaultText.signupMenu}`,
+      },
+      webSignupConfirmed: {
+        fieldName: 'gambitSignupMenuMessage',
+        default: defaultText.signupMenu,
       },
       invalidSignupMenuCommand: {
         fieldName: 'invalidSignupMenuCommandMessage',
@@ -111,6 +117,12 @@ module.exports = {
     },
     textPostConfig: {
       botSignupConfirmed: {
+        fieldName: 'botSignupConfirmedMessage',
+      },
+      // This will eventually get deprecated for webSignupConfirmed once Conversation Signup
+      // messages send the webSignupConfirmed.
+      // @see photoPostConfig above.
+      externalSignupMenu: {
         fieldName: 'botSignupConfirmedMessage',
       },
       webSignupConfirmed: {

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -145,6 +145,7 @@ module.exports.formatKeywordFromResponse = function formatKeywordFromResponse(co
 };
 
 /**
+ * Returns the Contentful entry saved to the postConfig reference field on given botConfig.
  * @param {object} botConfig
  * @param {object} - Contentful entry set for the botConfig.postConfig reference field.
  */
@@ -156,18 +157,20 @@ module.exports.getPostConfigFromBotConfig = function (botConfig) {
 };
 
 /**
+ * Returns the content type name of the postConfig entry saved for given botConfig.
  * @param {Object} botConfig
- * @return {String} - Name of the Contentful content type of entry saved as for postConfig field.
+ * @return {String}
  */
 module.exports.parsePostConfigContentTypeFromBotConfig = function (botConfig) {
   const postConfig = module.exports.getPostConfigFromBotConfig(botConfig);
-  return postConfig ? module.exports.parseContentTypeFromEntry(postConfig) : null;
+  return postConfig ? module.exports.parseContentTypeFromContentfulEntry(postConfig) : null;
 };
 
 /**
+ * Returns the name of the content type of the given Contentful entry.
  * @param {object} entry
  * @return {string}
  */
-module.exports.parseContentTypeFromEntry = function parseContentTypeFromEntry(entry) {
+module.exports.parseContentTypeFromContentfulEntry = function (entry) {
   return entry.sys.contentType.sys.id;
 };

--- a/lib/helpers/botConfig.js
+++ b/lib/helpers/botConfig.js
@@ -19,8 +19,8 @@ function fetchByCampaignId(campaignId) {
  * @param {String} templateName
  * @return {Object}
  */
-function getTemplateDataFromEntryAndTemplateName(entry, templateName) {
-  const contentTypeName = contentful.parseContentTypeFromEntry(entry);
+function getTemplateDataFromContentfulEntryAndTemplateName(entry, templateName) {
+  const contentTypeName = contentful.parseContentTypeFromContentfulEntry(entry);
   return config.templatesByContentType[contentTypeName][templateName];
 }
 
@@ -29,9 +29,10 @@ function getTemplateDataFromEntryAndTemplateName(entry, templateName) {
  * @param {String} templateName
  * @return {String}
  */
-function getDefaultValueFromEntryAndTemplateName(entry, templateName) {
-  const data = module.exports.getTemplateDataFromEntryAndTemplateName(entry, templateName);
-  return data.default;
+function getDefaultValueFromContentfulEntryAndTemplateName(entry, templateName) {
+  const templateData = module.exports
+    .getTemplateDataFromContentfulEntryAndTemplateName(entry, templateName);
+  return templateData.default;
 }
 
 /**
@@ -39,9 +40,10 @@ function getDefaultValueFromEntryAndTemplateName(entry, templateName) {
  * @param {String} templateName
  * @return {String}
  */
-function getFieldValueFromEntryAndTemplateName(entry, templateName) {
-  const data = module.exports.getTemplateDataFromEntryAndTemplateName(entry, templateName);
-  return entry.fields[data.fieldName];
+function getFieldValueFromContentfulEntryAndTemplateName(entry, templateName) {
+  const templateData = module.exports
+    .getTemplateDataFromContentfulEntryAndTemplateName(entry, templateName);
+  return entry.fields[templateData.fieldName];
 }
 
 /**
@@ -49,8 +51,9 @@ function getFieldValueFromEntryAndTemplateName(entry, templateName) {
  * @param {String} templateName
  * @return {Object}
  */
-function getTemplateFromEntryAndTemplateName(entry, templateName) {
-  const fieldValue = module.exports.getFieldValueFromEntryAndTemplateName(entry, templateName);
+function getTemplateFromContentfulEntryAndTemplateName(entry, templateName) {
+  const fieldValue = module.exports
+    .getFieldValueFromContentfulEntryAndTemplateName(entry, templateName);
   if (fieldValue) {
     return {
       raw: fieldValue,
@@ -59,7 +62,7 @@ function getTemplateFromEntryAndTemplateName(entry, templateName) {
   }
 
   return {
-    raw: module.exports.getDefaultValueFromEntryAndTemplateName(entry, templateName),
+    raw: module.exports.getDefaultValueFromContentfulEntryAndTemplateName(entry, templateName),
     override: false,
   };
 }
@@ -68,12 +71,13 @@ function getTemplateFromEntryAndTemplateName(entry, templateName) {
  * @param {Object} entry
  * @return {Object}
  */
-function getTemplatesFromEntry(entry) {
+function getTemplatesFromContentfulEntry(entry) {
   const result = {};
-  const contentTypeName = contentful.parseContentTypeFromEntry(entry);
+  const contentTypeName = contentful.parseContentTypeFromContentfulEntry(entry);
   const templateNames = Object.keys(config.templatesByContentType[contentTypeName]);
   templateNames.forEach((templateName) => {
-    result[templateName] = module.exports.getTemplateFromEntryAndTemplateName(entry, templateName);
+    result[templateName] = module.exports
+      .getTemplateFromContentfulEntryAndTemplateName(entry, templateName);
   });
   return result;
 }
@@ -87,9 +91,9 @@ function getTemplatesFromBotConfig(botConfig) {
   let postConfigTemplates = {};
   const postConfig = contentful.getPostConfigFromBotConfig(botConfig);
   if (postConfig) {
-    postConfigTemplates = module.exports.getTemplatesFromEntry(postConfig);
+    postConfigTemplates = module.exports.getTemplatesFromContentfulEntry(postConfig);
   }
-  const botConfigTemplates = module.exports.getTemplatesFromEntry(botConfig);
+  const botConfigTemplates = module.exports.getTemplatesFromContentfulEntry(botConfig);
   return Object.assign(postConfigTemplates, botConfigTemplates);
 }
 
@@ -107,11 +111,11 @@ function getPostTypeFromBotConfig(botConfig) {
 
 module.exports = {
   fetchByCampaignId,
-  getDefaultValueFromEntryAndTemplateName,
-  getFieldValueFromEntryAndTemplateName,
-  getTemplateDataFromEntryAndTemplateName,
-  getTemplateFromEntryAndTemplateName,
+  getDefaultValueFromContentfulEntryAndTemplateName,
+  getFieldValueFromContentfulEntryAndTemplateName,
+  getTemplateDataFromContentfulEntryAndTemplateName,
+  getTemplateFromContentfulEntryAndTemplateName,
   getTemplatesFromBotConfig,
-  getTemplatesFromEntry,
+  getTemplatesFromContentfulEntry,
   getPostTypeFromBotConfig,
 };

--- a/lib/helpers/botConfig.js
+++ b/lib/helpers/botConfig.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const logger = require('winston');
 const contentful = require('../contentful');
 const config = require('../../config/lib/helpers/botConfig');
 
@@ -16,101 +15,56 @@ function fetchByCampaignId(campaignId) {
 }
 
 /**
- * @param {String} templateName
- * @return {String}
- */
-function getDefaultTextForBotConfigTemplateName(templateName) {
-  return config.templates.botConfig[templateName].default;
-}
-
-/**
- * @param {Object} botConfig
+ * @param {Object} entry
  * @param {String} templateName
  * @return {Object}
  */
-function getTemplateFromBotConfigAndTemplateName(botConfig, templateName) {
-  const botConfigValue = this.getTemplateTextFromBotConfigAndTemplateName(botConfig, templateName);
-  if (botConfig && botConfigValue) {
+function getTemplateFromEntryAndTemplateName(entry, templateName) {
+  const contentTypeName = contentful.parseContentTypeFromEntry(entry);
+  const contentTypeTemplateConfig = config.templatesByContentType[contentTypeName][templateName];
+  const fieldName = contentTypeTemplateConfig.fieldName;
+  const fieldValue = entry.fields[fieldName];
+
+  if (fieldValue) {
     return {
-      raw: botConfigValue,
+      raw: fieldValue,
       override: true,
     };
   }
+
   return {
-    raw: this.getDefaultTextForBotConfigTemplateName(templateName),
+    raw: contentTypeTemplateConfig.default,
     override: false,
   };
 }
 
 /**
- * @return {Array}
+ * @param {Object} entry
+ * @return {Object}
  */
-function getTemplatesFromBotConfig(botConfig) {
+function getTemplatesFromEntry(entry) {
   const result = {};
-  const postConfig = contentful.getPostConfigFromBotConfig(botConfig);
-
-  if (module.exports.getPostTypeFromBotConfig(botConfig) === 'text') {
-    const textPostConfigTemplates = Object.keys(config.templates.textPostConfig);
-    textPostConfigTemplates.forEach((templateName) => {
-      const data = module.exports
-        .getTemplateFromTextPostConfigAndTemplateName(postConfig, templateName);
-      result[templateName] = data;
-    });
-  } else if (postConfig) {
-    const photoPostConfigTemplates = Object.keys(config.templates.photoPostConfig);
-    photoPostConfigTemplates.forEach((templateName) => {
-      const data = module.exports
-        .getTemplateFromPhotoPostConfigAndTemplateName(postConfig, templateName);
-      result[templateName] = data;
-    });
-  }
-
-  const botConfigTemplates = Object.keys(config.templates.botConfig);
-  botConfigTemplates.forEach((templateName) => {
-    result[templateName] = module.exports
-      .getTemplateFromBotConfigAndTemplateName(botConfig, templateName);
+  const contentTypeName = contentful.parseContentTypeFromEntry(entry);
+  const templateNames = Object.keys(config.templatesByContentType[contentTypeName]);
+  templateNames.forEach((templateName) => {
+    result[templateName] = module.exports.getTemplateFromEntryAndTemplateName(entry, templateName);
   });
   return result;
 }
 
 /**
+ * Returns a templates object for given botConfig, including its postConfig templates.
  * @param {Object} botConfig
- * @param {String} templateName
- * @return {String}
+ * @return {Object}
  */
-function getTemplateTextFromBotConfigAndTemplateName(botConfig, templateName) {
-  if (!botConfig) {
-    return null;
+function getTemplatesFromBotConfig(botConfig) {
+  let postConfigTemplates = {};
+  const postConfig = contentful.getPostConfigFromBotConfig(botConfig);
+  if (postConfig) {
+    postConfigTemplates = module.exports.getTemplatesFromEntry(postConfig);
   }
-  const fieldName = config.templates.botConfig[templateName].fieldName;
-  return botConfig.fields[fieldName];
-}
-
-function getFieldNameForContentTypeAndTemplateName(contentTypeName, templateName) {
-  logger.debug('getFieldNameForContentTypeAndTemplateName', { contentTypeName, templateName });
-  return config.templates[contentTypeName][templateName].fieldName;
-}
-
-/**
- * @param {Object} textPostConfig
- * @param {String} templateName
- * @return {Object}
- */
-function getTemplateFromTextPostConfigAndTemplateName(textPostConfig, templateName) {
-  logger.debug('getTemplateFromTextPostConfigAndTemplateName', { templateName });
-  const fieldName = getFieldNameForContentTypeAndTemplateName('textPostConfig', templateName);
-  return { raw: textPostConfig.fields[fieldName] };
-}
-
-/**
- * @param {Object} photoPostConfig
- * @param {String} templateName
- * @return {Object}
- */
-function getTemplateFromPhotoPostConfigAndTemplateName(photoPostConfig, templateName) {
-  logger.debug('getTemplateFromPhotoPostConfigAndTemplateName', { templateName });
-  const fieldName = getFieldNameForContentTypeAndTemplateName('photoPostConfig', templateName);
-  return { raw: photoPostConfig.fields[fieldName] };
+  const botConfigTemplates = module.exports.getTemplatesFromEntry(botConfig);
+  return Object.assign(postConfigTemplates, botConfigTemplates);
 }
 
 /**
@@ -127,11 +81,8 @@ function getPostTypeFromBotConfig(botConfig) {
 
 module.exports = {
   fetchByCampaignId,
-  getDefaultTextForBotConfigTemplateName,
-  getTemplateFromBotConfigAndTemplateName,
-  getTemplateTextFromBotConfigAndTemplateName,
-  getTemplateFromPhotoPostConfigAndTemplateName,
-  getTemplateFromTextPostConfigAndTemplateName,
+  getTemplateFromEntryAndTemplateName,
   getTemplatesFromBotConfig,
+  getTemplatesFromEntry,
   getPostTypeFromBotConfig,
 };

--- a/lib/helpers/botConfig.js
+++ b/lib/helpers/botConfig.js
@@ -56,6 +56,13 @@ function getTemplatesFromBotConfig(botConfig) {
         .getTemplateFromTextPostConfigAndTemplateName(postConfig, templateName);
       result[templateName] = data;
     });
+  } else if (postConfig) {
+    const photoPostConfigTemplates = Object.keys(config.templates.photoPostConfig);
+    photoPostConfigTemplates.forEach((templateName) => {
+      const data = module.exports
+        .getTemplateFromPhotoPostConfigAndTemplateName(postConfig, templateName);
+      result[templateName] = data;
+    });
   }
 
   const botConfigTemplates = Object.keys(config.templates.botConfig);
@@ -79,6 +86,11 @@ function getTemplateTextFromBotConfigAndTemplateName(botConfig, templateName) {
   return botConfig.fields[fieldName];
 }
 
+function getFieldNameForContentTypeAndTemplateName(contentTypeName, templateName) {
+  logger.debug('getFieldNameForContentTypeAndTemplateName', { contentTypeName, templateName });
+  return config.templates[contentTypeName][templateName].fieldName;
+}
+
 /**
  * @param {Object} textPostConfig
  * @param {String} templateName
@@ -86,10 +98,19 @@ function getTemplateTextFromBotConfigAndTemplateName(botConfig, templateName) {
  */
 function getTemplateFromTextPostConfigAndTemplateName(textPostConfig, templateName) {
   logger.debug('getTemplateFromTextPostConfigAndTemplateName', { templateName });
-  const fieldName = config.templates.textPostConfig[templateName].fieldName;
-  return {
-    raw: textPostConfig.fields[fieldName],
-  };
+  const fieldName = getFieldNameForContentTypeAndTemplateName('textPostConfig', templateName);
+  return { raw: textPostConfig.fields[fieldName] };
+}
+
+/**
+ * @param {Object} photoPostConfig
+ * @param {String} templateName
+ * @return {Object}
+ */
+function getTemplateFromPhotoPostConfigAndTemplateName(photoPostConfig, templateName) {
+  logger.debug('getTemplateFromPhotoPostConfigAndTemplateName', { templateName });
+  const fieldName = getFieldNameForContentTypeAndTemplateName('photoPostConfig', templateName);
+  return { raw: photoPostConfig.fields[fieldName] };
 }
 
 /**
@@ -109,6 +130,7 @@ module.exports = {
   getDefaultTextForBotConfigTemplateName,
   getTemplateFromBotConfigAndTemplateName,
   getTemplateTextFromBotConfigAndTemplateName,
+  getTemplateFromPhotoPostConfigAndTemplateName,
   getTemplateFromTextPostConfigAndTemplateName,
   getTemplatesFromBotConfig,
   getPostTypeFromBotConfig,

--- a/lib/helpers/botConfig.js
+++ b/lib/helpers/botConfig.js
@@ -19,12 +19,41 @@ function fetchByCampaignId(campaignId) {
  * @param {String} templateName
  * @return {Object}
  */
-function getTemplateFromEntryAndTemplateName(entry, templateName) {
+function getTemplateConfigFromEntryAndTemplateName(entry, templateName) {
   const contentTypeName = contentful.parseContentTypeFromEntry(entry);
-  const contentTypeTemplateConfig = config.templatesByContentType[contentTypeName][templateName];
-  const fieldName = contentTypeTemplateConfig.fieldName;
-  const fieldValue = entry.fields[fieldName];
+  return config.templatesByContentType[contentTypeName][templateName];
+}
 
+/**
+ * @param {Object} entry
+ * @param {String} templateName
+ * @return {String}
+ */
+function getDefaultValueFromEntryAndTemplateName(entry, templateName) {
+  const templateConfig = module.exports
+    .getTemplateConfigFromEntryAndTemplateName(entry, templateName);
+  return templateConfig.default;
+}
+
+/**
+ * @param {Object} entry
+ * @param {String} templateName
+ * @return {String}
+ */
+function getFieldValueFromEntryAndTemplateName(entry, templateName) {
+  const templateConfig = module.exports
+    .getTemplateConfigFromEntryAndTemplateName(entry, templateName);
+  const fieldName = templateConfig.fieldName;
+  return entry.fields[fieldName];
+}
+
+/**
+ * @param {Object} entry
+ * @param {String} templateName
+ * @return {Object}
+ */
+function getTemplateFromEntryAndTemplateName(entry, templateName) {
+  const fieldValue = module.exports.getFieldValueFromEntryAndTemplateName(entry, templateName);
   if (fieldValue) {
     return {
       raw: fieldValue,
@@ -33,7 +62,7 @@ function getTemplateFromEntryAndTemplateName(entry, templateName) {
   }
 
   return {
-    raw: contentTypeTemplateConfig.default,
+    raw: module.exports.getDefaultValueFromEntryAndTemplateName(entry, templateName),
     override: false,
   };
 }
@@ -81,6 +110,9 @@ function getPostTypeFromBotConfig(botConfig) {
 
 module.exports = {
   fetchByCampaignId,
+  getDefaultValueFromEntryAndTemplateName,
+  getFieldValueFromEntryAndTemplateName,
+  getTemplateConfigFromEntryAndTemplateName,
   getTemplateFromEntryAndTemplateName,
   getTemplatesFromBotConfig,
   getTemplatesFromEntry,

--- a/lib/helpers/botConfig.js
+++ b/lib/helpers/botConfig.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const logger = require('winston');
 const contentful = require('../contentful');
 const config = require('../../config/lib/helpers/botConfig');
 
@@ -46,10 +47,21 @@ function getTemplateFromBotConfigAndTemplateName(botConfig, templateName) {
  */
 function getTemplatesFromBotConfig(botConfig) {
   const result = {};
-  const botConfigTemplates = Object.keys(config.templates.botConfig);
+  const postConfig = contentful.getPostConfigFromBotConfig(botConfig);
 
+  if (module.exports.getPostTypeFromBotConfig(botConfig) === 'text') {
+    const textPostConfigTemplates = Object.keys(config.templates.textPostConfig);
+    textPostConfigTemplates.forEach((templateName) => {
+      const data = module.exports
+        .getTemplateFromTextPostConfigAndTemplateName(postConfig, templateName);
+      result[templateName] = data;
+    });
+  }
+
+  const botConfigTemplates = Object.keys(config.templates.botConfig);
   botConfigTemplates.forEach((templateName) => {
-    result[templateName] = this.getTemplateFromBotConfigAndTemplateName(botConfig, templateName);
+    result[templateName] = module.exports
+      .getTemplateFromBotConfigAndTemplateName(botConfig, templateName);
   });
   return result;
 }
@@ -65,6 +77,19 @@ function getTemplateTextFromBotConfigAndTemplateName(botConfig, templateName) {
   }
   const fieldName = config.templates.botConfig[templateName].fieldName;
   return botConfig.fields[fieldName];
+}
+
+/**
+ * @param {Object} textPostConfig
+ * @param {String} templateName
+ * @return {Object}
+ */
+function getTemplateFromTextPostConfigAndTemplateName(textPostConfig, templateName) {
+  logger.debug('getTemplateFromTextPostConfigAndTemplateName', { templateName });
+  const fieldName = config.templates.textPostConfig[templateName].fieldName;
+  return {
+    raw: textPostConfig.fields[fieldName],
+  };
 }
 
 /**
@@ -84,6 +109,7 @@ module.exports = {
   getDefaultTextForBotConfigTemplateName,
   getTemplateFromBotConfigAndTemplateName,
   getTemplateTextFromBotConfigAndTemplateName,
+  getTemplateFromTextPostConfigAndTemplateName,
   getTemplatesFromBotConfig,
   getPostTypeFromBotConfig,
 };

--- a/lib/helpers/botConfig.js
+++ b/lib/helpers/botConfig.js
@@ -19,7 +19,7 @@ function fetchByCampaignId(campaignId) {
  * @param {String} templateName
  * @return {Object}
  */
-function getTemplateConfigFromEntryAndTemplateName(entry, templateName) {
+function getTemplateDataFromEntryAndTemplateName(entry, templateName) {
   const contentTypeName = contentful.parseContentTypeFromEntry(entry);
   return config.templatesByContentType[contentTypeName][templateName];
 }
@@ -30,9 +30,8 @@ function getTemplateConfigFromEntryAndTemplateName(entry, templateName) {
  * @return {String}
  */
 function getDefaultValueFromEntryAndTemplateName(entry, templateName) {
-  const templateConfig = module.exports
-    .getTemplateConfigFromEntryAndTemplateName(entry, templateName);
-  return templateConfig.default;
+  const data = module.exports.getTemplateDataFromEntryAndTemplateName(entry, templateName);
+  return data.default;
 }
 
 /**
@@ -41,10 +40,8 @@ function getDefaultValueFromEntryAndTemplateName(entry, templateName) {
  * @return {String}
  */
 function getFieldValueFromEntryAndTemplateName(entry, templateName) {
-  const templateConfig = module.exports
-    .getTemplateConfigFromEntryAndTemplateName(entry, templateName);
-  const fieldName = templateConfig.fieldName;
-  return entry.fields[fieldName];
+  const data = module.exports.getTemplateDataFromEntryAndTemplateName(entry, templateName);
+  return entry.fields[data.fieldName];
 }
 
 /**
@@ -112,7 +109,7 @@ module.exports = {
   fetchByCampaignId,
   getDefaultValueFromEntryAndTemplateName,
   getFieldValueFromEntryAndTemplateName,
-  getTemplateConfigFromEntryAndTemplateName,
+  getTemplateDataFromEntryAndTemplateName,
   getTemplateFromEntryAndTemplateName,
   getTemplatesFromBotConfig,
   getTemplatesFromEntry,

--- a/lib/middleware/campaignActivity/text/post-create.js
+++ b/lib/middleware/campaignActivity/text/post-create.js
@@ -21,7 +21,7 @@ module.exports = function textPost() {
     return helpers.campaignActivity.createTextPostFromReq(req)
       .then((textPostRes) => {
         logger.debug('createTextPostFromReq response', textPostRes);
-        return replies.menuCompleted(req, res);
+        return replies.textPostCompleted(req, res);
       })
       .catch(err => helpers.sendErrorResponse(res, err));
   };

--- a/lib/middleware/campaignActivity/text/post-create.js
+++ b/lib/middleware/campaignActivity/text/post-create.js
@@ -11,13 +11,11 @@ module.exports = function textPost() {
     }
 
     if (req.keyword) {
-      // TODO: Send a new askText reply, sending askCaption for now.
-      return replies.askCaption(req, res);
+      return replies.askText(req, res);
     }
 
     if (!helpers.request.isValidReportbackText(req)) {
-      // TODO: Send a new invalidText reply.
-      return replies.invalidCaption(req, res);
+      return replies.invalidText(req, res);
     }
 
     return helpers.campaignActivity.createTextPostFromReq(req)

--- a/lib/middleware/campaigns/single/bot-config-parse.js
+++ b/lib/middleware/campaigns/single/bot-config-parse.js
@@ -5,6 +5,10 @@ const helpers = require('../../../helpers');
 module.exports = function parseBotConfig() {
   return (req, res) => {
     try {
+      if (!req.botConfig) {
+        req.campaign.botConfig = null;
+        return res.send({ data: req.campaign });
+      }
       req.campaign.botConfig = {
         postType: helpers.botConfig.getPostTypeFromBotConfig(req.botConfig),
       };

--- a/lib/middleware/campaigns/single/bot-config-parse.js
+++ b/lib/middleware/campaigns/single/bot-config-parse.js
@@ -15,9 +15,6 @@ module.exports = function parseBotConfig() {
         template.rendered = helpers.replacePhoenixCampaignVars(template.raw, req.campaign);
       });
       req.campaign.botConfig.templates = templates;
-      // Adding this for backwards-compatability.
-      // TODO: remove this property once we make change on Conversations side to inspect botConfig.
-      req.campaign.templates = templates;
     } catch (err) {
       return helpers.sendErrorResponse(res, err);
     }

--- a/lib/replies.js
+++ b/lib/replies.js
@@ -77,3 +77,11 @@ module.exports.campaignClosed = function campaignClosed(req, res) {
 module.exports.memberSupport = function memberSupport(req, res) {
   return sendResponse('memberSupport', req, res);
 };
+
+module.exports.askText = function askCaption(req, res) {
+  return sendResponse('askText', req, res);
+};
+
+module.exports.invalidText = function invalidText(req, res) {
+  return sendResponse('invalidText', req, res);
+};

--- a/lib/replies.js
+++ b/lib/replies.js
@@ -79,9 +79,13 @@ module.exports.memberSupport = function memberSupport(req, res) {
 };
 
 module.exports.askText = function askCaption(req, res) {
-  return sendResponse('askText', req, res);
+  return sendResponse('botSignupConfirmed', req, res);
 };
 
 module.exports.invalidText = function invalidText(req, res) {
   return sendResponse('invalidText', req, res);
+};
+
+module.exports.textPostCompleted = function textPostCompleted(req, res) {
+  return sendResponse('textPostCompleted', req, res);
 };

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -155,7 +155,7 @@ test('fetchKeywords should call contentfulError when it fails', async () => {
 test('parsePostConfigContentTypeFromBotConfig returns content type if botConfig has postConfig', () => {
   sandbox.stub(contentful, 'getPostConfigFromBotConfig')
     .returns({});
-  sandbox.stub(contentful, 'parseContentTypeFromEntry')
+  sandbox.stub(contentful, 'parseContentTypeFromContentfulEntry')
     .returns(postConfigContentTypeStub);
   const result = contentful.parsePostConfigContentTypeFromBotConfig(botConfigStub);
   result.should.equal(postConfigContentTypeStub);
@@ -169,7 +169,7 @@ test('parsePostConfigContentTypeFromBotConfig returns falsy if botConfig does no
 });
 
 // parseContentTypeFromEntry
-test('parseContentTypeFromEntry returns content type name of given entry', () => {
-  const result = contentful.parseContentTypeFromEntry(botConfigStub);
+test('parseContentTypeFromContentfulEntry returns content type name of given entry', () => {
+  const result = contentful.parseContentTypeFromContentfulEntry(botConfigStub);
   result.should.equal('campaign');
 });

--- a/test/lib/lib-helpers/botConfig.test.js
+++ b/test/lib/lib-helpers/botConfig.test.js
@@ -76,7 +76,7 @@ test('getTemplateFromBotConfigAndTemplateName returns template text when botConf
 test('getTemplateTextFromBotConfigAndTemplateName returns the botConfig field value for templateName arg', () => {
   const result = botConfigHelper
     .getTemplateTextFromBotConfigAndTemplateName(botConfig, templateName);
-  result.should.deep.equal(botConfig.fields.completedMenuMessage);
+  result.should.deep.equal(botConfig.fields.memberSupportMessage);
 });
 
 test('getTemplateTextFromBotConfigAndTemplateName returns null if botConfig undefined', (t) => {

--- a/test/lib/lib-helpers/botConfig.test.js
+++ b/test/lib/lib-helpers/botConfig.test.js
@@ -26,7 +26,7 @@ chai.use(sinonChai);
 const sandbox = sinon.sandbox.create();
 
 test.beforeEach(() => {
-  sandbox.stub(contentful, 'parseContentTypeFromEntry')
+  sandbox.stub(contentful, 'parseContentTypeFromContentfulEntry')
     .returns(botConfigContentType);
 });
 
@@ -45,50 +45,52 @@ test('fetchByCampaignId returns contentful.fetchBotConfigByCampaignId', async ()
 });
 
 // getDefaultTextForBotConfigTemplateName
-test('getDefaultValueFromEntryAndTemplateName returns default for templateName', () => {
-  const result = botConfigHelper.getDefaultValueFromEntryAndTemplateName(botConfig, templateName);
+test('getDefaultValueFromContentfulEntryAndTemplateName returns default for templateName', () => {
+  const result = botConfigHelper
+    .getDefaultValueFromContentfulEntryAndTemplateName(botConfig, templateName);
   result.should.equal(campaignTemplates[templateName].default);
 });
 
-// getTemplateFromEntryAndTemplateName
-test('getTemplateFromEntryAndTemplateName returns default text when no field value exists', () => {
-  sandbox.stub(botConfigHelper, 'getDefaultValueFromEntryAndTemplateName')
+// getTemplateFromContentfulEntryAndTemplateName
+test('getTemplateFromContentfulEntryAndTemplateName returns default text when no field value exists', () => {
+  sandbox.stub(botConfigHelper, 'getDefaultValueFromContentfulEntryAndTemplateName')
     .returns(templateText);
-  sandbox.stub(botConfigHelper, 'getFieldValueFromEntryAndTemplateName')
+  sandbox.stub(botConfigHelper, 'getFieldValueFromContentfulEntryAndTemplateName')
     .returns(null);
 
-  const result = botConfigHelper.getTemplateFromEntryAndTemplateName(botConfig, templateName);
-  botConfigHelper.getDefaultValueFromEntryAndTemplateName.should.have.been.called;
-  botConfigHelper.getFieldValueFromEntryAndTemplateName.should.have.been.called;
+  const result = botConfigHelper
+    .getTemplateFromContentfulEntryAndTemplateName(botConfig, templateName);
+  botConfigHelper.getDefaultValueFromContentfulEntryAndTemplateName.should.have.been.called;
+  botConfigHelper.getFieldValueFromContentfulEntryAndTemplateName.should.have.been.called;
   result.override.should.equal(false);
   result.raw.should.equal(templateText);
 });
 
-test('getTemplateFromEntryAndTemplateName returns template text when botConfig value exists', () => {
-  sandbox.stub(botConfigHelper, 'getDefaultValueFromEntryAndTemplateName')
+test('getTemplateFromContentfulEntryAndTemplateName returns template text when botConfig value exists', () => {
+  sandbox.stub(botConfigHelper, 'getDefaultValueFromContentfulEntryAndTemplateName')
     .returns(stubs.getRandomString());
-  sandbox.stub(botConfigHelper, 'getFieldValueFromEntryAndTemplateName')
+  sandbox.stub(botConfigHelper, 'getFieldValueFromContentfulEntryAndTemplateName')
     .returns(templateText);
 
   const result = botConfigHelper
-    .getTemplateFromEntryAndTemplateName(botConfig, templateName);
-  botConfigHelper.getDefaultValueFromEntryAndTemplateName.should.not.have.been.called;
-  botConfigHelper.getFieldValueFromEntryAndTemplateName.should.have.been.called;
+    .getTemplateFromContentfulEntryAndTemplateName(botConfig, templateName);
+  botConfigHelper.getDefaultValueFromContentfulEntryAndTemplateName.should.not.have.been.called;
+  botConfigHelper.getFieldValueFromContentfulEntryAndTemplateName.should.have.been.called;
   result.override.should.equal(true);
   result.raw.should.equal(templateText);
 });
 
-// getFieldValueFromEntryAndTemplateName
-test('getFieldValueFromEntryAndTemplateName returns the entry field value for templateName', () => {
+// getFieldValueFromContentfulEntryAndTemplateName
+test('getFieldValueFromContentfulEntryAndTemplateName returns the entry field value for templateName', () => {
   const result = botConfigHelper
-    .getFieldValueFromEntryAndTemplateName(botConfig, templateName);
+    .getFieldValueFromContentfulEntryAndTemplateName(botConfig, templateName);
   result.should.deep.equal(botConfig.fields.memberSupportMessage);
 });
 
 // getTemplatesFromBotConfig
 test('getTemplatesFromBotConfig returns an object with template names as properties', () => {
   const templateData = { raw: templateText };
-  sandbox.stub(botConfigHelper, 'getTemplateFromEntryAndTemplateName')
+  sandbox.stub(botConfigHelper, 'getTemplateFromContentfulEntryAndTemplateName')
     .returns(templateData);
   const result = botConfigHelper.getTemplatesFromBotConfig(botConfig);
   Object.keys(campaignTemplates).forEach((name) => {

--- a/test/lib/lib-helpers/botConfig.test.js
+++ b/test/lib/lib-helpers/botConfig.test.js
@@ -10,7 +10,7 @@ const stubs = require('../../utils/stubs');
 const config = require('../../../config/lib/helpers/botConfig');
 
 const botConfig = stubs.contentful.getEntries('default-campaign').items[0];
-const botConfigTemplates = config.templates.botConfig;
+const botConfigTemplates = config.templatesByContentType.campaign;
 const postConfigContentType = 'textPostConfig';
 const postType = config.postTypesByContentType[postConfigContentType];
 const templateName = stubs.getTemplateName();
@@ -45,7 +45,7 @@ test('getDefaultTextForBotConfigTemplateName returns default for templateName', 
 });
 
 // getTemplateDataFromBotConfig
-test('getTemplateFromBotConfigAndTemplateName returns default text when botConfig undefined', () => {
+test('getTemplateFromEntryAndTemplateName returns default text when field value undefined', () => {
   sandbox.stub(botConfigHelper, 'getDefaultTextForBotConfigTemplateName')
     .returns(templateText);
   sandbox.stub(botConfigHelper, 'getTemplateTextFromBotConfigAndTemplateName')

--- a/test/lib/middleware/campaignActivity/text/post-create.test.js
+++ b/test/lib/middleware/campaignActivity/text/post-create.test.js
@@ -23,9 +23,9 @@ const sandbox = sinon.sandbox.create();
 test.beforeEach((t) => {
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);
-  sandbox.stub(replies, 'askCaption')
+  sandbox.stub(replies, 'askText')
     .returns(underscore.noop);
-  sandbox.stub(replies, 'invalidCaption')
+  sandbox.stub(replies, 'invalidText')
     .returns(underscore.noop);
   sandbox.stub(replies, 'menuCompleted')
     .returns(underscore.noop);
@@ -46,13 +46,13 @@ test('textPost returns next if not a textPost request', async (t) => {
 
   await middleware(t.context.req, t.context.res, next);
   next.should.have.been.called;
-  replies.askCaption.should.not.have.been.called;
-  replies.invalidCaption.should.not.have.been.called;
+  replies.askText.should.not.have.been.called;
+  replies.invalidText.should.not.have.been.called;
   replies.menuCompleted.should.not.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('textPost returns askCaption when request has a keyword', async (t) => {
+test('textPost returns askText when request has a keyword', async (t) => {
   const next = sinon.stub();
   const middleware = textPost();
   sandbox.stub(helpers.request, 'isTextPost')
@@ -61,13 +61,13 @@ test('textPost returns askCaption when request has a keyword', async (t) => {
 
   await middleware(t.context.req, t.context.res, next);
   next.should.not.have.been.called;
-  replies.askCaption.should.have.been.calledWith(t.context.req, t.context.res);
-  replies.invalidCaption.should.not.have.been.called;
+  replies.askText.should.have.been.calledWith(t.context.req, t.context.res);
+  replies.invalidText.should.not.have.been.called;
   replies.menuCompleted.should.not.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('textPost returns invalidCaption when request.isValidReportbackText is false', async (t) => {
+test('textPost returns invalidText when request.isValidReportbackText is false', async (t) => {
   const next = sinon.stub();
   const middleware = textPost();
   sandbox.stub(helpers.request, 'isTextPost')
@@ -79,8 +79,8 @@ test('textPost returns invalidCaption when request.isValidReportbackText is fals
 
   await middleware(t.context.req, t.context.res, next);
   next.should.not.have.been.called;
-  replies.askCaption.should.not.have.been.calledWith(t.context.req, t.context.res);
-  replies.invalidCaption.should.not.have.been.called;
+  replies.askText.should.not.have.been.calledWith(t.context.req, t.context.res);
+  replies.invalidText.should.not.have.been.called;
   helpers.campaignActivity.createTextPostFromReq.should.have.been.calledWith(t.context.req);
   replies.menuCompleted.should.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
@@ -98,8 +98,8 @@ test('textPost returns completedMenu upon createTextPostFromReq success', async 
 
   await middleware(t.context.req, t.context.res, next);
   next.should.not.have.been.called;
-  replies.askCaption.should.not.have.been.calledWith(t.context.req, t.context.res);
-  replies.invalidCaption.should.not.have.been.called;
+  replies.askText.should.not.have.been.calledWith(t.context.req, t.context.res);
+  replies.invalidText.should.not.have.been.called;
   helpers.campaignActivity.createTextPostFromReq.should.have.been.calledWith(t.context.req);
   replies.menuCompleted.should.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
@@ -118,8 +118,8 @@ test('textPost returns sendErrorResponse upon createTextPostFromReq error', asyn
 
   await middleware(t.context.req, t.context.res, next);
   next.should.not.have.been.called;
-  replies.askCaption.should.not.have.been.calledWith(t.context.req, t.context.res);
-  replies.invalidCaption.should.not.have.been.called;
+  replies.askText.should.not.have.been.calledWith(t.context.req, t.context.res);
+  replies.invalidText.should.not.have.been.called;
   helpers.campaignActivity.createTextPostFromReq.should.have.been.calledWith(t.context.req);
   replies.menuCompleted.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);

--- a/test/lib/middleware/campaignActivity/text/post-create.test.js
+++ b/test/lib/middleware/campaignActivity/text/post-create.test.js
@@ -27,7 +27,7 @@ test.beforeEach((t) => {
     .returns(underscore.noop);
   sandbox.stub(replies, 'invalidText')
     .returns(underscore.noop);
-  sandbox.stub(replies, 'menuCompleted')
+  sandbox.stub(replies, 'textPostCompleted')
     .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
   t.context.res = httpMocks.createResponse();
@@ -48,7 +48,7 @@ test('textPost returns next if not a textPost request', async (t) => {
   next.should.have.been.called;
   replies.askText.should.not.have.been.called;
   replies.invalidText.should.not.have.been.called;
-  replies.menuCompleted.should.not.have.been.called;
+  replies.textPostCompleted.should.not.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
@@ -63,7 +63,7 @@ test('textPost returns askText when request has a keyword', async (t) => {
   next.should.not.have.been.called;
   replies.askText.should.have.been.calledWith(t.context.req, t.context.res);
   replies.invalidText.should.not.have.been.called;
-  replies.menuCompleted.should.not.have.been.called;
+  replies.textPostCompleted.should.not.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
@@ -82,7 +82,7 @@ test('textPost returns invalidText when request.isValidReportbackText is false',
   replies.askText.should.not.have.been.calledWith(t.context.req, t.context.res);
   replies.invalidText.should.not.have.been.called;
   helpers.campaignActivity.createTextPostFromReq.should.have.been.calledWith(t.context.req);
-  replies.menuCompleted.should.have.been.called;
+  replies.textPostCompleted.should.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
@@ -101,7 +101,7 @@ test('textPost returns completedMenu upon createTextPostFromReq success', async 
   replies.askText.should.not.have.been.calledWith(t.context.req, t.context.res);
   replies.invalidText.should.not.have.been.called;
   helpers.campaignActivity.createTextPostFromReq.should.have.been.calledWith(t.context.req);
-  replies.menuCompleted.should.have.been.called;
+  replies.textPostCompleted.should.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
@@ -121,6 +121,6 @@ test('textPost returns sendErrorResponse upon createTextPostFromReq error', asyn
   replies.askText.should.not.have.been.calledWith(t.context.req, t.context.res);
   replies.invalidText.should.not.have.been.called;
   helpers.campaignActivity.createTextPostFromReq.should.have.been.calledWith(t.context.req);
-  replies.menuCompleted.should.not.have.been.called;
+  replies.textPostCompleted.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
 });

--- a/test/lib/middleware/campaigns/single/bot-config-parse.test.js
+++ b/test/lib/middleware/campaigns/single/bot-config-parse.test.js
@@ -13,6 +13,7 @@ const stubs = require('../../../../utils/stubs');
 const helpers = require('../../../../../lib/helpers');
 
 const campaign = stubs.getPhoenixCampaign();
+const templateName = stubs.getTemplateName();
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -41,27 +42,29 @@ test.afterEach((t) => {
 
 test('renderTemplates injects a templates object, where properties are objects with template data', (t) => {
   const middleware = renderTemplates();
-  const templateNames = [stubs.getTemplateName()];
-  const mockPostType = 'photo';
+  const templateNames = [templateName];
+  const mockPostType = stubs.getPostType();
   const mockRawText = stubs.getRandomString();
   const mockRenderedText = stubs.getRandomString();
-  sandbox.spy(t.context.res, 'send');
-  sandbox.stub(helpers.botConfig, 'getTemplateFromBotConfigAndTemplateName')
-    .returns({ raw: mockRawText });
+  const mockTemplates = {};
+  mockTemplates[templateName] = { raw: mockRawText };
+  sandbox.stub(helpers.botConfig, 'getTemplatesFromBotConfig')
+    .returns(mockTemplates);
   sandbox.stub(helpers, 'replacePhoenixCampaignVars')
     .returns(mockRenderedText);
   sandbox.stub(helpers.botConfig, 'getPostTypeFromBotConfig')
     .returns(mockPostType);
-
+  sandbox.spy(t.context.res, 'send');
 
   middleware(t.context.req, t.context.res);
   t.context.req.campaign.should.have.property('templates');
   t.context.req.campaign.botConfig.postType.should.equal(mockPostType);
   t.context.req.campaign.botConfig.templates.should.equal(t.context.req.campaign.templates);
   helpers.replacePhoenixCampaignVars.should.have.been.calledWith(mockRawText, campaign);
-  templateNames.forEach((templateName) => {
-    t.context.req.campaign.templates[templateName].raw.should.equal(mockRawText);
-    t.context.req.campaign.templates[templateName].rendered.should.equal(mockRenderedText);
+  templateNames.forEach((name) => {
+    const template = t.context.req.campaign.templates[name];
+    template.raw.should.equal(mockRawText);
+    template.rendered.should.equal(mockRenderedText);
   });
   t.context.res.send.should.have.been.called;
 });

--- a/test/lib/middleware/campaigns/single/bot-config-parse.test.js
+++ b/test/lib/middleware/campaigns/single/bot-config-parse.test.js
@@ -57,12 +57,11 @@ test('renderTemplates injects a templates object, where properties are objects w
   sandbox.spy(t.context.res, 'send');
 
   middleware(t.context.req, t.context.res);
-  t.context.req.campaign.should.have.property('templates');
+  t.context.req.campaign.botConfig.should.have.property('templates');
   t.context.req.campaign.botConfig.postType.should.equal(mockPostType);
-  t.context.req.campaign.botConfig.templates.should.equal(t.context.req.campaign.templates);
   helpers.replacePhoenixCampaignVars.should.have.been.calledWith(mockRawText, campaign);
   templateNames.forEach((name) => {
-    const template = t.context.req.campaign.templates[name];
+    const template = t.context.req.campaign.botConfig.templates[name];
     template.raw.should.equal(mockRawText);
     template.rendered.should.equal(mockRenderedText);
   });

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -52,7 +52,7 @@ module.exports = {
     return 9040481;
   },
   getTemplateName: function getTemplateName() {
-    return 'completedMenu';
+    return 'memberSupport';
   },
   getUserId: function getUserId() {
     return '597b9ef910707d07c84b00aa';

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -51,6 +51,9 @@ module.exports = {
   getPostId: function getPostId() {
     return 9040481;
   },
+  getPostType: function getPostType() {
+    return 'text';
+  },
   getTemplateName: function getTemplateName() {
     return 'memberSupport';
   },


### PR DESCRIPTION
#### What's this PR do?

Returns the field values from a botConfig's `postConfig` entry as properties in the `templates` object of a `GET /campaigns/:id` response.

Contentful changes:

*  [x] Added a new `photoPostConfig` content type, with `photoPost` fields like `gambitSignupMenuMessage`, `askQuantityMessage`

* [x] Added `askTextMessage`, `invalidTextMessage`, and `menuCompletedMessages` fields to the `textPostConfig` content type.

* [x] Added `photoPostConfig` as an available type to reference as a botConfig's `postConfig` field.

* [x] Create `photoPostConfig` entries for all botConfigs currently running on staging and production, migrating overrides. This sounds like the stuff Contentful migrations are made for, but the number's small enough that I'll just manually add 💻 📝 Campaigns id's to edit:

    * [x] 7 - Mirror Messages
    * [x] 2178  - Give A Spit (thirdParty)
    * [x] 7059 - VCard (thirdParty)
    * [x] 7483 - Rinse Recycle Repeat
    * [x] 7951 - Gun Violence (thirdParty)
    * [x] 8017 - Grab the Mic (thirdParty)
    * [x] 8038 - Save Mascots
<br>

* [x] Make `postConfig` field mandatory 

After go live:

* [ ] Remove botConfig fields like `askQuantity` that have been migrated to the photoPostConfig type.

Gambit changes:

* Renames the botConfig `config.templates` as `config.templatesByContentType`, adds `textPostConfig` and `photoPostConfig` properties (#1032) per Contentful changes above 👆 

* Refactors the `botConfig` helper to gather templates based on content type

* Adds new `askText` and `invalidText` replies for use in Text Post middleware

#### How should this be reviewed?

Upon staging deploy:

* Verify textPost conversation flow (LUCKYBOT)

* Verify photoPost conversation flow (BOOKBOT)

#### Relevant tickets
#1021 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
- [x] Deploy https://github.com/DoSomething/gambit-conversations/pull/317 to Conversations prod before deploying this branch to Campaigns prod