### PR TITLE
External Posts

### DIFF
--- a/app/routes/campaignActivity.js
+++ b/app/routes/campaignActivity.js
@@ -13,6 +13,9 @@ const getSignupMiddleware = require('../../lib/middleware/campaignActivity/signu
 const createNewSignupIfNotFoundMiddleware = require('../../lib/middleware/campaignActivity/signup-create');
 const validateRequestMiddleware = require('../../lib/middleware/campaignActivity/validate');
 
+// Middleware for External Posts.
+const externalPostMiddleware = require('../../lib/middleware/campaignActivity/external');
+
 // Middleware for Text Posts.
 const createTextPostMiddleware = require('../../lib/middleware/campaignActivity/text/post-create');
 
@@ -51,12 +54,17 @@ router.use(
 router.use(validateRequestMiddleware());
 
 /**
- * Submits a Text Post for requests with postType text.
+ * Handle External Post requests.
+ */
+router.use(externalPostMiddleware());
+
+/**
+ * Handle Text Post requests.
  */
 router.use(createTextPostMiddleware());
 
 /**
- * Check if this request is starting a Photo Post Submission.
+ * Check if this request is starting a submission for a Photo Post.
  */
 router.use(createDraftSubmissionMiddleware());
 

--- a/config/lib/helpers/botConfig.js
+++ b/config/lib/helpers/botConfig.js
@@ -26,6 +26,7 @@ module.exports = {
    * { contentTypeName: 'postType' }
    */
   postTypesByContentType: {
+    externalPostConfig: 'external',
     textPostConfig: 'text',
     photoPostConfig: 'photo',
   },
@@ -66,6 +67,17 @@ module.exports = {
       invalidAskContinueResponse: {
         fieldName: 'invalidContinueResponseMessage',
         default: `${defaultText.invalidInput} Did you want to join {{title}}?${defaultText.yesNo}`,
+      },
+    },
+    externalPostConfig: {
+      startExternalPost: {
+        fieldName: 'startExternalPostMessage',
+      },
+      webStartExternalPost: {
+        fieldName: 'webStartExternalPostMessage',
+      },
+      startExternalPostAutoReply: {
+        fieldName: 'startExternalPostAutoReplyMessage',
       },
     },
     photoPostConfig: {

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -20,6 +20,13 @@ function hasSubmittedPhotoPost(req) {
 /**
  * @return {Boolean}
  */
+function isExternalPost(req) {
+  return req.postType === 'external';
+}
+
+/**
+ * @return {Boolean}
+ */
 function isTextPost(req) {
   return req.postType === 'text';
 }
@@ -34,6 +41,7 @@ function isValidReportbackText(req) {
 module.exports = {
   hasDraftSubmission,
   hasSubmittedPhotoPost,
+  isExternalPost,
   isTextPost,
   isValidReportbackText,
 };

--- a/lib/middleware/campaignActivity/external/index.js
+++ b/lib/middleware/campaignActivity/external/index.js
@@ -5,14 +5,16 @@ const replies = require('../../../replies');
 
 module.exports = function externalPost() {
   return (req, res, next) => {
-    if (!helpers.request.isExternalPost(req)) {
-      return next();
+    try {
+      if (!helpers.request.isExternalPost(req)) {
+        return next();
+      }
+      if (req.keyword) {
+        return replies.startExternalPost(req, res);
+      }
+      return replies.startExternalPostAutoReply(req, res);
+    } catch (error) {
+      return helpers.sendErrorResponse(res, error);
     }
-
-    if (req.keyword) {
-      return replies.startExternalPost(req, res);
-    }
-
-    return replies.startExternalPostAutoReply(req, res);
   };
 };

--- a/lib/middleware/campaignActivity/external/index.js
+++ b/lib/middleware/campaignActivity/external/index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const helpers = require('../../../helpers');
+const replies = require('../../../replies');
+
+module.exports = function externalPost() {
+  return (req, res, next) => {
+    if (!helpers.request.isExternalPost(req)) {
+      return next();
+    }
+
+    if (req.keyword) {
+      return replies.startExternalPost(req, res);
+    }
+
+    return replies.startExternalPostAutoReply(req, res);
+  };
+};

--- a/lib/replies.js
+++ b/lib/replies.js
@@ -80,3 +80,18 @@ module.exports.invalidText = function invalidText(req, res) {
 module.exports.completedTextPost = function completedTextPost(req, res) {
   return sendResponse('completedTextPost', req, res);
 };
+
+/**
+ * External Post replies
+ */
+module.exports.startExternalPost = function startExternalPost(req, res) {
+  return sendResponse('startExternalPost', req, res);
+};
+
+module.exports.webStartExternalPost = function webStartExternalPost(req, res) {
+  return sendResponse('webStartExternalPost', req, res);
+};
+
+module.exports.startExternalPostAutoReply = function startExternalPostAutoReply(req, res) {
+  return sendResponse('startExternalPostAutoReply', req, res);
+};

--- a/test/lib/lib-helpers/request.test.js
+++ b/test/lib/lib-helpers/request.test.js
@@ -28,8 +28,16 @@ test.afterEach((t) => {
   t.context = {};
 });
 
+// isExternalPost
+test('isExternalPost returns whether req.postType is external', (t) => {
+  t.context.req.postType = 'external';
+  t.truthy(requestHelper.isExternalPost(t.context.req));
+  t.context.req.postType = 'photo';
+  t.falsy(requestHelper.isExternalPost(t.context.req));
+});
+
 // isTextPost
-test('isTextPost returns whether req.keyword', (t) => {
+test('isTextPost returns whether req.postType is text', (t) => {
   t.context.req.postType = 'text';
   t.truthy(requestHelper.isTextPost(t.context.req));
   t.context.req.postType = 'photo';

--- a/test/lib/middleware/campaignActivity/external/index.test.js
+++ b/test/lib/middleware/campaignActivity/external/index.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../lib/helpers');
+const replies = require('../../../../../lib/replies');
+const stubs = require('../../../../utils/stubs');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const externalPost = require('../../../../../lib/middleware/campaignActivity/external');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  sandbox.stub(replies, 'startExternalPost')
+    .returns(underscore.noop);
+  sandbox.stub(replies, 'startExternalPostAutoReply')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('externalPost returns next if not an externalPost request', async (t) => {
+  const next = sinon.stub();
+  const middleware = externalPost();
+  sandbox.stub(helpers.request, 'isExternalPost')
+    .returns(false);
+
+  await middleware(t.context.req, t.context.res, next);
+  next.should.have.been.called;
+  replies.startExternalPost.should.not.have.been.called;
+  replies.startExternalPostAutoReply.should.not.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('externalPost returns start reply for externalPost request with keyword', async (t) => {
+  const next = sinon.stub();
+  const middleware = externalPost();
+  sandbox.stub(helpers.request, 'isExternalPost')
+    .returns(true);
+  t.context.req.keyword = stubs.getKeyword();
+
+  await middleware(t.context.req, t.context.res, next);
+  next.should.not.have.been.called;
+  replies.startExternalPost.should.have.been.calledWith(t.context.req, t.context.res);
+  replies.startExternalPostAutoReply.should.not.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('externalPost returns auto reply for externalPost request without keyword', async (t) => {
+  const next = sinon.stub();
+  const middleware = externalPost();
+  sandbox.stub(helpers.request, 'isExternalPost')
+    .returns(true);
+
+  await middleware(t.context.req, t.context.res, next);
+  next.should.not.have.been.called;
+  replies.startExternalPost.should.not.have.been.called;
+  replies.startExternalPostAutoReply.should.have.been.calledWith(t.context.req, t.context.res);
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('externalPost returns sendErrorResponse if error', async (t) => {
+  const next = sinon.stub();
+  const middleware = externalPost();
+  const error = new Error('o noes');
+  sandbox.stub(helpers.request, 'isExternalPost')
+    .throws(error);
+
+  await middleware(t.context.req, t.context.res, next);
+  next.should.not.have.been.called;
+  replies.startExternalPost.should.not.have.been.called;
+  replies.startExternalPostAutoReply.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
+});


### PR DESCRIPTION
#### What's this PR do?

Adds support for a new `externalPostConfig` content type that can be saved to a botConfig's `postConfig` reference field.

* I've manually created the content type in Contentful, and added it as an available entry to select in the campaign `postConfig` reference field settings.

#### How should this be reviewed?

I've edited BOOKBOT (campaign 2299) on staging to reference a new `externalPostConfig` entry. Upon staging deploy, verify:

* A [`GET /campaigns/2299` response](https://ds-mdata-responder-staging.herokuapp.com/v1/campaigns/2299) returns a `postType` of `'external'`, and contains `startExternalPost`, `webStartExternalPost`, and `startExternalPostAutoReply` templates

* In tandem with https://github.com/DoSomething/gambit-conversations/pull/321, verify texting BOOKBOT enters a campaign conversation that creates a signup for 2299, sends the `startExternalPost` template, and then subsequently replies with the `startExternalPostAutoReply` template.

#### Any background context you want to provide?

To support broadcasts, we'll want to add an additional `startExternalPost` option to the Broadcast `template` select field per https://github.com/DoSomething/gambit-conversations/issues/304

#### Relevant tickets
Fixes #1034 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
