### PR TITLE
Contentful cleanup

### DIFF
--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -4,7 +4,6 @@
  * Imports.
  */
 const contentful = require('contentful');
-const Promise = require('bluebird');
 const logger = require('winston');
 const underscore = require('underscore');
 
@@ -110,16 +109,18 @@ function fetchByContentfulId(contentfulId) {
  * @return {Promise}
  */
 function fetchByContentTypes(contentTypes) {
+  logger.debug('fetchByContentTypes', { contentTypes });
   const query = module.exports.getQueryBuilder()
     .contentTypes(contentTypes)
     .build();
-  logger.debug('fetchByContentTypes', { contentTypes });
   return module.exports.getClient().getEntries(query)
     .then((res) => {
       logger.debug('fetchByContentTypes count', res.total);
       return res.items;
     })
-    .catch(error => Promise.reject(module.exports.contentfulError(error)));
+    .catch((error) => {
+      throw module.exports.contentfulError(error);
+    });
 }
 
 /**

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -250,25 +250,3 @@ module.exports.formatKeywordFromResponse = function formatKeywordFromResponse(co
     campaign: entry.campaign,
   };
 };
-
-/**
- * Returns the Contentful entry saved to the postConfig reference field on given botConfig.
- * @param {object} botConfig
- * @param {object} - Contentful entry set for the botConfig.postConfig reference field.
- */
-module.exports.getPostConfigFromBotConfig = function (botConfig) {
-  if (botConfig && botConfig.fields) {
-    return botConfig.fields.postConfig;
-  }
-  return null;
-};
-
-/**
- * Returns the content type name of the postConfig entry saved for given botConfig.
- * @param {Object} botConfig
- * @return {String}
- */
-module.exports.parsePostConfigContentTypeFromBotConfig = function (botConfig) {
-  const postConfig = module.exports.getPostConfigFromBotConfig(botConfig);
-  return postConfig ? module.exports.getContentTypeFromContentfulEntry(postConfig) : null;
-};

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -6,6 +6,7 @@
 const contentful = require('contentful');
 const Promise = require('bluebird');
 const logger = require('winston');
+const underscore = require('underscore');
 
 const NotFoundError = require('../app/exceptions/NotFoundError');
 const config = require('../config/lib/contentful');
@@ -82,13 +83,21 @@ function contentfulError(error) {
  */
 function fetchByContentfulId(contentfulId) {
   logger.debug('contentful.fetchByContentfulId', { contentfulId });
-
-  return module.exports.getClient().getEntry(contentfulId)
-    .then(contentfulEntry => contentfulEntry)
-    .catch((error) => {
-      if (error.sys && error.sys.id === 'NotFound') {
+  const query = module.exports.getQueryBuilder()
+    .contentfulId(contentfulId)
+    .build();
+  // We call getEntries instead of getEntry to get loaded reference entries back from Contentful.
+  // @see https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/links
+  // @see https://stackoverflow.com/a/44425987/1470725
+  return module.exports.getClient().getEntries(query)
+    .then((res) => {
+      const firstEntry = underscore.first(res.items);
+      if (!firstEntry) {
         throw new NotFoundError(`${ERROR_PREFIX} Entry not found for ${contentfulId}`);
       }
+      return firstEntry;
+    })
+    .catch((error) => {
       throw module.exports.contentfulError(error);
     });
 }

--- a/lib/helpers/defaultTopicTrigger.js
+++ b/lib/helpers/defaultTopicTrigger.js
@@ -39,8 +39,13 @@ function getAll() {
  */
 function getByTopicId(topicId) {
   return module.exports.getAll()
-    .then(defaultTopicTriggers => defaultTopicTriggers
-      .filter(defaultTopicTrigger => defaultTopicTrigger.topicId === topicId));
+    .then(defaultTopicTriggers => defaultTopicTriggers.filter((defaultTopicTrigger) => {
+      // Checks for any draft entries that may be missing required field values.
+      if (!defaultTopicTrigger) {
+        return false;
+      }
+      return defaultTopicTrigger.topicId === topicId;
+    }));
 }
 
 /**

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -21,7 +21,7 @@ function getRandomWord() {
 function getTopic() {
   return {
     id: module.exports.getContentfulId(),
-    type: module.exports.getPostConfigContentType(),
+    type: module.exports.getTopicContentType(),
     postType: module.exports.getPostType(),
   };
 }
@@ -87,7 +87,7 @@ module.exports = {
   getPost: function getPost() {
     return { id: this.getPostId() };
   },
-  getPostConfigContentType: function getPostConfigContentType() {
+  getTopicContentType: function getTopicContentType() {
     return 'textPostConfig';
   },
   getPostId: function getPostId() {


### PR DESCRIPTION
#### What's this PR do?
* Restores using the Contentful client `getEntries` to fetch a single entry, and documents why to use instead of `getEntry` - (refs #1048).  The `campaign` reference entry wasn't available in a `GET /topics/:id` request when fetching the topic entry.

* Removes functions that reference the `campaign.postConfig` reference field -- this is no longer used and should be deleted from the `campaign` content type. Campaigns are linked to topics via the topic entry's `campaign` reference field.

#### How should this be reviewed?
Verify that `GET /campaigns/:id` and `GET topics/:id` return expected data.

#### Checklist
- [x] Tested on staging.
