### PR TITLE
Caption + Why Participated campaignActivity helpers [pr]

### DIFF
--- a/lib/helpers/campaignActivity.js
+++ b/lib/helpers/campaignActivity.js
@@ -59,10 +59,10 @@ module.exports = {
     logger.debug('getCreatePhotoPostPayloadFromReq', data);
     return data;
   },
-  getCreateTextPostPayloadFromReq: function getCreatePhotoPostPayloadFromReq(req) {
+  getCreateTextPostPayloadFromReq: function getCreateTextPostPayloadFromReq(req) {
     const data = this.getDefaultCreatePayloadFromReq(req);
     data.type = 'text';
-    data.text = req.incoming_message;
+    data.text = this.getReportbackTextFromReq(req);
     logger.debug('getCreateTextPostPayloadFromReq', data);
     return data;
   },
@@ -78,16 +78,31 @@ module.exports = {
         return res.body;
       });
   },
+  /**
+   * @param {Object} req
+   * @return {String}
+   */
   getReportbackTextFromReq: function getReportbackTextFromReq(req) {
+    // We trim the user message text for edge-case when it's too long, Twilio splits out the message
+    // into two different requests to our inbound URL.
+    // TODO: Verify this is still needed and not just in place for legacy reasons.
     const reportbackText = util.trimText(requestHelper.messageText(req));
     logger.verbose('getReportbackTextFromReq', { reportbackText });
     return reportbackText;
   },
+  /**
+   * @param {Object} req
+   * @return {Promise}
+   */
   saveDraftCaptionFromReq: function saveDraftCaptionFromReq(req) {
     logger.verbose('saveDraftCaptionFromReq');
     req.draftSubmission.caption = this.getReportbackTextFromReq(req);
     return req.draftSubmission.save();
   },
+  /**
+   * @param {Object} req
+   * @return {Promise}
+   */
   saveDraftWhyParticipatedFromReq: function saveDraftWhyParticipatedFromReq(req) {
     logger.verbose('saveDraftWhyParticipatedFromReq');
     req.draftSubmission.why_participated = this.getReportbackTextFromReq(req);

--- a/lib/helpers/campaignActivity.js
+++ b/lib/helpers/campaignActivity.js
@@ -2,8 +2,9 @@
 
 const superagent = require('superagent');
 const logger = require('winston');
+const requestHelper = require('./request');
 const rogue = require('../rogue');
-
+const util = require('./reportback');
 const rogueClientConfig = require('../../config/lib/rogue/rogue-client');
 
 module.exports = {
@@ -76,5 +77,16 @@ module.exports = {
         }
         return res.body;
       });
+  },
+  getReportbackTextFromReq: function getReportbackTextFromReq(req) {
+    return util.trimText(requestHelper.messageText(req));
+  },
+  saveDraftCaptionFromReq: function saveDraftCaptionFromReq(req) {
+    req.signup.draft_reportback_submission.caption = this.getReportbackTextFromReq(req);
+    return req.signup.save();
+  },
+  saveDraftWhyParticipatedFromReq: function saveDraftWhyParticipatedFromReq(req) {
+    req.signup.draft_reportback_submission.why_participated = this.getReportbackTextFromReq(req);
+    return req.signup.save();
   },
 };

--- a/lib/helpers/campaignActivity.js
+++ b/lib/helpers/campaignActivity.js
@@ -79,14 +79,18 @@ module.exports = {
       });
   },
   getReportbackTextFromReq: function getReportbackTextFromReq(req) {
-    return util.trimText(requestHelper.messageText(req));
+    const reportbackText = util.trimText(requestHelper.messageText(req));
+    logger.verbose('getReportbackTextFromReq', { reportbackText });
+    return reportbackText;
   },
   saveDraftCaptionFromReq: function saveDraftCaptionFromReq(req) {
-    req.signup.draft_reportback_submission.caption = this.getReportbackTextFromReq(req);
-    return req.signup.save();
+    logger.verbose('saveDraftCaptionFromReq');
+    req.draftSubmission.caption = this.getReportbackTextFromReq(req);
+    return req.draftSubmission.save();
   },
   saveDraftWhyParticipatedFromReq: function saveDraftWhyParticipatedFromReq(req) {
-    req.signup.draft_reportback_submission.why_participated = this.getReportbackTextFromReq(req);
-    return req.signup.save();
+    logger.verbose('saveDraftWhyParticipatedFromReq');
+    req.draftSubmission.why_participated = this.getReportbackTextFromReq(req);
+    return req.draftSubmission.save();
   },
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -9,6 +9,10 @@ function messageText(req) {
   return req.incoming_message;
 }
 
