### PR TITLE
Broadcasts endpoint - part 1

### DIFF
--- a/app/routes/broadcasts/index.js
+++ b/app/routes/broadcasts/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const express = require('express');
+
+const getBroadcastsMiddleware = require('../../../lib/middleware/broadcasts/index/broadcasts-get');
+
+const router = express.Router();
+
+router.use(getBroadcastsMiddleware());
+
+module.exports = router;

--- a/app/routes/broadcasts/single.js
+++ b/app/routes/broadcasts/single.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const express = require('express');
+
+const getBroadcastMiddleware = require('../../../lib/middleware/broadcasts/single/broadcast-get');
+
+const router = express.Router({ mergeParams: true });
+
+router.use(getBroadcastMiddleware());
+
+module.exports = router;

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 // Routes
+const broadcastsIndexRoute = require('./broadcasts/index');
+const broadcastsSingleRoute = require('./broadcasts/single');
 const campaignsIndexRoute = require('./campaigns/index');
 const campaignsSingleRoute = require('./campaigns/single');
 const campaignActivityRoute = require('./campaignActivity');
@@ -30,6 +32,15 @@ module.exports = function init(app) {
   regGlobalMiddleware(app);
   app.get('/', statusRoute);
   app.use('/v1/status', statusRoute);
+
+  // Provides data for a chatbot broadcast.
+  app.use('/v1/broadcasts/:broadcastId', broadcastsSingleRoute);
+
+  // Provides list of chatbot broadcasts.
+  app.use('/v1/broadcasts', broadcastsIndexRoute);
+
+  // Provides list of campaigns with active topics.
+  app.use('/v1/campaigns', campaignsIndexRoute);
 
   // Provides list of defaultTopicTriggers
   app.use('/v1/defaultTopicTriggers', defaultTopicTriggersRoute);

--- a/config/lib/helpers/broadcast.js
+++ b/config/lib/helpers/broadcast.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  broadcastContentTypes: [
+    'broadcast',
+  ],
+};

