### PR TITLE
Fixes reply when keyword sent for completed photo post

### DIFF
--- a/lib/middleware/campaignActivity/photo/draft-not-found.js
+++ b/lib/middleware/campaignActivity/photo/draft-not-found.js
@@ -18,7 +18,7 @@ module.exports = function draftSubmissionNotFound() {
 
       const hasSubmittedPost = helpers.request.hasSubmittedPhotoPost(req);
 
-      if (req.askNextQuestion) {
+      if (helpers.request.shouldAskNextQuestion(req)) {
         if (hasSubmittedPost) {
           return replies.completedPhotoPost(req, res);
         }

--- a/test/lib/middleware/campaignActivity/photo/draft-not-found.test.js
+++ b/test/lib/middleware/campaignActivity/photo/draft-not-found.test.js
@@ -132,7 +132,7 @@ test('draftNotFound sends startPhotoPostAutoReply when not hasSubmittedPhotoPost
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('draftNotFound sends startPhotoPost when not hasSubmittedPhotoPost and askNextQuestion', async (t) => {
+test('draftNotFound sends startPhotoPost when not hasSubmittedPhotoPost and shouldAskNextQuestion', async (t) => {
   const next = sinon.stub();
   const middleware = draftNotFound();
   sandbox.stub(helpers.request, 'hasDraftSubmission')
@@ -141,7 +141,8 @@ test('draftNotFound sends startPhotoPost when not hasSubmittedPhotoPost and askN
     .returns(false);
   sandbox.stub(helpers.request, 'hasSubmittedPhotoPost')
     .returns(false);
-  t.context.req.askNextQuestion = true;
+  sandbox.stub(helpers.request, 'shouldAskNextQuestion')
+    .returns(true);
 
   await middleware(t.context.req, t.context.res, next);
   next.should.not.have.been.called;
@@ -152,7 +153,7 @@ test('draftNotFound sends startPhotoPost when not hasSubmittedPhotoPost and askN
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('draftNotFound sends completedPhotoPost when hasSubmittedPhotoPost and askNextQuestion', async (t) => {
+test('draftNotFound sends completedPhotoPost when hasSubmittedPhotoPost and shouldAskNextQuestion', async (t) => {
   const next = sinon.stub();
   const middleware = draftNotFound();
   sandbox.stub(helpers.request, 'hasDraftSubmission')
@@ -161,7 +162,8 @@ test('draftNotFound sends completedPhotoPost when hasSubmittedPhotoPost and askN
     .returns(false);
   sandbox.stub(helpers.request, 'hasSubmittedPhotoPost')
     .returns(true);
-  t.context.req.askNextQuestion = true;
+  sandbox.stub(helpers.request, 'shouldAskNextQuestion')
+    .returns(true);
 
   await middleware(t.context.req, t.context.res, next);
   next.should.not.have.been.called;
@@ -172,7 +174,7 @@ test('draftNotFound sends completedPhotoPost when hasSubmittedPhotoPost and askN
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('draftNotFound sends completedPhotoPostAutoReply when hasSubmittedPhotoPost and not askNextQuestion', async (t) => {
+test('draftNotFound sends completedPhotoPostAutoReply when hasSubmittedPhotoPost and not shouldAskNextQuestion', async (t) => {
   const next = sinon.stub();
   const middleware = draftNotFound();
   sandbox.stub(helpers.request, 'hasDraftSubmission')
@@ -181,6 +183,8 @@ test('draftNotFound sends completedPhotoPostAutoReply when hasSubmittedPhotoPost
     .returns(false);
   sandbox.stub(helpers.request, 'hasSubmittedPhotoPost')
     .returns(true);
+  sandbox.stub(helpers.request, 'shouldAskNextQuestion')
+    .returns(false);
 
   await middleware(t.context.req, t.context.res, next);
   next.should.not.have.been.called;


### PR DESCRIPTION
#### What's this PR do?
Replaces check for deprecated `req.askNextQuestion` check with a call to `helpers.request.shouldAskNextQuestion` in the Photo Post Draft Not Found middleware.

#### How should this be reviewed?
Complete a photo post, and text in the keyword (e.g. MIRROR). Verify the `completedPhotoPost` template is sent.

<img width="691" alt="screen shot 2018-05-31 at 9 56 18 am" src="https://user-images.githubusercontent.com/1236811/40796461-ffbaeef8-64b9-11e8-88ec-f0909532fc69.png">

#### Relevant tickets
Fixes #1047

#### Checklist
- [x] Tested on staging.