+function hasDraftWithCaption(req) {
+  return req.signup.draft_reportback_submission.caption;
+}
+
 function hasDraftSubmission(req) {
   return req.signup.draft_reportback_submission;
 }
@@ -39,9 +43,11 @@ function isValidReportbackText(req) {
 }
 
 module.exports = {
+  hasDraftWithCaption,
   hasDraftSubmission,
   hasSubmittedPhotoPost,
   isExternalPost,
   isTextPost,
   isValidReportbackText,
+  messageText,
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const logger = require('winston');
 const util = require('./reportback');
 
 /**
@@ -10,15 +11,17 @@ function messageText(req) {
 }
 
 function hasDraftWithCaption(req) {
-  return req.signup.draft_reportback_submission.caption;
+  return req.draftSubmission.caption;
 }
 
 function hasDraftSubmission(req) {
-  return req.signup.draft_reportback_submission;
+  return req.draftSubmission;
 }
 
 function hasSubmittedPhotoPost(req) {
-  return req.signup.total_quantity_submitted;
+  const result = req.signup.total_quantity_submitted;
+  logger.verbose('hasSubmittedPhotoPost', { result });
+  return result;
 }
 
 /**
@@ -42,6 +45,14 @@ function isValidReportbackText(req) {
   return util.isValidText(messageText(req));
 }
 
+function setDraftSubmission(req, draftSubmission) {
+  req.draftSubmission = draftSubmission;
+}
+
+function setSignup(req, signup) {
+  req.signup = signup;
+}
+
 module.exports = {
   hasDraftWithCaption,
   hasDraftSubmission,
@@ -50,4 +61,6 @@ module.exports = {
   isTextPost,
   isValidReportbackText,
   messageText,
+  setDraftSubmission,
+  setSignup,
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -10,18 +10,27 @@ function messageText(req) {
   return req.incoming_message;
 }
 
+/**
+ * @return {Boolean}
+ */
 function hasDraftWithCaption(req) {
-  return req.draftSubmission.caption;
+  return !!req.draftSubmission.caption;
 }
 
+/**
+ * @return {Boolean}
+ */
 function hasDraftSubmission(req) {
-  return req.draftSubmission;
+  return !!req.draftSubmission;
 }
 
+/**
+ * @return {Boolean}
+ */
 function hasSubmittedPhotoPost(req) {
   const result = req.signup.total_quantity_submitted;
   logger.verbose('hasSubmittedPhotoPost', { result });
-  return result;
+  return !!result;
 }
 
 /**

--- a/lib/middleware/campaignActivity/photo/draft-caption.js
+++ b/lib/middleware/campaignActivity/photo/draft-caption.js
@@ -1,12 +1,11 @@
 'use strict';
 
 const helpers = require('../../../helpers');
-const reportbackHelper = require('../../../helpers/reportback');
 const replies = require('../../../replies');
 
-module.exports = function draftSubmissionCaption() {
+module.exports = function draftCaption() {
   return (req, res, next) => {
-    if (req.draftSubmission.caption) {
+    if (helpers.request.hasDraftWithCaption(req)) {
       return next();
     }
 
@@ -14,22 +13,17 @@ module.exports = function draftSubmissionCaption() {
       return replies.askCaption(req, res);
     }
 
-    const input = req.incoming_message;
-
-    if (!reportbackHelper.isValidText(input)) {
+    if (!helpers.request.isValidReportbackText(req)) {
       return replies.invalidCaption(req, res);
     }
 
-    req.draftSubmission.caption = reportbackHelper.trimText(input);
-
-    return req.draftSubmission.save()
+    return helpers.campaignActivity.saveDraftCaptionFromReq(req)
       .then(() => {
-        // If member hasn't submitted a reportback yet, ask for why_participated.
-        if (!req.signup.total_quantity_submitted) {
+        // Ask for why_participated if this is user's first photo post for the campaign.
+        if (!helpers.request.hasSubmittedPhotoPost(req)) {
           return replies.askWhyParticipated(req, res);
         }
 
-        // Otherwise exit to call our completed middleware
         return next();
       })
       .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/campaignActivity/photo/draft-why-participated.js
+++ b/lib/middleware/campaignActivity/photo/draft-why-participated.js
@@ -1,13 +1,12 @@
 'use strict';
 
 const helpers = require('../../../helpers');
-const reportbackHelper = require('../../../helpers/reportback');
 const replies = require('../../../replies');
 
-module.exports = function draftSubmissionWhyParticipated() {
+module.exports = function draftWhyParticipated() {
   return (req, res, next) => {
-    // Only ask for Why Participated if this is User's first submission for their Campaign Signup.
-    if (req.signup.total_quantity_submitted) {
+    // Only collected during user's first photo post for a campaign.
+    if (helpers.request.hasSubmittedPhotoPost(req)) {
       return next();
     }
 
@@ -15,15 +14,11 @@ module.exports = function draftSubmissionWhyParticipated() {
       return replies.askWhyParticipated(req, res);
     }
 
-    const input = req.incoming_message;
-
-    if (!reportbackHelper.isValidText(input)) {
+    if (!helpers.request.isValidReportbackText(req)) {
       return replies.invalidWhyParticipated(req, res);
     }
 
-    req.draftSubmission.why_participated = reportbackHelper.trimText(input);
-
-    return req.draftSubmission.save()
+    return helpers.campaignActivity.saveDraftWhyParticipatedFromReq(req)
       .then(() => next())
       .catch(err => helpers.sendErrorResponse(res, err));
   };

--- a/lib/middleware/campaignActivity/signup-create.js
+++ b/lib/middleware/campaignActivity/signup-create.js
@@ -12,7 +12,7 @@ module.exports = function createNewSignup() {
     return Signup.createSignupForReq(req)
       .then((signup) => {
         helpers.handleTimeout(req, res);
-        req.signup = signup;
+        helpers.request.setSignup(req, signup);
 
         return next();
       })

--- a/lib/middleware/campaignActivity/signup-get.js
+++ b/lib/middleware/campaignActivity/signup-get.js
@@ -12,8 +12,8 @@ module.exports = function getSignup() {
         helpers.handleTimeout(req, res);
 
         if (signup) {
-          req.signup = signup;
-          req.draftSubmission = req.signup.draft_reportback_submission;
+          helpers.request.setSignup(req, signup);
+          helpers.request.setDraftSubmission(req, signup.draft_reportback_submission);
         }
 
         return next();

--- a/test/lib/lib-helpers/campaignActivity.test.js
+++ b/test/lib/lib-helpers/campaignActivity.test.js
@@ -9,6 +9,7 @@ const sinonChai = require('sinon-chai');
 const sinon = require('sinon');
 const httpMocks = require('node-mocks-http');
 
+const helpers = require('../../../lib/helpers');
 const rogue = require('../../../lib/rogue');
 const stubs = require('../../utils/stubs');
 const reportbackSubmissionFactory = require('../../utils/factories/reportbackSubmission');
@@ -79,6 +80,20 @@ test('getCreatePhotoPostPayloadFromReq returns an object', (t) => {
   result.quantity.should.equal(mockDraft.quantity);
   result.caption.should.equal(mockDraft.caption);
   result.why_participated.should.equal(mockDraft.why_participated);
+});
+
+// getReportbackTextFromReq
+test('getReportbackTextFromReq returns a string', (t) => {
+  const mockResult = 'Winter is coming';
+  sandbox.stub(helpers.request, 'messageText')
+    .returns(mockMessageText);
+  sandbox.stub(helpers.reportback, 'trimText')
+    .returns(mockResult);
+
+  const result = activityHelper.getReportbackTextFromReq(t.context.req);
+  result.should.equal(mockResult);
+  helpers.request.messageText.should.have.been.calledWith(t.context.req);
+  helpers.reportback.trimText.should.have.been.calledWith(mockMessageText);
 });
 
 // getCreateTextPostPayloadFromReq

--- a/test/lib/lib-helpers/campaignActivity.test.js
+++ b/test/lib/lib-helpers/campaignActivity.test.js
@@ -100,9 +100,12 @@ test('getReportbackTextFromReq returns a string', (t) => {
 test('getCreateTextPostPayloadFromReq returns an object', (t) => {
   sandbox.stub(activityHelper, 'getDefaultCreatePayloadFromReq')
     .returns(mockDefaultCreatePayload);
+  sandbox.stub(activityHelper, 'getReportbackTextFromReq')
+    .returns(mockMessageText);
+
   const result = activityHelper.getCreateTextPostPayloadFromReq(t.context.req);
-  result.type.should.equal('text');
-  result.text.should.equal(t.context.req.incoming_message);
+  activityHelper.getReportbackTextFromReq.should.have.been.called;
+  result.text.should.equal(mockMessageText);
 });
 
 // saveDraftCaptionFromReq

--- a/test/lib/lib-helpers/request.test.js
+++ b/test/lib/lib-helpers/request.test.js
@@ -61,10 +61,18 @@ test('isValidReportbackText returns false is incoming_message is not valid text'
 
 // hasDraftSubmission
 test('hasDraftSubmission returns whether the signup total quantity submitted exists', (t) => {
-  t.context.req.signup = stubs.getSignupWithDraft();
+  t.context.req.draftSubmission = stubs.getDraft();
   t.truthy(requestHelper.hasDraftSubmission(t.context.req));
-  t.context.req.signup.draft_reportback_submission = null;
+  t.context.req.draftSubmission = null;
   t.falsy(requestHelper.hasDraftSubmission(t.context.req));
+});
+
+// hasDraftSubmission
+test('hasDraftWithCaption returns whether the draft has a caption set', (t) => {
+  t.context.req.draftSubmission = stubs.getDraft();
+  t.truthy(requestHelper.hasDraftWithCaption(t.context.req));
+  t.context.req.draftSubmission = {};
+  t.falsy(requestHelper.hasDraftWithCaption(t.context.req));
 });
 
 // hasSubmittedPhotoPost
@@ -73,4 +81,18 @@ test('hasSubmittedPhotoPost returns whether the signup total quantity submitted 
   t.truthy(requestHelper.hasSubmittedPhotoPost(t.context.req));
   t.context.req.signup = stubs.getSignupWithDraft();
   t.falsy(requestHelper.hasSubmittedPhotoPost(t.context.req));
+});
+
+// setDraftSubmission
+test('setDraftSubmission should inject a draftSubmission property to req', (t) => {
+  const draftSubmission = stubs.getDraft();
+  requestHelper.setDraftSubmission(t.context.req, draftSubmission);
+  t.context.req.draftSubmission.should.deep.equal(draftSubmission);
+});
+
+// setSignup
+test('setSignup should inject a signup property to req', (t) => {
+  const signup = stubs.getSignupWithTotalQuantitySubmitted();
+  requestHelper.setSignup(t.context.req, signup);
+  t.context.req.signup.should.deep.equal(signup);
 });

--- a/test/lib/lib-helpers/request.test.js
+++ b/test/lib/lib-helpers/request.test.js
@@ -67,7 +67,7 @@ test('hasDraftSubmission returns whether the signup total quantity submitted exi
   t.falsy(requestHelper.hasDraftSubmission(t.context.req));
 });
 
-// hasDraftSubmission
+// hasDraftWithCaption
 test('hasDraftWithCaption returns whether the draft has a caption set', (t) => {
   t.context.req.draftSubmission = stubs.getDraft();
   t.truthy(requestHelper.hasDraftWithCaption(t.context.req));

--- a/test/utils/factories/reportbackSubmission.js
+++ b/test/utils/factories/reportbackSubmission.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const Chance = require('chance');
+const ObjectID = require('mongoose').Types.ObjectId;
+const ReportbackSubmission = require('../../../app/models/ReportbackSubmission');
+
+const chance = new Chance();
+
+module.exports.getValidReportbackSubmission = function getValidReportbackSubmission() {
+  return new ReportbackSubmission({
+    _id: new ObjectID(),
+    quantity: chance.natural({ min: 2, max: 500 }),
+    photo: 'http://placekitten.com/200/300',
+    caption: chance.sentence({ words: 5 }),
+    why_participated: chance.sentence(),
+  });
+};


### PR DESCRIPTION
#### What's this PR do?
Adds new campaignActivity helpers for saving a draft caption and whyParticipated, slowly chipping away at adding unit test coverage for `lib/middleware/campaignActivity/photo`, using the `helpers.request.isValidReportbackText` introduced in #1029.

* Adds request helpers `setSignup` and `setDraftSubmission`, following conventions used in the [Conversations request helper](https://github.com/DoSomething/gambit-conversations/blob/2.5.6/lib/helpers/request.js#L19).

* Adds campaignActivity helper function `getReportbackTextFromReq`, with comment to document why we trim reportback text, refs [Slack conversation in #gambit 
](https://dosomething.slack.com/archives/C1V0M6RPE/p1523558690000067)

#### How should this be reviewed?
Verify the first and second photo post for a campaign work as expected (1st post should collect whyParticipated, 2nd post should not)

#### Any background context you want to provide?

Coming soon 🎥 🍿 
* Tests for the caption and whyParticipated middleware.
* Similar helpers and tests for quantity and photo middleware.

#### Checklist
- [x] Tested on staging.
