### PR TITLE
Broadcasts endpoint - part 2

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -39,9 +39,6 @@ module.exports = function init(app) {
   // Provides list of chatbot broadcasts.
   app.use('/v1/broadcasts', broadcastsIndexRoute);
 
-  // Provides list of campaigns with active topics.
-  app.use('/v1/campaigns', campaignsIndexRoute);
-
   // Provides list of defaultTopicTriggers
   app.use('/v1/defaultTopicTriggers', defaultTopicTriggersRoute);
 

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -141,6 +141,18 @@ function getContentTypeFromContentfulEntry(contentfulEntry) {
 }
 
 /**
+ * @param {Object} contentfulEntry
+ * @return {object}
+ */
+function getAttachmentsFromContentfulEntry(contentfulEntry) {
+  const attachmentsFieldValue = contentfulEntry.fields.attachments;
+  if (!attachmentsFieldValue) {
+    return [];
+  }
+  return attachmentsFieldValue.map(assetObject => assetObject.fields.file);
+}
+
+/**
  * @param {Object} messageObject - A Contentful entry
  * @return {String}
  */
@@ -203,6 +215,7 @@ module.exports = {
   createNewClient,
   fetchByContentfulId,
   fetchByContentTypes,
+  getAttachmentsFromContentfulEntry,
   getCampaignIdFromContentfulEntry,
   getClient,
   getContentfulIdFromContentfulEntry,

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -53,8 +53,7 @@ function parseBroadcastFromContentfulEntry(contentfulEntry) {
     updatedAt: contentfulEntry.sys.updatedAt,
     message: {
       text: contentfulEntry.fields.message,
-      // TODO: Parse from attachments reference field.
-      attachments: [],
+      attachments: contentful.getAttachmentsFromContentfulEntry(contentfulEntry),
     },
   };
   // Note: We plan to split broadcast content type into two separate content types, so editors

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -68,7 +68,7 @@ function parseBroadcastFromContentfulEntry(contentfulEntry) {
     data.message.template = 'rivescript';
   } else {
     const campaignConfigEntry = contentfulEntry.fields.campaign;
-    data.campaignId = contentful.getCampaignIdFromContentfulEntry(campaignConfigEntry);
+    data.campaignId = Number(contentful.getCampaignIdFromContentfulEntry(campaignConfigEntry));
     data.topic = null;
     data.message.template = contentfulEntry.fields.template || 'askSignup';
   }

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -15,6 +15,7 @@ const underscore = require('underscore');
 const stubs = require('../../test/utils/stubs');
 const stathat = require('../../lib/stathat');
 const contentfulAPI = require('contentful');
+const broadcastContentfulFactory = require('../../test/utils/factories/contentful/broadcast');
 const defaultTopicTriggerContentfulFactory = require('../../test/utils/factories/contentful/defaultTopicTrigger');
 const textPostConfigContentfulFactory = require('../../test/utils/factories/contentful/textPostConfig');
 
@@ -29,6 +30,7 @@ const contentful = rewire('../../lib/contentful');
 const sandbox = sinon.sandbox.create();
 
 // Stubs
+const broadcastEntry = broadcastContentfulFactory.getValidCampaignBroadcast();
 const defaultTopicTriggerEntry = defaultTopicTriggerContentfulFactory
   .getValidDefaultTopicTrigger();
 const textPostConfigEntry = textPostConfigContentfulFactory.getValidTextPostConfig();
@@ -161,6 +163,13 @@ test('getContentfulIdFromContentfulEntry returns contentful entry id of given en
 test('getContentTypeFromContentfulEntry returns content type name of given entry', () => {
   const result = contentful.getContentTypeFromContentfulEntry(campaignConfigStub);
   result.should.equal(campaignConfigStub.sys.contentType.sys.id);
+});
+
+// getAttachmentsFromContentfulEntry
+test('getAttachmentsFromContentfulEntry returns value of given entry name field', () => {
+  const result = contentful.getAttachmentsFromContentfulEntry(broadcastEntry);
+  const attachment = broadcastEntry.fields.attachments[0].fields.file;
+  result.should.deep.equal([attachment]);
 });
 
 // getNameTextFromContentfulEntry

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -13,6 +13,8 @@ const config = require('../../../config/lib/helpers/broadcast');
 const broadcastEntryFactory = require('../../utils/factories/contentful/broadcast');
 const broadcastFactory = require('../../utils/factories/broadcast');
 
+// stubs
+const attachments = [stubs.getAttachment()];
 const broadcastId = stubs.getContentfulId();
 const broadcastEntry = broadcastEntryFactory.getValidCampaignBroadcast();
 const broadcast = broadcastFactory.getValidCampaignBroadcast();
@@ -83,6 +85,9 @@ test('fetchById returns contentful.fetchByContentfulId parsed as broadcast objec
 
 // parseBroadcastFromContentfulEntry
 test('parseBroadcastFromContentfulEntry returns an object with null topic if campaign broadcast', (t) => {
+  sandbox.stub(contentful, 'getAttachmentsFromContentfulEntry')
+    .returns(attachments);
+
   const result = broadcastHelper.parseBroadcastFromContentfulEntry(broadcastEntry);
   contentful.getContentfulIdFromContentfulEntry.should.have.been.calledWith(broadcastEntry);
   result.id.should.equal(broadcastId);
@@ -92,6 +97,8 @@ test('parseBroadcastFromContentfulEntry returns an object with null topic if cam
   result.campaignId.should.equal(campaignId);
   result.message.text.should.equal(broadcastEntry.fields.message);
   result.message.template.should.equal(broadcastEntry.fields.template);
+  contentful.getAttachmentsFromContentfulEntry.should.have.been.calledWith(broadcastEntry);
+  result.message.attachments.should.equal(attachments);
 });
 
 test('parseBroadcastFromContentfulEntry returns an object with null campaignId if hardcoded topic broadcast', (t) => {

--- a/test/lib/middleware/broadcasts/index/broadcasts-get.test.js
+++ b/test/lib/middleware/broadcasts/index/broadcasts-get.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+// libs
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../lib/helpers');
+const broadcastFactory = require('../../../../utils/factories/broadcast');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const getBroadcasts = require('../../../../../lib/middleware/broadcasts/index/broadcasts-get');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+  sandbox.spy(t.context.res, 'send');
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('getBroadcasts should send helpers.broadcast.fetchAll result', async (t) => {
+  const next = sinon.stub();
+  const middleware = getBroadcasts();
+  const firstBroadcast = broadcastFactory.getValidCampaignBroadcast();
+  const secondBroadcast = broadcastFactory.getValidCampaignBroadcast();
+  sandbox.stub(helpers.broadcast, 'fetchAll')
+    .returns(Promise.resolve([firstBroadcast, secondBroadcast]));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.broadcast.fetchAll.should.have.been.called;
+  t.context.req.data[0].name.should.equal(firstBroadcast.name);
+  t.context.req.data[1].name.should.equal(secondBroadcast.name);
+  t.context.res.send.should.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('getBroadcasts should send errorResponse if helpers.broadcast.getAll fails', async (t) => {
+  const next = sinon.stub();
+  const middleware = getBroadcasts();
+  const error = new Error('o noes');
+  sandbox.stub(helpers.broadcast, 'fetchAll')
+    .returns(Promise.reject(error));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.broadcast.fetchAll.should.have.been.called;
+  t.context.res.send.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
+});

--- a/test/lib/middleware/broadcasts/single/broadcast-get.test.js
+++ b/test/lib/middleware/broadcasts/single/broadcast-get.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+// libs
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const stubs = require('../../../../utils/stubs');
+const helpers = require('../../../../../lib/helpers');
+
+const broadcastFactory = require('../../../../utils/factories/broadcast');
+
+const broadcast = broadcastFactory.getValidCampaignBroadcast();
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const getBroadcast = require('../../../../../lib/middleware/broadcasts/single/broadcast-get');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.req.params = {
+    broadcastId: stubs.getBroadcastId(),
+  };
+  t.context.res = httpMocks.createResponse();
+  sandbox.spy(t.context.res, 'send');
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('getBroadcast should inject a broadcast property set to getById result', async (t) => {
+  const next = sinon.stub();
+  const middleware = getBroadcast();
+  sandbox.stub(helpers.broadcast, 'getById')
+    .returns(Promise.resolve(broadcast));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.broadcast.getById.should.have.been.calledWith(t.context.req.params.broadcastId);
+  t.context.res.send.should.have.been.calledWith({ data: broadcast });
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('getBroadcast should sendErrorResponse if getById fails', async (t) => {
+  const next = sinon.stub();
+  const middleware = getBroadcast();
+  const mockError = { message: 'Epic fail' };
+  sandbox.stub(helpers.broadcast, 'getById')
+    .returns(Promise.reject(mockError));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.broadcast.getById.should.have.been.calledWith(t.context.req.params.broadcastId);
+  t.context.res.send.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, mockError);
+});

--- a/test/utils/factories/contentful/broadcast.js
+++ b/test/utils/factories/contentful/broadcast.js
@@ -22,6 +22,16 @@ module.exports.getValidCampaignBroadcast = function getValidCampaignBroadcast(da
           campaignId: stubs.getCampaignId(),
         },
       },
+      attachments: [
+        {
+          sys: {
+            id: stubs.getContentfulId(),
+          },
+          fields: {
+            file: stubs.getAttachment(),
+          },
+        },
+      ],
     },
   };
 };

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -8,6 +8,27 @@ const Chance = require('chance');
 
 const chance = new Chance();
 
+/**
+ * @return {Object}
+ */
+function getAttachment() {
+  return {
+    url: '//images.ctfassets.net/owik07lyerdj/55kiwuII4oWWG2OiWM2E6e/fb93ab4a76c2f4a5d6c6afb1a2fc810f/doge-code.png',
+    details: {
+      size: 182729,
+      image: {
+        width: 476,
+        height: 249,
+      },
+    },
+    fileName: 'doge-code.png',
+    contentType: 'image/png',
+  };
+}
+
+/**
+ * @return {String}
+ */
 function getBroadcastName() {
   return 'FeedingBetterFutures2018_Jan30_Niche_TestA';
 }
@@ -31,6 +52,7 @@ function getTopic() {
 }
 
 module.exports = {
+  getAttachment,
   getTopic,
   rogueClient: {
     getOauth2ClientToken: (expiresInSeconds = 3600) => {


### PR DESCRIPTION
#### What's this PR do?

Continues part 1 (#1059):
- Returns broadcast media in the `message.attachments` property, porting over [code from Conversations](https://github.com/DoSomething/gambit-conversations/blob/2.12.3/lib/contentful.js#L139)
- Adds tests for `lib/middleware/broadcasts`
- Fixes epic bug in  `GET /campaigns/:id` response introduced by #1059 

#### How should this be reviewed?
- Verify `72mon4jUeQOaokEIkQMaoa` contains `message.attachments`
- Verify GET /campaigns/:id returns a single campaign

#### Any background context you want to provide?
Last items left for this PR or part 3:
- Add docs
- Add integration tests

#### Relevant tickets
https://www.pivotaltracker.com/story/show/154737123

#### Checklist
- [x] Tested on staging.
