### PR TITLE
Return templates when topic doesn't have a campaign

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -27,24 +27,28 @@ module.exports.addBlinkSuppressHeaders = function addBlinkSuppressHeaders(res) {
 /**
  * Replaces mustache tags used in raw Campaign Template strings with given variables.
  * @param {string} input
- * @param {object} phoenixCampaign
+ * @param {object} campaign
  * @return string.
  */
-module.exports.replacePhoenixCampaignVars = function (input, phoenixCampaign) {
+module.exports.replacePhoenixCampaignVars = function (input, campaign) {
   if (!input) {
     return '';
   }
 
   let scope = input;
-  scope = scope.replace(/{{title}}/gi, phoenixCampaign.title);
-  scope = scope.replace(/{{tagline}}/i, phoenixCampaign.tagline);
+  if (campaign) {
+    scope = scope.replace(/{{title}}/gi, campaign.title);
+    scope = scope.replace(/{{tagline}}/i, campaign.tagline);
+    if (campaign.keywords) {
+      scope = scope.replace(/{{keyword}}/gi, campaign.keywords[0]);
+    }
+  }
+
   // TODO: Get tags to search for from helpers.command instead of hardcoding here.
   // This whole function should be refactored and moved into the helpers.campaign.
   scope = scope.replace(/{{cmd_reportback}}/i, helpers.command.getStartCommand());
   scope = scope.replace(/{{cmd_member_support}}/i, helpers.command.getRequestSupportCommand());
-  if (phoenixCampaign.keywords) {
-    scope = scope.replace(/{{keyword}}/gi, phoenixCampaign.keywords[0]);
-  }
+
   return scope;
 };
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -45,7 +45,7 @@ module.exports.replacePhoenixCampaignVars = function (input, campaign) {
   }
 
   // TODO: Get tags to search for from helpers.command instead of hardcoding here.
-  // This whole function should be refactored and moved into the helpers.campaign.
+  // This whole function should be refactored with Mustache and moved into the topic helper.
   scope = scope.replace(/{{cmd_reportback}}/i, helpers.command.getStartCommand());
   scope = scope.replace(/{{cmd_member_support}}/i, helpers.command.getRequestSupportCommand());
 

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -172,30 +172,40 @@ function parseTopicFromContentfulEntry(contentfulEntry) {
 
   const campaignConfigEntry = contentfulEntry.fields.campaign;
   const campaignId = contentful.getCampaignIdFromContentfulEntry(campaignConfigEntry);
-  if (!campaignId) {
-    data.campaign = null;
-    return Promise.resolve(data);
-  }
 
   return helpers.campaign.fetchById(campaignId)
     .then((campaign) => {
       data.campaign = campaign;
-      const topicTemplates = module.exports
-        .parseTemplatesFromContentfulEntryAndCampaign(contentfulEntry, campaign);
-      const campaignConfigTemplates = module.exports
-        .parseTemplatesFromContentfulEntryAndCampaign(campaignConfigEntry, campaign);
-      data.templates = Object.assign(topicTemplates, campaignConfigTemplates);
+      data.templates = module.exports
+        .parseTopicTemplatesFromContentfulEntryAndCampaign(contentfulEntry, campaign);
       return data;
     })
     .catch((error) => {
       if (error.status === 404) {
         // The campaignId is set via freeform text field on the campaign content type.
-        // If a topic's campaign is misconfigured, we still want to return the topic data, no throw.
-        data.campaign = { id: campaignId, status: '404' };
+        // If a topic's campaign is misconfigured, we still want to return topic data.
+        // Hardcode the status as closed to auto reply with the campaignClosed template.
+        data.campaign = { id: campaignId, status: 'closed' };
+        data.templates = module.exports
+          .parseTopicTemplatesFromContentfulEntryAndCampaign(contentfulEntry, null);
         return data;
       }
       throw error;
     });
+}
+
+/**
+ * @param {Object} contentfulEntry
+ * @param {Object} campaign
+ * @return {Object}
+ */
+function parseTopicTemplatesFromContentfulEntryAndCampaign(contentfulEntry, campaign) {
+  const topicTemplates = module.exports
+    .parseTemplatesFromContentfulEntryAndCampaign(contentfulEntry, campaign);
+  const campaignConfigEntry = contentfulEntry.fields.campaign;
+  const campaignConfigTemplates = module.exports
+    .parseTemplatesFromContentfulEntryAndCampaign(campaignConfigEntry, campaign);
+  return Object.assign(topicTemplates, campaignConfigTemplates);
 }
 
 module.exports = {
@@ -212,4 +222,5 @@ module.exports = {
   parseTemplateFromContentfulEntryAndTemplateName,
   parseTemplatesFromContentfulEntryAndCampaign,
   parseTopicFromContentfulEntry,
+  parseTopicTemplatesFromContentfulEntryAndCampaign,
 };

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -185,11 +185,16 @@ function parseTopicFromContentfulEntry(contentfulEntry) {
       const campaignConfigTemplates = module.exports
         .parseTemplatesFromContentfulEntryAndCampaign(campaignConfigEntry, campaign);
       data.templates = Object.assign(topicTemplates, campaignConfigTemplates);
-      return helpers.defaultTopicTrigger.getByTopicId(topicId);
-    })
-    .then((defaultTopicTriggers) => {
-      data.defaultTopicTriggers = defaultTopicTriggers.map(triggerObject => triggerObject.trigger);
       return data;
+    })
+    .catch((error) => {
+      if (error.status === 404) {
+        // The campaignId is set via freeform text field on the campaign content type.
+        // If a topic's campaign is misconfigured, we still want to return the topic data, no throw.
+        data.campaign = { id: campaignId, status: '404' };
+        return data;
+      }
+      throw error;
     });
 }
 

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -169,11 +169,14 @@ function parseTopicFromContentfulEntry(contentfulEntry) {
     type: contentType,
     postType: module.exports.getPostTypeFromContentType(contentType),
   };
-
   const campaignConfigEntry = contentfulEntry.fields.campaign;
-  const campaignId = contentful.getCampaignIdFromContentfulEntry(campaignConfigEntry);
-
-  return helpers.campaign.fetchById(campaignId)
+  let promise = Promise.resolve(null);
+  let campaignId;
+  if (campaignConfigEntry) {
+    campaignId = contentful.getCampaignIdFromContentfulEntry(campaignConfigEntry);
+    promise = helpers.campaign.fetchById(campaignId);
+  }
+  return promise
     .then((campaign) => {
       data.campaign = campaign;
       data.templates = module.exports
@@ -203,6 +206,9 @@ function parseTopicTemplatesFromContentfulEntryAndCampaign(contentfulEntry, camp
   const topicTemplates = module.exports
     .parseTemplatesFromContentfulEntryAndCampaign(contentfulEntry, campaign);
   const campaignConfigEntry = contentfulEntry.fields.campaign;
+  if (!campaignConfigEntry) {
+    return topicTemplates;
+  }
   const campaignConfigTemplates = module.exports
     .parseTemplatesFromContentfulEntryAndCampaign(campaignConfigEntry, campaign);
   return Object.assign(topicTemplates, campaignConfigTemplates);


### PR DESCRIPTION
#### What's this PR do?
Modifies parsing the response of a `GET /topics/id` request to return a `templates` property, even if the topic doesn't have a `campaign` reference set.

* Adds check for when the `campaignId` field on a `campaign` entry doesn't exist in Phoenix, which is currently happening on `GET /v1/topics/5fpmfk4ETe4ss6qogEcGSi`

#### How should this be reviewed?
* 👀
* Set env vars to Contentful Preview API and verify `GET v1/topics` and `GET /v1/topics/5fpmfk4ETe4ss6qogEcGSi` return success responses

#### Any background context you want to provide?
Preview API is fun because Contentful creates an ID as soon as an editor opens the form to create a new entry. I ran into this error when working on https://github.com/DoSomething/gambit-conversations/pull/328 per continuing https://github.com/DoSomething/gambit-conversations/pull/336


#### Checklist
- [x] Tested on staging.