--- a/config/lib/helpers/cache.js
+++ b/config/lib/helpers/cache.js
@@ -1,6 +1,10 @@
 'use strict';
 
 module.exports = {
+  broadcasts: {
+    name: 'broadcasts',
+    ttl: parseInt(process.env.GAMBIT_BROADCASTS_CACHE_TTL, 10) || 3600,
+  },
   campaigns: {
     name: 'campaigns',
     ttl: parseInt(process.env.GAMBIT_CAMPAIGNS_CACHE_TTL, 10) || 3600,

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2,6 +2,9 @@
 
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
+`GET /v1/broadcasts` | Retrieve broadcasts
+`GET /v1/broadcasts/:id` | Retrieve a single broadcast
+`GET /v1/campaigns/:id` | [Retrieve a campaign](endpoints/campaigns.md#retrieve-a-campaigns)
 `GET /v1/campaigns` | [Retrieve all campaigns with active topics](endpoints/campaigns.md#retrieve-all-campaigns)
 `GET /v1/campaigns/:id` | [Retrieve a campaign](endpoints/campaigns.md#retrieve-a-campaigns)
 `POST /v1/campaignActivity` | [Parses an inbound message from user as campaign activity](endpoints/campaignActivity.md)

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -112,6 +112,7 @@ function fetchByContentTypes(contentTypes) {
   logger.debug('fetchByContentTypes', { contentTypes });
   const query = module.exports.getQueryBuilder()
     .contentTypes(contentTypes)
+    .orderByDescCreatedAt()
     .build();
   return module.exports.getClient().getEntries(query)
     .then((res) => {

--- a/lib/contentfulQueryBuilder.js
+++ b/lib/contentfulQueryBuilder.js
@@ -36,6 +36,10 @@ class QueryBuilder {
     });
     return this;
   }
+  orderByDescCreatedAt() {
+    this.query.order = '-sys.createdAt';
+    return this;
+  }
   build() {
     return this.query;
   }

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -61,11 +61,15 @@ function parseBroadcastFromContentfulEntry(contentfulEntry) {
   // don't need to remember which fields to include/exclude in order to create a specific type.
   const hardcodedTopic = contentfulEntry.fields.topic;
   if (hardcodedTopic) {
+    // Another note: the new broadcast content types will reference a topic Contentful entry, not
+    // a campaign Contentful entry -- eventually topic will be returned as a nested object.
+    data.campaignId = null;
     data.topic = hardcodedTopic;
     data.message.template = 'rivescript';
   } else {
     const campaignConfigEntry = contentfulEntry.fields.campaign;
     data.campaignId = contentful.getCampaignIdFromContentfulEntry(campaignConfigEntry);
+    data.topic = null;
     data.message.template = contentfulEntry.fields.template || 'askSignup';
   }
   return data;

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -46,9 +46,25 @@ function getById(broadcastId) {
  * @return {Promise}
  */
 function parseBroadcastFromContentfulEntry(contentfulEntry) {
-  return {
+  const data = {
     id: contentful.getContentfulIdFromContentfulEntry(contentfulEntry),
+    name: contentful.getNameTextFromContentfulEntry(contentfulEntry),
+    createdAt: contentfulEntry.sys.createdAt,
+    updatedAt: contentfulEntry.sys.updatedAt,
+    message: {
+      text: contentfulEntry.fields.message,
+    },
   };
+  const hardcodedTopic = contentfulEntry.fields.topic;
+  if (hardcodedTopic) {
+    data.topic = hardcodedTopic;
+    data.message.template = 'rivescript';
+  } else {
+    const campaignConfigEntry = contentfulEntry.fields.campaign;
+    data.campaignId = contentful.getCampaignIdFromContentfulEntry(campaignConfigEntry);
+    data.message.template = contentfulEntry.fields.template || 'askSignup';
+  }
+  return data;
 }
 
 module.exports = {

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -57,6 +57,8 @@ function parseBroadcastFromContentfulEntry(contentfulEntry) {
       attachments: [],
     },
   };
+  // Note: We plan to split broadcast content type into two separate content types, so editors
+  // don't need to remember which fields to include/exclude in order to create a specific type.
   const hardcodedTopic = contentfulEntry.fields.topic;
   if (hardcodedTopic) {
     data.topic = hardcodedTopic;

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const logger = require('winston');
+const contentful = require('../contentful');
+const helpers = require('../helpers');
+const config = require('../../config/lib/helpers/broadcast');
+
+/**
+ * @return {Promise}
+ */
+function fetchAll() {
+  // TODO: Loop through all pages of query results - currently returns 100.
+  return contentful.fetchByContentTypes(config.broadcastContentTypes)
+    .then(contentfulEntries => Promise.all(contentfulEntries.map(module.exports
+      .parseBroadcastFromContentfulEntry)));
+}
+
+/**
+ * @param {String} broadcastId
+ * @return {Promise}
+ */
+function fetchById(broadcastId) {
+  return contentful.fetchByContentfulId(broadcastId)
+    .then(contentfulEntry => module.exports.parseBroadcastFromContentfulEntry(contentfulEntry));
+}
+
+/**
+ * @param {String} topicId
+ * @return {Promise}
+ */
+function getById(broadcastId) {
+  return helpers.cache.broadcasts.get(broadcastId)
+    .then((data) => {
+      if (data) {
+        logger.debug('Broadcast cache hit', { broadcastId });
+        return data;
+      }
+      logger.debug('Broadcast cache miss', { broadcastId });
+      return module.exports.fetchById(broadcastId)
+        .then(broadcast => helpers.cache.broadcasts.set(broadcastId, broadcast));
+    });
+}
+
+/**
+ * @param {Object} contentfulEntry
+ * @return {Promise}
+ */
+function parseBroadcastFromContentfulEntry(contentfulEntry) {
+  return {
+    id: contentful.getContentfulIdFromContentfulEntry(contentfulEntry),
+  };
+}
+
+module.exports = {
+  fetchAll,
+  fetchById,
+  getById,
+  parseBroadcastFromContentfulEntry,
+};

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -53,6 +53,8 @@ function parseBroadcastFromContentfulEntry(contentfulEntry) {
     updatedAt: contentfulEntry.sys.updatedAt,
     message: {
       text: contentfulEntry.fields.message,
+      // TODO: Parse from attachments reference field.
+      attachments: [],
     },
   };
   const hardcodedTopic = contentfulEntry.fields.topic;

--- a/lib/helpers/cache.js
+++ b/lib/helpers/cache.js
@@ -6,6 +6,10 @@ const redisClient = require('../../config/redis')();
 const config = require('../../config/lib/helpers/cache');
 
 const redisEngine = new RedisEngine(redisClient);
+const broadcastsCache = new Cacheman(config.broadcasts.name, {
+  ttl: config.broadcasts.ttl,
+  engine: redisEngine,
+});
 const campaignsCache = new Cacheman(config.campaigns.name, {
   ttl: config.campaigns.ttl,
   engine: redisEngine,
@@ -24,6 +28,14 @@ function parseSetCacheResponse(res) {
 }
 
 module.exports = {
+  broadcasts: {
+    get: function get(id) {
+      return broadcastsCache.get(id);
+    },
+    set: function set(id, data) {
+      return broadcastsCache.set(id, data).then(res => parseSetCacheResponse(res));
+    },
+  },
   campaigns: {
     get: function get(id) {
       return campaignsCache.get(id);

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const broadcast = require('./broadcast');
 const cache = require('./cache');
 const campaign = require('./campaign');
 const campaignActivity = require('./campaignActivity');
@@ -10,6 +11,7 @@ const topic = require('./topic');
 const util = require('./util');
 
 module.exports = {
+  broadcast,
   cache,
   campaign,
   campaignActivity,

--- a/lib/middleware/broadcasts/index/broadcasts-get.js
+++ b/lib/middleware/broadcasts/index/broadcasts-get.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const helpers = require('../../../helpers');
+
+module.exports = function getBroadcasts() {
+  return (req, res) => helpers.topic.getAll()
+    .then((topics) => {
+      req.data = topics;
+      return res.send({ data: req.data });
+    })
+    .catch(err => helpers.sendErrorResponse(res, err));
+};

--- a/lib/middleware/broadcasts/index/broadcasts-get.js
+++ b/lib/middleware/broadcasts/index/broadcasts-get.js
@@ -3,9 +3,9 @@
 const helpers = require('../../../helpers');
 
 module.exports = function getBroadcasts() {
-  return (req, res) => helpers.topic.getAll()
-    .then((topics) => {
-      req.data = topics;
+  return (req, res) => helpers.broadcast.fetchAll()
+    .then((broadcasts) => {
+      req.data = broadcasts;
       return res.send({ data: req.data });
     })
     .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/broadcasts/single/broadcast-get.js
+++ b/lib/middleware/broadcasts/single/broadcast-get.js
@@ -2,10 +2,10 @@
 
 const helpers = require('../../../helpers');
 
-module.exports = function getTopic() {
-  return (req, res) => helpers.topic.getById(req.params.broadcastId)
-    .then((topic) => {
-      req.data = topic;
+module.exports = function getBroadcast() {
+  return (req, res) => helpers.broadcast.getById(req.params.broadcastId)
+    .then((broadcast) => {
+      req.data = broadcast;
       return res.send({ data: req.data });
     })
     .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/broadcasts/single/broadcast-get.js
+++ b/lib/middleware/broadcasts/single/broadcast-get.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const helpers = require('../../../helpers');
+
+module.exports = function getTopic() {
+  return (req, res) => helpers.topic.getById(req.params.broadcastId)
+    .then((topic) => {
+      req.data = topic;
+      return res.send({ data: req.data });
+    })
+    .catch(err => helpers.sendErrorResponse(res, err));
+};

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -132,7 +132,8 @@ test('fetchByContentTypes should send contentful a query with contentTypes', asy
   contentful.__set__('client', {
     getEntries: sinon.stub().returns(getEntriesStub),
   });
-  const query = contentful.getQueryBuilder().contentTypes(contentTypes).build();
+  const query = contentful.getQueryBuilder()
+    .contentTypes(contentTypes).orderByDescCreatedAt().build();
 
   // test
   await contentful.fetchByContentTypes(contentTypes);

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const sinon = require('sinon');
+
+const contentful = require('../../../lib/contentful');
+const stubs = require('../../utils/stubs');
+const config = require('../../../config/lib/helpers/broadcast');
+const broadcastEntryFactory = require('../../utils/factories/contentful/broadcast');
+const broadcastFactory = require('../../utils/factories/broadcast');
+
+const broadcastId = stubs.getContentfulId();
+const broadcastEntry = broadcastEntryFactory.getValidCampaignBroadcast();
+const broadcast = broadcastFactory.getValidCampaignBroadcast();
+
+// Module to test
+const broadcastHelper = require('../../../lib/helpers/broadcast');
+
+chai.should();
+chai.use(sinonChai);
+
+const sandbox = sinon.sandbox.create();
+
+test.afterEach(() => {
+  sandbox.restore();
+});
+
+// fetchAll
+test('fetchAll returns contentful.fetchByContentTypes parsed as broadcast objects', async () => {
+  const fetchEntriesResult = [broadcastEntry];
+  sandbox.stub(contentful, 'fetchByContentTypes')
+    .returns(Promise.resolve(fetchEntriesResult));
+  sandbox.stub(broadcastHelper, 'parseBroadcastFromContentfulEntry')
+    .returns(Promise.resolve(broadcast));
+
+  const result = await broadcastHelper.fetchAll();
+  contentful.fetchByContentTypes.should.have.been.calledWith(config.broadcastContentTypes);
+  fetchEntriesResult.forEach((item) => {
+    broadcastHelper.parseBroadcastFromContentfulEntry.should.have.been.calledWith(item);
+  });
+  result.should.deep.equal([broadcast]);
+});
+
+test('fetchAll throws if contentful.fetchByContentTypes fails', async (t) => {
+  const error = new Error('epic fail');
+  sandbox.stub(contentful, 'fetchByContentTypes')
+    .returns(Promise.reject(error));
+  sandbox.stub(broadcastHelper, 'parseBroadcastFromContentfulEntry')
+    .returns(Promise.resolve(broadcast));
+
+  const result = await t.throws(broadcastHelper.fetchAll());
+  result.should.deep.equal(error);
+});
+
+// fetchById
+test('fetchById returns contentful.fetchByContentfulId parsed as broadcast object', async () => {
+  const fetchEntryResult = broadcastEntry;
+  sandbox.stub(contentful, 'fetchByContentfulId')
+    .returns(Promise.resolve(fetchEntryResult));
+  sandbox.stub(broadcastHelper, 'parseBroadcastFromContentfulEntry')
+    .returns(Promise.resolve(broadcast));
+
+  const result = await broadcastHelper.fetchById(broadcastId);
+  contentful.fetchByContentfulId.should.have.been.calledWith(broadcastId);
+  broadcastHelper.parseBroadcastFromContentfulEntry.should.have.been.calledWith(fetchEntryResult);
+  result.should.deep.equal(broadcast);
+});

--- a/test/utils/factories/broadcast.js
+++ b/test/utils/factories/broadcast.js
@@ -5,7 +5,7 @@ const stubs = require('../stubs');
 function getValidCampaignBroadcast(date = Date.now()) {
   return {
     id: stubs.getBroadcastId(),
-    name: 'FeedingBetterFutures2018_Jan30_Niche_TestA',
+    name: stubs.getBroadcastName(),
     createdAt: date,
     updatedAt: date,
     message: {

--- a/test/utils/factories/broadcast.js
+++ b/test/utils/factories/broadcast.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const stubs = require('../stubs');
+
+function getValidCampaignBroadcast(date = Date.now()) {
+  return {
+    id: stubs.getBroadcastId(),
+    name: 'FeedingBetterFutures2018_Jan30_Niche_TestA',
+    createdAt: date,
+    updatedAt: date,
+    message: {
+      text: stubs.getRandomMessageText(),
+      attachments: [],
+      template: 'askSignup',
+    },
+    campaignId: stubs.getCampaignId(),
+  };
+}
+
+function getValidTopicBroadcast(date = Date.now()) {
+  const data = getValidCampaignBroadcast(date);
+  data.topic = 'survey_response';
+  data.message.template = 'rivescript';
+  delete data.campaignId;
+  return data;
+}
+
+module.exports = {
+  getValidCampaignBroadcast,
+  getValidTopicBroadcast,
+};

--- a/test/utils/factories/contentful/broadcast.js
+++ b/test/utils/factories/contentful/broadcast.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const stubs = require('../../stubs');
+
+module.exports.getValidCampaignBroadcast = function getValidCampaignBroadcast(date = Date.now()) {
+  return {
+    sys: {
+      id: stubs.getContentfulId(),
+      createdAt: date,
+      updatedAt: date,
+    },
+    fields: {
+      name: stubs.getRandomWord(),
+      topic: null,
+      message: stubs.getRandomMessageText(),
+      template: 'askSignup',
+      campaign: {
+        sys: {
+          id: stubs.getContentfulId(),
+        },
+        fields: {
+          campaignId: stubs.getCampaignId(),
+        },
+      },
+    },
+  };
+};
+
+module.exports.getValidTopicBroadcast = function getValidTopicBroadcast(date = Date.now()) {
+  const broadcast = module.exports.getValidCampaignBroadcast(date);
+  broadcast.fields.topic = stubs.getRandomWord();
+  broadcast.fields.campaign = null;
+  broadcast.fields.template = null;
+  return broadcast;
+};

--- a/test/utils/factories/contentful/broadcast.js
+++ b/test/utils/factories/contentful/broadcast.js
@@ -5,12 +5,12 @@ const stubs = require('../../stubs');
 module.exports.getValidCampaignBroadcast = function getValidCampaignBroadcast(date = Date.now()) {
   return {
     sys: {
-      id: stubs.getContentfulId(),
+      id: stubs.getBroadcastId(),
       createdAt: date,
       updatedAt: date,
     },
     fields: {
-      name: stubs.getRandomWord(),
+      name: stubs.getBroadcastName(),
       topic: null,
       message: stubs.getRandomMessageText(),
       template: 'askSignup',

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -70,7 +70,7 @@ module.exports = {
     return 6677;
   },
   getBroadcastId: function getBroadcastId() {
-    return 1246319;
+    return this.getContentfulId();
   },
   getContentfulId: function getContentfulId() {
     return '5xa3oDEx4Ao0Sm2qoQCeI';

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -8,6 +8,10 @@ const Chance = require('chance');
 
 const chance = new Chance();
 
+function getBroadcastName() {
+  return 'FeedingBetterFutures2018_Jan30_Niche_TestA';
+}
+
 /**
  * @return {String}
  */
@@ -72,6 +76,7 @@ module.exports = {
   getBroadcastId: function getBroadcastId() {
     return this.getContentfulId();
   },
+  getBroadcastName,
   getContentfulId: function getContentfulId() {
     return '5xa3oDEx4Ao0Sm2qoQCeI';
   },


### PR DESCRIPTION
#### What's this PR do?
Adds `GET /v1/broadcasts` and `GET /v1/broadcasts/:id` endpoints to fetch and parse `broadcast` entries in Contentful, caching entries for the single view. This is essentially moving the code out of [gambit-conversations ](https://github.com/dosomething/gambit-conversations) and into this repo, allowing us to consolidate Contentful queries (and caching them in Redis)

Part 2 will include the following (excluded to help keep this reviewable):

* Parsing the `attachments` Media field on the `broadcast 
* Documentation, example requests & responses
* Unit tests for middleware, integration tests for routes

#### How should this be reviewed?
Verify the `GET /broadcasts` and `GET broadcasts/:id` responses look as expected.

#### Any background context you want to provide?
Feels appropriate to rename this repo as `gambit-content` once we remove all references to Contentful from [gambit-conversations ](https://github.com/dosomething/gambit-conversations)?

#### Relevant tickets
https://www.pivotaltracker.com/story/show/154737123

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
