### PR TITLE
Adds meta property into index query result [pr]

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2,8 +2,8 @@
 
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
-`GET /v1/broadcasts` | Retrieve broadcasts
-`GET /v1/broadcasts/:id` | Retrieve a single broadcast
+`GET /v1/broadcasts` | [Retrieve broadcasts](endpoints/broadcasts.md#retrieve-broadcast)
+`GET /v1/broadcasts/:id` | [Retrieve a broadcast](endpoints/broadcasts.md#retrieve-broadcasts)
 `GET /v1/campaigns` | [Retrieve all campaigns with active topics](endpoints/campaigns.md#retrieve-all-campaigns)
 `GET /v1/campaigns/:id` | [Retrieve a campaign](endpoints/campaigns.md#retrieve-a-campaigns)
 `GET /v1/defaultTopicTriggers` | [Retrieve all additional default topic triggers](endpoints/defaultTopicTriggers.md)

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2,12 +2,12 @@
 
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
-`GET /v1/broadcasts` | Retrieve broadcasts
-`GET /v1/broadcasts/:id` | Retrieve a single broadcast
+`GET /v1/broadcasts` | [Retrieve broadcasts](endpoints/broadcasts.md#retrieve-broadcasts)
+`GET /v1/broadcasts/:id` | [Retrieve a broadcast](endpoints/broadcasts.md#retrieve-broadcast)
 `GET /v1/campaigns/:id` | [Retrieve a campaign](endpoints/campaigns.md#retrieve-a-campaigns)
 `GET /v1/campaigns` | [Retrieve all campaigns with active topics](endpoints/campaigns.md#retrieve-all-campaigns)
 `GET /v1/campaigns/:id` | [Retrieve a campaign](endpoints/campaigns.md#retrieve-a-campaigns)
 `POST /v1/campaignActivity` | [Parses an inbound message from user as campaign activity](endpoints/campaignActivity.md)
 `GET /v1/defaultTopicTriggers` | [Retrieve all additional default topic triggers](endpoints/defaultTopicTriggers.md)
-`GET /v1/topics` | [Retrieve all topics](endpoints/topics.md#retrieve-all-topics)
+`GET /v1/topics` | [Retrieve topics](endpoints/topics.md#retrieve-all-topics)
 `GET /v1/topics/:id` | [Retrieve a topic](endpoints/topics.md#retrieve-a-topic)

--- a/documentation/endpoints/broadcasts.md
+++ b/documentation/endpoints/broadcasts.md
@@ -8,9 +8,14 @@ Name | Type | Description
 -----|------|------------
 `id` | String | The Contentful entry id
 `name` | String | Internal name used to reference the broadcast
-`message` | Object | Broadcast message content. See the Gambit Conversations messages endpoint for details.
-`topic` | String | If set, updates the conversation topic to this string.
-`campaignId` | Number | If set, updates the conversation topic to the given campaign's topic.
+`message` | Object | Contains the [outbound message content](https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/messages.md) to send to user
+`message.text` | String |
+`message.attachments` | Array |
+`message.template` | String |
+`topic` | String | If set, updates the conversation topic to this string.*
+`campaignId` | Number | If set, updates the conversation topic to the given campaign's topic.*
+
+* Note: These fields will likely be deprecated by a `topicId` per https://www.pivotaltracker.com/story/show/157369418
 
 
 ## Retrieve broadcasts

--- a/documentation/endpoints/broadcasts.md
+++ b/documentation/endpoints/broadcasts.md
@@ -1,0 +1,122 @@
+# Broadcasts
+
+Broadcast messages sent to users.
+
+Fields:
+
+Name | Type | Description
+-----|------|------------
+`id` | String | The Contentful entry id
+`name` | String | Internal name used to reference the broadcast
+`message` | Object | Broadcast message content. See the Gambit Conversations messages endpoint for details.
+`topic` | String | If set, updates the conversation topic to this string.
+`campaignId` | Number | If set, updates the conversation topic to the given campaign's topic.
+
+
+## Retrieve broadcasts
+
+```
+GET /v1/broadcasts
+```
+
+Returns broadcasts.
+
+### Query parameters
+
+Name | Type | Description
+-----|------|------------
+`skip` | Number | Number of results to skip
+
+<details><summary>**Example Request**</summary><p>
+
+```
+curl http://localhost:5000/v1/broadcasts?skip=20
+  -H "Accept: application/json"
+  -H "Content-Type: application/json"
+```
+
+</p></details>
+
+<details><summary>**Example Response**</summary><p>
+```
+{
+  "data": [
+    {
+      "id": "2pdZ69lVukaEw2MM8gcEOg",
+      "name": "VoterRegistration2018_Jul10_MissouriPrimaryReminder",
+      "createdAt": "2018-07-10T13:43:15.338Z",
+      "updatedAt": "2018-07-10T13:44:12.830Z",
+      "message": {
+        "text": "It's Freddie! Guess what -- Missouri needs YOU. Voters have the power to make a huge difference in your state, so make sure you're registered to vote in Missouri's primary before tonight's deadline! It takes just 2 mins: https://vote.dosomething.org/?r=user:{{user.id}},campaignID:8017,campaignRunID:8022,source:sms,source_details:broadcastID_2pdZ69lVukaEw2MM8gcEOg",
+        "attachments": [],
+        "template": "rivescript"
+      },
+      "campaignId": null,
+      "topic": "survey_response"
+    },
+    {
+      "id": "4C2gkDV8oUAaewSMYeokEC",
+      "name": "VoterRegistration2018_Jul8_OhioSpecialHouseGeneralReminder",
+      "createdAt": "2018-07-06T18:28:51.478Z",
+      "updatedAt": "2018-07-06T18:31:55.968Z",
+      "message": {
+        "text": "It's Freddie! Guess what -- Ohio needs YOU. Voters have the power to make a huge difference in your state, so make sure you're registered to vote in Ohio's special house general election before tonight's deadline! It takes just 2 mins: https://vote.dosomething.org/?r=user:{{user.id}},campaignID:8017,campaignRunID:8022,source:sms,source_details:broadcastID_4C2gkDV8oUAaewSMYeokEC",
+        "attachments": [],
+        "template": "rivescript"
+      },
+      "campaignId": null,
+      "topic": "survey_response"
+    },
+    ...
+  },
+  "meta": {
+    "pagination": {
+      "total": 573,
+      "skip": 20,
+      "limit": 100
+    }
+  }
+}
+```
+
+</p></details>
+
+
+## Retrieve broadcast
+
+```
+GET /v1/broadcasts/:id
+```
+
+Returns a broadcast.
+
+<details><summary>**Example Request**</summary><p>
+
+```
+curl http://localhost:5000/v1/broadcasts/2HdYviqiK46skcgKW6OSGk
+  -H "Accept: application/json"
+  -H "Content-Type: application/json"
+```
+
+</p></details>
+
+<details><summary>**Example Response**</summary><p>
+```
+{
+  "data": {
+    "id": "2HdYviqiK46skcgKW6OSGk",
+    "name": "VoterRegistration2018_Jun27_Pending_TestG",
+    "createdAt": "2018-06-27T16:53:41.058Z",
+    "updatedAt": "2018-06-27T16:54:34.766Z",
+    "message": {
+      "text": "It's Freddie from DoSomething. There's an election coming up in Nov. I wanna hear from you. Tell me: What issue do you want to see Americans vote for this year?",
+      "attachments": [],
+      "template": "askText"
+    },
+    "campaignId": 7059,
+    "topic": null
+  }
+}
+```
+
+</p></details>

--- a/documentation/endpoints/broadcasts.md
+++ b/documentation/endpoints/broadcasts.md
@@ -38,6 +38,7 @@ curl http://localhost:5000/v1/broadcasts?skip=20
 </p></details>
 
 <details><summary>**Example Response**</summary><p>
+  
 ```
 {
   "data": [
@@ -101,6 +102,7 @@ curl http://localhost:5000/v1/broadcasts/2HdYviqiK46skcgKW6OSGk
 </p></details>
 
 <details><summary>**Example Response**</summary><p>
+  
 ```
 {
   "data": {

--- a/documentation/endpoints/topics.md
+++ b/documentation/endpoints/topics.md
@@ -20,21 +20,27 @@ Name | Type | Description
 `templates.override` | Boolean | Whether the `raw` value is set from a Contentful field value (override is `true`), or from a hardcoded default (override is `false`)
 `triggers` | Array | List of defaultTopicTriggers that change user conversation to this topic
 
-## Retrieve all topics
+## Retrieve topics
 
 ```
 GET /v1/topics
 ```
 
-Returns all topics.
+Returns topics.
+
+### Query parameters
+
+Name | Type | Description
+-----|------|------------
+`skip` | Number | Number of results to skip
 
 
 <details><summary>**Example Request**</summary><p>
 
 ```
-curl http://localhost:5000/v1/topics \
-  -H "Accept: application/json" \
-  -H "Content-Type: application/json" \
+curl http://localhost:5000/v1/topics
+  -H "Accept: application/json"
+  -H "Content-Type: application/json"
 ```
 
 </p></details>
@@ -248,7 +254,15 @@ curl http://localhost:5000/v1/topics \
         "mascot",
       ]
     },
-  ]
+    ...
+  ],
+  "meta": {
+    "pagination": {
+      "total": 21,
+      "skip": 0,
+      "limit": 100
+    }
+  }
 }
 ```
 

--- a/documentation/endpoints/topics.md
+++ b/documentation/endpoints/topics.md
@@ -38,7 +38,7 @@ Name | Type | Description
 <details><summary>**Example Request**</summary><p>
 
 ```
-curl http://localhost:5000/v1/topics
+curl http://localhost:5000/v1/topics?skip=5
   -H "Accept: application/json"
   -H "Content-Type: application/json"
 ```
@@ -259,7 +259,7 @@ curl http://localhost:5000/v1/topics
   "meta": {
     "pagination": {
       "total": 21,
-      "skip": 0,
+      "skip": 5,
       "limit": 100
     }
   }

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -120,10 +120,10 @@ function fetchByContentTypes(contentTypes, queryParams = {}) {
     .build();
 
   return module.exports.getClient().getEntries(query)
-    .then((res) => {
-      res.meta = utilHelper.getPagination(res.total, res.skip, res.limit);
-      return res;
-    })
+    .then(res => ({
+      meta: utilHelper.getMeta(res.total, res.skip, res.limit),
+      data: res.items,
+    }))
     .catch((error) => {
       throw module.exports.contentfulError(error);
     });

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -103,22 +103,19 @@ function fetchByContentfulId(contentfulId) {
 
 /**
  * Returns Contentful entries with contentType in given contentTypes array.
- * TODO: Add pagination support, this only returns the first 100 (Contentful default limit).
  *
+ * @param {Number} skip
  * @param {Array} contentTypes
  * @return {Promise}
  */
-function fetchByContentTypes(contentTypes) {
+function fetchByContentTypes(contentTypes, skip = 0) {
   logger.debug('fetchByContentTypes', { contentTypes });
   const query = module.exports.getQueryBuilder()
     .contentTypes(contentTypes)
+    .skip(skip)
     .orderByDescCreatedAt()
     .build();
   return module.exports.getClient().getEntries(query)
-    .then((res) => {
-      logger.debug('fetchByContentTypes count', res.total);
-      return res.items;
-    })
     .catch((error) => {
       throw module.exports.contentfulError(error);
     });

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -10,6 +10,7 @@ const underscore = require('underscore');
 const NotFoundError = require('../app/exceptions/NotFoundError');
 const config = require('../config/lib/contentful');
 const Builder = require('./contentfulQueryBuilder');
+const utilHelper = require('./helpers/util');
 
 const ERROR_PREFIX = 'Contentful:';
 
@@ -104,26 +105,23 @@ function fetchByContentfulId(contentfulId) {
 /**
  * Returns Contentful entries with contentType in given contentTypes array.
  *
- * @param {Number} skip
+ * @param {Object} query
  * @param {Array} contentTypes
  * @return {Promise}
  */
-function fetchByContentTypes(contentTypes, skip = 0) {
+function fetchByContentTypes(contentTypes, queryParams = {}) {
   logger.debug('fetchByContentTypes', { contentTypes });
+  const skipParam = queryParams.skip || 0;
+
   const query = module.exports.getQueryBuilder()
     .contentTypes(contentTypes)
-    .skip(skip)
+    .skip(skipParam)
     .orderByDescCreatedAt()
     .build();
+
   return module.exports.getClient().getEntries(query)
     .then((res) => {
-      res.meta = {
-        pagination: {
-          total: res.total,
-          skip: res.skip,
-          limit: res.limit,
-        },
-      };
+      res.meta = utilHelper.getPagination(res.total, res.skip, res.limit);
       return res;
     })
     .catch((error) => {

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -116,6 +116,16 @@ function fetchByContentTypes(contentTypes, skip = 0) {
     .orderByDescCreatedAt()
     .build();
   return module.exports.getClient().getEntries(query)
+    .then((res) => {
+      res.meta = {
+        pagination: {
+          total: res.total,
+          skip: res.skip,
+          limit: res.limit,
+        },
+      };
+      return res;
+    })
     .catch((error) => {
       throw module.exports.contentfulError(error);
     });

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -120,13 +120,23 @@ function fetchByContentTypes(contentTypes, queryParams = {}) {
     .build();
 
   return module.exports.getClient().getEntries(query)
-    .then(res => ({
-      meta: utilHelper.getMeta(res.total, res.skip, res.limit),
-      data: res.items,
-    }))
+    .then(res => module.exports.parseGetEntriesResponse(res))
     .catch((error) => {
       throw module.exports.contentfulError(error);
     });
+}
+
+/**
+ * Parses Contentful getEntries response as object with meta and data properties.
+ *
+ * @param {res} Object
+ * @return {Object}
+ */
+function parseGetEntriesResponse(res) {
+  return {
+    meta: utilHelper.getMeta(res.total, res.skip, res.limit),
+    data: res.items,
+  };
 }
 
 /**
@@ -233,4 +243,5 @@ module.exports = {
   isContentType,
   isDefaultTopicTrigger,
   isMessage,
+  parseGetEntriesResponse,
 };

--- a/lib/contentfulQueryBuilder.js
+++ b/lib/contentfulQueryBuilder.js
@@ -40,6 +40,10 @@ class QueryBuilder {
     this.query.order = '-sys.createdAt';
     return this;
   }
+  skip(offset) {
+    this.query.skip = offset;
+    return this;
+  }
   build() {
     return this.query;
   }

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -6,7 +6,7 @@ const helpers = require('../helpers');
 const config = require('../../config/lib/helpers/broadcast');
 
 /**
- * @param {Number} skip
+ * @param {Object} query
  * @return {Promise}
  */
 function fetch(query = {}) {

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -6,21 +6,22 @@ const helpers = require('../helpers');
 const config = require('../../config/lib/helpers/broadcast');
 
 /**
+ * Fetches broadcast Contentful entries and parses them as broadcasts.
+ *
  * @param {Object} query
  * @return {Promise}
  */
 function fetch(query = {}) {
   return contentful.fetchByContentTypes(config.broadcastContentTypes, query)
-    .then((res) => {
-      const broadcasts = res.items.map(module.exports.parseBroadcastFromContentfulEntry);
-      return {
-        meta: res.meta,
-        data: broadcasts,
-      };
-    });
+    .then(contentfulRes => ({
+      meta: contentfulRes.meta,
+      data: contentfulRes.data.map(module.exports.parseBroadcastFromContentfulEntry),
+    }));
 }
 
 /**
+ * Fetches a Contentful entry and parses as a broadcast.
+ *
  * @param {String} broadcastId
  * @return {Promise}
  */

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -9,10 +9,15 @@ const config = require('../../config/lib/helpers/broadcast');
  * @param {Number} skip
  * @return {Promise}
  */
-function fetchAll(skip = 0) {
+function fetch(skip = 0) {
   return contentful.fetchByContentTypes(config.broadcastContentTypes, skip)
-    .then(res => Promise.all(res.items.map(module.exports
-      .parseBroadcastFromContentfulEntry)));
+    .then((res) => {
+      const broadcasts = res.items.map(module.exports.parseBroadcastFromContentfulEntry);
+      return {
+        meta: res.meta,
+        data: broadcasts,
+      };
+    });
 }
 
 /**
@@ -43,7 +48,7 @@ function getById(broadcastId) {
 
 /**
  * @param {Object} contentfulEntry
- * @return {Promise}
+ * @return {Object}
  */
 function parseBroadcastFromContentfulEntry(contentfulEntry) {
   const data = {
@@ -75,7 +80,7 @@ function parseBroadcastFromContentfulEntry(contentfulEntry) {
 }
 
 module.exports = {
-  fetchAll,
+  fetch,
   fetchById,
   getById,
   parseBroadcastFromContentfulEntry,

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -9,8 +9,8 @@ const config = require('../../config/lib/helpers/broadcast');
  * @param {Number} skip
  * @return {Promise}
  */
-function fetch(skip = 0) {
-  return contentful.fetchByContentTypes(config.broadcastContentTypes, skip)
+function fetch(query = {}) {
+  return contentful.fetchByContentTypes(config.broadcastContentTypes, query)
     .then((res) => {
       const broadcasts = res.items.map(module.exports.parseBroadcastFromContentfulEntry);
       return {

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -6,12 +6,12 @@ const helpers = require('../helpers');
 const config = require('../../config/lib/helpers/broadcast');
 
 /**
+ * @param {Number} skip
  * @return {Promise}
  */
-function fetchAll() {
-  // TODO: Loop through all pages of query results - currently returns 100.
-  return contentful.fetchByContentTypes(config.broadcastContentTypes)
-    .then(contentfulEntries => Promise.all(contentfulEntries.map(module.exports
+function fetchAll(skip = 0) {
+  return contentful.fetchByContentTypes(config.broadcastContentTypes, skip)
+    .then(res => Promise.all(res.items.map(module.exports
       .parseBroadcastFromContentfulEntry)));
 }
 

--- a/lib/helpers/defaultTopicTrigger.js
+++ b/lib/helpers/defaultTopicTrigger.js
@@ -8,7 +8,7 @@ const helpers = require('../helpers');
 const config = require('../../config/lib/helpers/defaultTopicTrigger');
 
 /**
- * @param {Object}
+ * @param {Object} query
  * @return {Promise}
  */
 function fetch(query = {}) {

--- a/lib/helpers/defaultTopicTrigger.js
+++ b/lib/helpers/defaultTopicTrigger.js
@@ -8,11 +8,11 @@ const helpers = require('../helpers');
 const config = require('../../config/lib/helpers/defaultTopicTrigger');
 
 /**
- * @param {Number} skip
+ * @param {Object}
  * @return {Promise}
  */
-function fetchAll(skip = 0) {
-  return contentful.fetchByContentTypes(config.defaultTopicTriggerContentTypes, skip)
+function fetch(query = {}) {
+  return contentful.fetchByContentTypes(config.defaultTopicTriggerContentTypes, query)
     .then(res => Promise.map(res.items, module.exports
       .parseDefaultTopicTriggerFromContentfulEntry))
     .then(defaultTopicTriggers => module.exports
@@ -41,7 +41,11 @@ function getAll() {
         return triggers;
       }
       logger.debug('All defaultTopicTriggers cache miss');
-      return module.exports.fetchAll()
+      // TODO: If total count of defaultTopicTriggers is greater than number of results returned,
+      // execute multiple requests to cache all defaultTopicTriggers.
+      // We want the list of all triggers cached, as a Conversations restart requires each dyno
+      // to fetch the index to load all Rivescript.
+      return module.exports.fetch()
         .then(defaultTopicTriggers => helpers.cache.defaultTopicTriggers
           .set(config.allDefaultTopicTriggersCacheKey, defaultTopicTriggers));
     });
@@ -110,7 +114,7 @@ function parseDefaultTopicTriggerFromContentfulEntry(contentfulEntry) {
 }
 
 module.exports = {
-  fetchAll,
+  fetch,
   getAll,
   getAllWithCampaignTopics,
   getByTopicId,

--- a/lib/helpers/defaultTopicTrigger.js
+++ b/lib/helpers/defaultTopicTrigger.js
@@ -8,12 +8,12 @@ const helpers = require('../helpers');
 const config = require('../../config/lib/helpers/defaultTopicTrigger');
 
 /**
+ * @param {Number} skip
  * @return {Promise}
  */
-function fetchAll() {
-  // TODO: Loop through all pages of query results - currently returns 100.
-  return contentful.fetchByContentTypes(config.defaultTopicTriggerContentTypes)
-    .then(contentfulEntries => Promise.map(contentfulEntries, module.exports
+function fetchAll(skip = 0) {
+  return contentful.fetchByContentTypes(config.defaultTopicTriggerContentTypes, skip)
+    .then(res => Promise.map(res.items, module.exports
       .parseDefaultTopicTriggerFromContentfulEntry))
     .then(defaultTopicTriggers => module.exports
       .removeInvalidDefaultTopicTriggers(defaultTopicTriggers));

--- a/lib/helpers/defaultTopicTrigger.js
+++ b/lib/helpers/defaultTopicTrigger.js
@@ -13,7 +13,7 @@ const config = require('../../config/lib/helpers/defaultTopicTrigger');
  */
 function fetch(query = {}) {
   return contentful.fetchByContentTypes(config.defaultTopicTriggerContentTypes, query)
-    .then(res => Promise.map(res.items, module.exports
+    .then(contentfulRes => Promise.map(contentfulRes.data, module.exports
       .parseDefaultTopicTriggerFromContentfulEntry))
     .then(defaultTopicTriggers => module.exports
       .removeInvalidDefaultTopicTriggers(defaultTopicTriggers));

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -7,6 +7,7 @@ const campaignActivity = require('./campaignActivity');
 const command = require('./command');
 const defaultTopicTrigger = require('./defaultTopicTrigger');
 const request = require('./request');
+const response = require('./response');
 const topic = require('./topic');
 const util = require('./util');
 
@@ -18,6 +19,7 @@ module.exports = {
   defaultTopicTrigger,
   command,
   request,
+  response,
   topic,
   util,
 };

--- a/lib/helpers/response.js
+++ b/lib/helpers/response.js
@@ -2,6 +2,15 @@
 
 /**
  * @param {Object} res - Express response
+ * @param {Object} data
+ * @param {Object} meta
+ */
+function sendData(res, data) {
+  return res.send({ data });
+}
+
+/**
+ * @param {Object} res - Express response
  * @param {Array} data
  * @param {Object} meta
  */
@@ -10,5 +19,6 @@ function sendDataAndMeta(res, data, meta) {
 }
 
 module.exports = {
+  sendData,
   sendDataAndMeta,
 };

--- a/lib/helpers/response.js
+++ b/lib/helpers/response.js
@@ -1,0 +1,14 @@
+'use strict';
+
+/**
+ * @param {Object} res - Express response
+ * @param {Array} data
+ * @param {Object} meta
+ */
+function sendDataAndMeta(res, data, meta) {
+  return res.send({ data, meta });
+}
+
+module.exports = {
+  sendDataAndMeta,
+};

--- a/lib/helpers/response.js
+++ b/lib/helpers/response.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const utilHelper = require('./util');
+
 /**
  * @param {Object} res - Express response
  * @param {Object} data
@@ -14,11 +16,14 @@ function sendData(res, data) {
  * @param {Array} data
  * @param {Object} meta
  */
-function sendDataAndMeta(res, data, meta) {
-  return res.send({ data, meta });
+function sendIndexData(res, data, meta) {
+  return res.send({
+    data,
+    meta: meta || utilHelper.getMeta(data.length),
+  });
 }
 
 module.exports = {
   sendData,
-  sendDataAndMeta,
+  sendIndexData,
 };

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -9,19 +9,11 @@ const config = require('../../config/lib/helpers/topic');
  * @param {Object} query
  * @return {Promise}
  */
-function fetch(query = {}) {
-  let result = {};
-
-  return contentful.fetchByContentTypes(config.topicContentTypes, query)
-    .then((contentfulRes) => {
-      result = contentfulRes;
-      return Promise.all(contentfulRes.data.map(module.exports
-        .parseTopicFromContentfulEntry));
-    })
-    .then((topics) => {
-      result.data = topics;
-      return result;
-    });
+async function fetch(query = {}) {
+  const contentfulRes = await contentful.fetchByContentTypes(config.topicContentTypes, query);
+  const topics = await Promise
+    .all(contentfulRes.data.map(module.exports.parseTopicFromContentfulEntry));
+  return Object.assign(contentfulRes, { data: topics });
 }
 
 /**

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -6,11 +6,11 @@ const helpers = require('../helpers');
 const config = require('../../config/lib/helpers/topic');
 
 /**
+ * @param {Object}
  * @return {Promise}
  */
-function fetchAll(skip = 0) {
-  // TODO: Loop through all pages of query results - currently returns 100.
-  return contentful.fetchByContentTypes(config.topicContentTypes, skip)
+function fetch(query = {}) {
+  return contentful.fetchByContentTypes(config.topicContentTypes, query)
     .then(res => Promise.all(res.items.map(module.exports
       .parseTopicFromContentfulEntry)));
 }
@@ -36,7 +36,11 @@ function getAll() {
         return allTopics;
       }
       logger.debug('All topics cache miss');
-      return module.exports.fetchAll()
+      // TODO: Loop through all pages of query results - currently returns 100.
+      // Note - the reason we want a list of all topics is to easily grab topics by campaignId.
+      // Querying Contentful for topics by campaign isn't that easy because we use multiple content
+      // types, and can only filter by field for a single content type (not multiple).
+      return module.exports.fetch()
         .then(topics => Promise.all(topics.map(topic => helpers.cache.topics
           .set(topic.id, topic))))
         .then(topics => helpers.cache.topics.set(allTopicsKey, topics));
@@ -216,7 +220,7 @@ function parseTopicTemplatesFromContentfulEntryAndCampaign(contentfulEntry, camp
 }
 
 module.exports = {
-  fetchAll,
+  fetch,
   fetchById,
   getAll,
   getById,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -10,12 +10,12 @@ const config = require('../../config/lib/helpers/topic');
  * @return {Promise}
  */
 function fetch(query = {}) {
-  const result = {};
+  let result = {};
 
   return contentful.fetchByContentTypes(config.topicContentTypes, query)
     .then((contentfulRes) => {
-      result.meta = contentfulRes.meta;
-      return Promise.all(contentfulRes.items.map(module.exports
+      result = contentfulRes;
+      return Promise.all(contentfulRes.data.map(module.exports
         .parseTopicFromContentfulEntry));
     })
     .then((topics) => {

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -6,7 +6,7 @@ const helpers = require('../helpers');
 const config = require('../../config/lib/helpers/topic');
 
 /**
- * @param {Object}
+ * @param {Object} query
  * @return {Promise}
  */
 function fetch(query = {}) {

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -8,10 +8,10 @@ const config = require('../../config/lib/helpers/topic');
 /**
  * @return {Promise}
  */
-function fetchAll() {
+function fetchAll(skip = 0) {
   // TODO: Loop through all pages of query results - currently returns 100.
-  return contentful.fetchByContentTypes(config.topicContentTypes)
-    .then(contentfulEntries => Promise.all(contentfulEntries.map(module.exports
+  return contentful.fetchByContentTypes(config.topicContentTypes, skip)
+    .then(res => Promise.all(res.items.map(module.exports
       .parseTopicFromContentfulEntry)));
 }
 

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -10,9 +10,18 @@ const config = require('../../config/lib/helpers/topic');
  * @return {Promise}
  */
 function fetch(query = {}) {
+  const result = {};
+
   return contentful.fetchByContentTypes(config.topicContentTypes, query)
-    .then(res => Promise.all(res.items.map(module.exports
-      .parseTopicFromContentfulEntry)));
+    .then((contentfulRes) => {
+      result.meta = contentfulRes.meta;
+      return Promise.all(contentfulRes.items.map(module.exports
+        .parseTopicFromContentfulEntry));
+    })
+    .then((topics) => {
+      result.data = topics;
+      return result;
+    });
 }
 
 /**
@@ -41,7 +50,7 @@ function getAll() {
       // Querying Contentful for topics by campaign isn't that easy because we use multiple content
       // types, and can only filter by field for a single content type (not multiple).
       return module.exports.fetch()
-        .then(topics => Promise.all(topics.map(topic => helpers.cache.topics
+        .then(fetchResult => Promise.all(fetchResult.data.map(topic => helpers.cache.topics
           .set(topic.id, topic))))
         .then(topics => helpers.cache.topics.set(allTopicsKey, topics));
     });

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -8,7 +8,7 @@ const config = require('../../config/lib/helpers/util');
  * @param {Number} limit
  * @return {Object}
  */
-function getPagination(total = 0, skip = 0, limit = 100) {
+function getMeta(total = 0, skip = 0, limit = 100) {
   return {
     pagination: {
       total,
@@ -75,7 +75,7 @@ function trimText(input) {
 }
 
 module.exports = {
-  getPagination,
+  getMeta,
   isValidQuantity: qty => validateQuantity(qty),
   isValidText: txt => validateText(txt),
   trimText: txt => trimText(txt),

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -3,6 +3,22 @@
 const config = require('../../config/lib/helpers/util');
 
 /**
+ * @param {Number} total
+ * @param {Number} skip
+ * @param {Number} limit
+ * @return {Object}
+ */
+function getPagination(total = 0, skip = 0, limit = 100) {
+  return {
+    pagination: {
+      total,
+      skip,
+      limit,
+    },
+  };
+}
+
+/**
  * @param {string} message
  * @return {boolean}
  */
@@ -59,6 +75,7 @@ function trimText(input) {
 }
 
 module.exports = {
+  getPagination,
   isValidQuantity: qty => validateQuantity(qty),
   isValidText: txt => validateText(txt),
   trimText: txt => trimText(txt),

--- a/lib/middleware/broadcasts/index/broadcasts-get.js
+++ b/lib/middleware/broadcasts/index/broadcasts-get.js
@@ -4,6 +4,6 @@ const helpers = require('../../../helpers');
 
 module.exports = function getBroadcasts() {
   return (req, res) => helpers.broadcast.fetch(req.query)
-    .then(fetchResult => res.send({ meta: fetchResult.meta, data: fetchResult.data }))
+    .then(fetchResult => helpers.response.sendDataAndMeta(res, fetchResult.data, fetchResult.meta))
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/broadcasts/index/broadcasts-get.js
+++ b/lib/middleware/broadcasts/index/broadcasts-get.js
@@ -3,7 +3,7 @@
 const helpers = require('../../../helpers');
 
 module.exports = function getBroadcasts() {
-  return (req, res) => helpers.broadcast.fetch(req.query.skip)
+  return (req, res) => helpers.broadcast.fetch(req.query)
     .then(fetchResult => res.send({ meta: fetchResult.meta, data: fetchResult.data }))
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/broadcasts/index/broadcasts-get.js
+++ b/lib/middleware/broadcasts/index/broadcasts-get.js
@@ -4,6 +4,6 @@ const helpers = require('../../../helpers');
 
 module.exports = function getBroadcasts() {
   return (req, res) => helpers.broadcast.fetch(req.query)
-    .then(fetchResult => helpers.response.sendDataAndMeta(res, fetchResult.data, fetchResult.meta))
+    .then(fetchResult => helpers.response.sendIndexData(res, fetchResult.data, fetchResult.meta))
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/broadcasts/index/broadcasts-get.js
+++ b/lib/middleware/broadcasts/index/broadcasts-get.js
@@ -3,7 +3,7 @@
 const helpers = require('../../../helpers');
 
 module.exports = function getBroadcasts() {
-  return (req, res) => helpers.broadcast.fetchAll()
+  return (req, res) => helpers.broadcast.fetchAll(req.query.skip)
     .then((broadcasts) => {
       req.data = broadcasts;
       return res.send({ data: req.data });

--- a/lib/middleware/broadcasts/index/broadcasts-get.js
+++ b/lib/middleware/broadcasts/index/broadcasts-get.js
@@ -3,10 +3,7 @@
 const helpers = require('../../../helpers');
 
 module.exports = function getBroadcasts() {
-  return (req, res) => helpers.broadcast.fetchAll(req.query.skip)
-    .then((broadcasts) => {
-      req.data = broadcasts;
-      return res.send({ data: req.data });
-    })
+  return (req, res) => helpers.broadcast.fetch(req.query.skip)
+    .then(fetchResult => res.send({ meta: fetchResult.meta, data: fetchResult.data }))
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/broadcasts/single/broadcast-get.js
+++ b/lib/middleware/broadcasts/single/broadcast-get.js
@@ -4,9 +4,6 @@ const helpers = require('../../../helpers');
 
 module.exports = function getBroadcast() {
   return (req, res) => helpers.broadcast.getById(req.params.broadcastId)
-    .then((broadcast) => {
-      req.data = broadcast;
-      return res.send({ data: req.data });
-    })
+    .then(broadcast => helpers.response.sendData(res, broadcast))
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/campaigns/index/response.js
+++ b/lib/middleware/campaigns/index/response.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const underscore = require('underscore');
+const helpers = require('../../../helpers');
 
 module.exports = function sendResponse() {
   return (req, res) => {
@@ -36,6 +37,7 @@ module.exports = function sendResponse() {
       return formattedCampaign;
     });
 
-    return res.send({ data });
+    const meta = helpers.util.getMeta(data.length);
+    return helpers.response.sendDataAndMeta(res, data, meta);
   };
 };

--- a/lib/middleware/campaigns/index/response.js
+++ b/lib/middleware/campaigns/index/response.js
@@ -37,7 +37,6 @@ module.exports = function sendResponse() {
       return formattedCampaign;
     });
 
-    const meta = helpers.util.getMeta(data.length);
-    return helpers.response.sendDataAndMeta(res, data, meta);
+    return helpers.response.sendIndexData(res, data);
   };
 };

--- a/lib/middleware/campaigns/single/response.js
+++ b/lib/middleware/campaigns/single/response.js
@@ -14,6 +14,6 @@ module.exports = function sendResponse() {
       return helpers.sendErrorResponse(res, err);
     }
 
-    return res.send({ data: req.campaign });
+    return helpers.response.sendData(res, req.campaign);
   };
 };

--- a/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.js
+++ b/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.js
@@ -4,9 +4,13 @@ const helpers = require('../../../helpers');
 
 module.exports = function getDefaultTopicTriggers() {
   return (req, res) => helpers.defaultTopicTrigger.getAll()
-    .then((defaultTopicTriggers) => {
-      const meta = helpers.util.getPagination(defaultTopicTriggers.length);
-      return res.send({ meta, data: defaultTopicTriggers });
-    })
+    .then(defaultTopicTriggers => res.send({
+      // Our cached list doesn't contain the meta property, so we'll calculate it here.
+      // We will eventually need to support pagination once our list of triggers grows, but we need
+      // each page cached, as a Conversations restart requires all available triggers when loading
+      // the Rivescript bot on app start.
+      meta: helpers.util.getMeta(defaultTopicTriggers.length),
+      data: defaultTopicTriggers,
+    }))
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.js
+++ b/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.js
@@ -4,13 +4,6 @@ const helpers = require('../../../helpers');
 
 module.exports = function getDefaultTopicTriggers() {
   return (req, res) => helpers.defaultTopicTrigger.getAll()
-    .then((defaultTopicTriggers) => {
-      // Our cached list doesn't contain the meta property, so we'll calculate it here.
-      // We will eventually need to support pagination once our list of triggers grows, but we need
-      // each page cached, as a Conversations restart requires all available triggers when loading
-      // the Rivescript bot on app start.
-      const meta = helpers.util.getMeta(defaultTopicTriggers.length);
-      return helpers.response.sendDataAndMeta(res, defaultTopicTriggers, meta);
-    })
+    .then(defaultTopicTriggers => helpers.response.sendIndexData(res, defaultTopicTriggers))
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.js
+++ b/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.js
@@ -4,13 +4,13 @@ const helpers = require('../../../helpers');
 
 module.exports = function getDefaultTopicTriggers() {
   return (req, res) => helpers.defaultTopicTrigger.getAll()
-    .then(defaultTopicTriggers => res.send({
+    .then((defaultTopicTriggers) => {
       // Our cached list doesn't contain the meta property, so we'll calculate it here.
       // We will eventually need to support pagination once our list of triggers grows, but we need
       // each page cached, as a Conversations restart requires all available triggers when loading
       // the Rivescript bot on app start.
-      meta: helpers.util.getMeta(defaultTopicTriggers.length),
-      data: defaultTopicTriggers,
-    }))
+      const meta = helpers.util.getMeta(defaultTopicTriggers.length);
+      return helpers.response.sendDataAndMeta(res, defaultTopicTriggers, meta);
+    })
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.js
+++ b/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.js
@@ -4,6 +4,9 @@ const helpers = require('../../../helpers');
 
 module.exports = function getDefaultTopicTriggers() {
   return (req, res) => helpers.defaultTopicTrigger.getAll()
-    .then(data => res.send({ data }))
+    .then((defaultTopicTriggers) => {
+      const meta = helpers.util.getPagination(defaultTopicTriggers.length);
+      return res.send({ meta, data: defaultTopicTriggers });
+    })
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/topics/index/topics-get.js
+++ b/lib/middleware/topics/index/topics-get.js
@@ -15,7 +15,7 @@ module.exports = function getTopics() {
         req.data[index].triggers = helpers.defaultTopicTrigger
           .getTriggersFromDefaultTopicTriggers(result);
       });
-      return helpers.response.sendDataAndMeta(res, req.data, req.meta);
+      return helpers.response.sendIndexData(res, req.data, req.meta);
     })
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/topics/index/topics-get.js
+++ b/lib/middleware/topics/index/topics-get.js
@@ -3,10 +3,11 @@
 const helpers = require('../../../helpers');
 
 module.exports = function getTopics() {
-  return (req, res) => helpers.topic.getAll()
-    .then((topics) => {
-      req.data = topics;
-      const promises = topics.map(topic => helpers.defaultTopicTrigger.getByTopicId(topic.id));
+  return (req, res) => helpers.topic.fetch(req.query)
+    .then((fetchTopicResult) => {
+      req.meta = fetchTopicResult.meta;
+      req.data = fetchTopicResult.data;
+      const promises = req.data.map(topic => helpers.defaultTopicTrigger.getByTopicId(topic.id));
       return Promise.all(promises);
     })
     .then((defaultTopicTriggersByTopic) => {
@@ -14,7 +15,7 @@ module.exports = function getTopics() {
         req.data[index].triggers = helpers.defaultTopicTrigger
           .getTriggersFromDefaultTopicTriggers(result);
       });
-      return res.send({ data: req.data });
+      return res.send({ meta: req.meta, data: req.data });
     })
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/topics/index/topics-get.js
+++ b/lib/middleware/topics/index/topics-get.js
@@ -5,8 +5,8 @@ const helpers = require('../../../helpers');
 module.exports = function getTopics() {
   return (req, res) => helpers.topic.fetch(req.query)
     .then((fetchTopicResult) => {
-      req.meta = fetchTopicResult.meta;
       req.data = fetchTopicResult.data;
+      req.meta = fetchTopicResult.meta;
       const promises = req.data.map(topic => helpers.defaultTopicTrigger.getByTopicId(topic.id));
       return Promise.all(promises);
     })
@@ -15,7 +15,7 @@ module.exports = function getTopics() {
         req.data[index].triggers = helpers.defaultTopicTrigger
           .getTriggersFromDefaultTopicTriggers(result);
       });
-      return res.send({ meta: req.meta, data: req.data });
+      return helpers.response.sendDataAndMeta(res, req.data, req.meta);
     })
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/topics/single/topic-get.js
+++ b/lib/middleware/topics/single/topic-get.js
@@ -11,7 +11,7 @@ module.exports = function getTopic() {
     .then((defaultTopicTriggers) => {
       req.data.triggers = helpers.defaultTopicTrigger
         .getTriggersFromDefaultTopicTriggers(defaultTopicTriggers);
-      return res.send({ data: req.data });
+      return helpers.response.sendData(res, req.data);
     })
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -134,13 +134,13 @@ test('fetchByContentTypes should send contentful a query with contentTypes', asy
   contentful.__set__('client', {
     getEntries: sinon.stub().returns(getEntriesStub),
   });
-  const skipCount = 11;
+  const queryParams = { skip: 11 };
   const query = contentful.getQueryBuilder()
-    .contentTypes(contentTypes).skip(skipCount).orderByDescCreatedAt()
+    .contentTypes(contentTypes).skip(queryParams.skip).orderByDescCreatedAt()
     .build();
 
   // test
-  await contentful.fetchByContentTypes(contentTypes, skipCount);
+  await contentful.fetchByContentTypes(contentTypes, queryParams);
   contentful.getClient().getEntries.getCall(0).args[0].should.be.eql(query);
 });
 

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -14,6 +14,7 @@ const underscore = require('underscore');
 // app modules
 const stubs = require('../../test/utils/stubs');
 const stathat = require('../../lib/stathat');
+const utilHelper = require('../../lib/helpers/util');
 const contentfulAPI = require('contentful');
 const broadcastContentfulFactory = require('../../test/utils/factories/contentful/broadcast');
 const defaultTopicTriggerContentfulFactory = require('../../test/utils/factories/contentful/defaultTopicTrigger');
@@ -34,6 +35,7 @@ const broadcastEntry = broadcastContentfulFactory.getValidCampaignBroadcast();
 const defaultTopicTriggerEntry = defaultTopicTriggerContentfulFactory
   .getValidDefaultTopicTrigger();
 const textPostConfigEntry = textPostConfigContentfulFactory.getValidTextPostConfig();
+const campaignConfigIndexStub = stubs.contentful.getEntries('campaign');
 const campaignConfigStub = stubs.contentful.getEntries('default-campaign').items[0];
 const getEntriesStub = Promise.resolve({ items: [defaultTopicTriggerEntry] });
 const failStub = Promise.reject({ status: 500 });
@@ -178,4 +180,18 @@ test('getAttachmentsFromContentfulEntry returns value of given entry name field'
 test('getNameTextFromContentfulEntry returns value of given entry name field', () => {
   const result = contentful.getNameTextFromContentfulEntry(textPostConfigEntry);
   result.should.equal(textPostConfigEntry.fields.name);
+});
+
+// parseGetEntriesResponse
+test('parseGetEntriesResponse returns object with meta and data properties', () => {
+  const stubMeta = {
+    pagination: {
+      total: campaignConfigIndexStub.items.length,
+    },
+  };
+  sandbox.stub(utilHelper, 'getMeta')
+    .returns(stubMeta);
+  const result = contentful.parseGetEntriesResponse(campaignConfigIndexStub);
+  result.data.should.deep.equal(campaignConfigIndexStub.items);
+  result.meta.should.deep.equal(stubMeta);
 });

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -134,11 +134,13 @@ test('fetchByContentTypes should send contentful a query with contentTypes', asy
   contentful.__set__('client', {
     getEntries: sinon.stub().returns(getEntriesStub),
   });
+  const skipCount = 11;
   const query = contentful.getQueryBuilder()
-    .contentTypes(contentTypes).orderByDescCreatedAt().build();
+    .contentTypes(contentTypes).skip(skipCount).orderByDescCreatedAt()
+    .build();
 
   // test
-  await contentful.fetchByContentTypes(contentTypes);
+  await contentful.fetchByContentTypes(contentTypes, skipCount);
   contentful.getClient().getEntries.getCall(0).args[0].should.be.eql(query);
 });
 

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -44,7 +44,8 @@ test.afterEach(() => {
 
 // fetch
 test('fetch returns contentful.fetchByContentTypes parsed as broadcast objects', async () => {
-  const fetchEntriesResult = { items: [broadcastEntry] };
+  const entries = [broadcastEntry];
+  const fetchEntriesResult = stubs.contentful.getFetchByContentTypesResultWithArray(entries);
   sandbox.stub(contentful, 'fetchByContentTypes')
     .returns(Promise.resolve(fetchEntriesResult));
   sandbox.stub(broadcastHelper, 'parseBroadcastFromContentfulEntry')
@@ -52,8 +53,8 @@ test('fetch returns contentful.fetchByContentTypes parsed as broadcast objects',
 
   const result = await broadcastHelper.fetch();
   contentful.fetchByContentTypes.should.have.been.calledWith(config.broadcastContentTypes);
-  fetchEntriesResult.items.forEach((item) => {
-    broadcastHelper.parseBroadcastFromContentfulEntry.should.have.been.calledWith(item);
+  fetchEntriesResult.data.forEach((entry) => {
+    broadcastHelper.parseBroadcastFromContentfulEntry.should.have.been.calledWith(entry);
   });
   result.data.should.deep.equal([broadcast]);
 });

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -44,7 +44,7 @@ test.afterEach(() => {
 
 // fetchAll
 test('fetchAll returns contentful.fetchByContentTypes parsed as broadcast objects', async () => {
-  const fetchEntriesResult = [broadcastEntry];
+  const fetchEntriesResult = { items: [broadcastEntry] };
   sandbox.stub(contentful, 'fetchByContentTypes')
     .returns(Promise.resolve(fetchEntriesResult));
   sandbox.stub(broadcastHelper, 'parseBroadcastFromContentfulEntry')
@@ -52,7 +52,7 @@ test('fetchAll returns contentful.fetchByContentTypes parsed as broadcast object
 
   const result = await broadcastHelper.fetchAll();
   contentful.fetchByContentTypes.should.have.been.calledWith(config.broadcastContentTypes);
-  fetchEntriesResult.forEach((item) => {
+  fetchEntriesResult.items.forEach((item) => {
     broadcastHelper.parseBroadcastFromContentfulEntry.should.have.been.calledWith(item);
   });
   result.should.deep.equal([broadcast]);

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -42,30 +42,30 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
-// fetchAll
-test('fetchAll returns contentful.fetchByContentTypes parsed as broadcast objects', async () => {
+// fetch
+test('fetch returns contentful.fetchByContentTypes parsed as broadcast objects', async () => {
   const fetchEntriesResult = { items: [broadcastEntry] };
   sandbox.stub(contentful, 'fetchByContentTypes')
     .returns(Promise.resolve(fetchEntriesResult));
   sandbox.stub(broadcastHelper, 'parseBroadcastFromContentfulEntry')
-    .returns(Promise.resolve(broadcast));
+    .returns(broadcast);
 
-  const result = await broadcastHelper.fetchAll();
+  const result = await broadcastHelper.fetch();
   contentful.fetchByContentTypes.should.have.been.calledWith(config.broadcastContentTypes);
   fetchEntriesResult.items.forEach((item) => {
     broadcastHelper.parseBroadcastFromContentfulEntry.should.have.been.calledWith(item);
   });
-  result.should.deep.equal([broadcast]);
+  result.data.should.deep.equal([broadcast]);
 });
 
-test('fetchAll throws if contentful.fetchByContentTypes fails', async (t) => {
+test('fetch throws if contentful.fetchByContentTypes fails', async (t) => {
   const error = new Error('epic fail');
   sandbox.stub(contentful, 'fetchByContentTypes')
     .returns(Promise.reject(error));
   sandbox.stub(broadcastHelper, 'parseBroadcastFromContentfulEntry')
-    .returns(Promise.resolve(broadcast));
+    .returns(broadcast);
 
-  const result = await t.throws(broadcastHelper.fetchAll());
+  const result = await t.throws(broadcastHelper.fetch());
   result.should.deep.equal(error);
 });
 

--- a/test/lib/lib-helpers/defaultTopicTrigger.test.js
+++ b/test/lib/lib-helpers/defaultTopicTrigger.test.js
@@ -30,8 +30,8 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
-// fetchAll
-test('fetchAll returns contentful.fetchByContentTypes parsed as defaultTopicTrigger objects', async () => {
+// fetch
+test('fetch returns contentful.fetchByContentTypes parsed as defaultTopicTrigger objects', async () => {
   sandbox.stub(contentful, 'fetchByContentTypes')
     .returns(Promise.resolve({ items: [firstEntry, secondEntry] }));
   sandbox.stub(defaultTopicTriggerHelper, 'parseDefaultTopicTriggerFromContentfulEntry')
@@ -40,7 +40,7 @@ test('fetchAll returns contentful.fetchByContentTypes parsed as defaultTopicTrig
     .onCall(1)
     .returns(secondDefaultTopicTrigger);
 
-  const result = await defaultTopicTriggerHelper.fetchAll();
+  const result = await defaultTopicTriggerHelper.fetch();
   contentful.fetchByContentTypes
     .should.have.been.calledWith(config.defaultTopicTriggerContentTypes);
   defaultTopicTriggerHelper.parseDefaultTopicTriggerFromContentfulEntry
@@ -50,14 +50,14 @@ test('fetchAll returns contentful.fetchByContentTypes parsed as defaultTopicTrig
   result.should.deep.equal([firstDefaultTopicTrigger, secondDefaultTopicTrigger]);
 });
 
-test('fetchAll throws if contentful.fetchByContentTypes fails', async (t) => {
+test('fetch throws if contentful.fetchByContentTypes fails', async (t) => {
   const error = new Error('epic fail');
   sandbox.stub(contentful, 'fetchByContentTypes')
     .returns(Promise.reject(error));
   sandbox.stub(defaultTopicTriggerHelper, 'parseDefaultTopicTriggerFromContentfulEntry')
     .returns(firstDefaultTopicTrigger);
 
-  const result = await t.throws(defaultTopicTriggerHelper.fetchAll());
+  const result = await t.throws(defaultTopicTriggerHelper.fetch());
   result.should.deep.equal(error);
 });
 
@@ -66,21 +66,21 @@ test('getAll returns allDefaultTopicTriggers cache if set', async () => {
   const cacheResult = [firstDefaultTopicTrigger, secondDefaultTopicTrigger];
   sandbox.stub(helpers.cache.defaultTopicTriggers, 'get')
     .returns(Promise.resolve(cacheResult));
-  sandbox.stub(defaultTopicTriggerHelper, 'fetchAll')
+  sandbox.stub(defaultTopicTriggerHelper, 'fetch')
     .returns(Promise.resolve([]));
 
   const result = await defaultTopicTriggerHelper.getAll();
   helpers.cache.defaultTopicTriggers.get
     .should.have.been.calledWith(config.allDefaultTopicTriggersCacheKey);
-  defaultTopicTriggerHelper.fetchAll.should.not.have.been.called;
+  defaultTopicTriggerHelper.fetch.should.not.have.been.called;
   result.should.deep.equal(cacheResult);
 });
 
-test('getAll returns fetchAll results if cache not set', async () => {
+test('getAll returns fetch results if cache not set', async () => {
   const fetchResult = [firstDefaultTopicTrigger, secondDefaultTopicTrigger];
   sandbox.stub(helpers.cache.defaultTopicTriggers, 'get')
     .returns(Promise.resolve(null));
-  sandbox.stub(defaultTopicTriggerHelper, 'fetchAll')
+  sandbox.stub(defaultTopicTriggerHelper, 'fetch')
     .returns(Promise.resolve(fetchResult));
   sandbox.stub(helpers.cache.topics, 'set')
     .returns(Promise.resolve(fetchResult));
@@ -88,7 +88,7 @@ test('getAll returns fetchAll results if cache not set', async () => {
   const result = await defaultTopicTriggerHelper.getAll();
   helpers.cache.defaultTopicTriggers.get
     .should.have.been.calledWith(config.allDefaultTopicTriggersCacheKey);
-  defaultTopicTriggerHelper.fetchAll.should.have.been.called;
+  defaultTopicTriggerHelper.fetch.should.have.been.called;
   result.should.deep.equal(fetchResult);
 });
 

--- a/test/lib/lib-helpers/defaultTopicTrigger.test.js
+++ b/test/lib/lib-helpers/defaultTopicTrigger.test.js
@@ -33,7 +33,7 @@ test.afterEach(() => {
 // fetchAll
 test('fetchAll returns contentful.fetchByContentTypes parsed as defaultTopicTrigger objects', async () => {
   sandbox.stub(contentful, 'fetchByContentTypes')
-    .returns(Promise.resolve([firstEntry, secondEntry]));
+    .returns(Promise.resolve({ items: [firstEntry, secondEntry] }));
   sandbox.stub(defaultTopicTriggerHelper, 'parseDefaultTopicTriggerFromContentfulEntry')
     .onCall(0)
     .returns(firstDefaultTopicTrigger)

--- a/test/lib/lib-helpers/defaultTopicTrigger.test.js
+++ b/test/lib/lib-helpers/defaultTopicTrigger.test.js
@@ -8,6 +8,7 @@ const sinonChai = require('sinon-chai');
 const sinon = require('sinon');
 
 const contentful = require('../../../lib/contentful');
+const stubs = require('../../utils/stubs');
 const helpers = require('../../../lib/helpers');
 const config = require('../../../config/lib/helpers/defaultTopicTrigger');
 const defaultTopicTriggerContentfulFactory = require('../../utils/factories/contentful/defaultTopicTrigger');
@@ -32,8 +33,10 @@ test.afterEach(() => {
 
 // fetch
 test('fetch returns contentful.fetchByContentTypes parsed as defaultTopicTrigger objects', async () => {
+  const entries = [firstEntry, secondEntry];
+  const fetchEntriesResult = stubs.contentful.getFetchByContentTypesResultWithArray(entries);
   sandbox.stub(contentful, 'fetchByContentTypes')
-    .returns(Promise.resolve({ items: [firstEntry, secondEntry] }));
+    .returns(Promise.resolve(fetchEntriesResult));
   sandbox.stub(defaultTopicTriggerHelper, 'parseDefaultTopicTriggerFromContentfulEntry')
     .onCall(0)
     .returns(firstDefaultTopicTrigger)

--- a/test/lib/lib-helpers/response.test.js
+++ b/test/lib/lib-helpers/response.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const test = require('ava');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const sinon = require('sinon');
+const httpMocks = require('node-mocks-http');
+
+const stubs = require('../../utils/stubs');
+
+// Module to test
+const responseHelper = require('../../../lib/helpers/response');
+
+chai.should();
+chai.use(sinonChai);
+
+const data = { id: stubs.getContentfulId() };
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  t.context.res = httpMocks.createResponse();
+  sandbox.spy(t.context.res, 'send');
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+// sendData
+test('sendData passes object with data property to res.send', (t) => {
+  responseHelper.sendData(t.context.res, data);
+  t.context.res.send.should.have.been.calledWith({ data });
+});
+
+// sendDataAndMeta
+test('sendDataAndMeta passes object with data and meta properties to res.send', (t) => {
+  const meta = {
+    pagination: {
+      total: 240,
+    },
+  };
+  responseHelper.sendDataAndMeta(t.context.res, data, meta);
+  t.context.res.send.should.have.been.calledWith({ data, meta });
+});

--- a/test/lib/lib-helpers/response.test.js
+++ b/test/lib/lib-helpers/response.test.js
@@ -6,6 +6,7 @@ const sinonChai = require('sinon-chai');
 const sinon = require('sinon');
 const httpMocks = require('node-mocks-http');
 
+const utilHelper = require('../../../lib/helpers/util');
 const stubs = require('../../utils/stubs');
 
 // Module to test
@@ -34,13 +35,23 @@ test('sendData passes object with data property to res.send', (t) => {
   t.context.res.send.should.have.been.calledWith({ data });
 });
 
-// sendDataAndMeta
-test('sendDataAndMeta passes object with data and meta properties to res.send', (t) => {
+// sendIndexData
+test('sendIndexData calls res.send with data arg and given meta arg if exists', (t) => {
   const meta = {
     pagination: {
       total: 240,
     },
   };
-  responseHelper.sendDataAndMeta(t.context.res, data, meta);
+  responseHelper.sendIndexData(t.context.res, data, meta);
   t.context.res.send.should.have.been.calledWith({ data, meta });
+});
+
+// sendIndexData
+test('sendIndexData calls res.send with data arg and util.getMeta if meta undefined', (t) => {
+  const stubMeta = { total: data.length };
+  sandbox.stub(utilHelper, 'getMeta')
+    .returns(stubMeta);
+  responseHelper.sendIndexData(t.context.res, data);
+  utilHelper.getMeta.should.have.been.calledWith(data.length);
+  t.context.res.send.should.have.been.calledWith({ data, meta: stubMeta });
 });

--- a/test/lib/lib-helpers/topic.test.js
+++ b/test/lib/lib-helpers/topic.test.js
@@ -35,23 +35,23 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
-// fetchAll
-test('fetchAll returns contentful.fetchByContentTypes parsed as topic objects', async () => {
+// fetch
+test('fetch returns contentful.fetchByContentTypes parsed as topic objects', async () => {
   const fetchTopicsEntriesResult = { items: [textPostConfigFactory.getValidTextPostConfig()] };
   sandbox.stub(contentful, 'fetchByContentTypes')
     .returns(Promise.resolve(fetchTopicsEntriesResult));
   sandbox.stub(topicHelper, 'parseTopicFromContentfulEntry')
     .returns(Promise.resolve(topic));
 
-  const result = await topicHelper.fetchAll();
-  contentful.fetchByContentTypes.should.have.been.calledWith(config.topicContentTypes);
+  const result = await topicHelper.fetch();
+  contentful.fetchByContentTypes.should.have.been.calledWith(config.topicContentTypes, {});
   fetchTopicsEntriesResult.items.forEach((item) => {
     topicHelper.parseTopicFromContentfulEntry.should.have.been.calledWith(item);
   });
   result.should.deep.equal([topic]);
 });
 
-test('fetchAll throws if contentful.fetchByContentTypes fails', async (t) => {
+test('fetch throws if contentful.fetchByContentTypes fails', async (t) => {
   const error = new Error('epic fail');
   sandbox.stub(contentful, 'fetchByContentTypes')
     .returns(Promise.reject(error));
@@ -59,7 +59,7 @@ test('fetchAll throws if contentful.fetchByContentTypes fails', async (t) => {
     .returns(Promise.resolve(topic));
 
 
-  const result = await t.throws(topicHelper.fetchAll());
+  const result = await t.throws(topicHelper.fetch());
   result.should.deep.equal(error);
 });
 
@@ -83,28 +83,28 @@ test('getAll returns allTopics cache if set', async () => {
   const allTopicsCacheResult = [{ id: '132' }];
   sandbox.stub(helpers.cache.topics, 'get')
     .returns(Promise.resolve(allTopicsCacheResult));
-  sandbox.stub(topicHelper, 'fetchAll')
+  sandbox.stub(topicHelper, 'fetch')
     .returns(Promise.resolve(allTopicsCacheResult));
 
 
   const result = await topicHelper.getAll();
   helpers.cache.topics.get.should.have.been.calledWith(config.allTopicsCacheKey);
-  topicHelper.fetchAll.should.not.have.been.called;
+  topicHelper.fetch.should.not.have.been.called;
   result.should.deep.equal(allTopicsCacheResult);
 });
 
-test('getAll returns fetchAll results if cache not set', async () => {
+test('getAll returns fetch results if cache not set', async () => {
   const allTopics = [{ id: '132' }];
   sandbox.stub(helpers.cache.topics, 'get')
     .returns(Promise.resolve(null));
-  sandbox.stub(topicHelper, 'fetchAll')
+  sandbox.stub(topicHelper, 'fetch')
     .returns(Promise.resolve(allTopics));
   sandbox.stub(helpers.cache.topics, 'set')
     .returns(Promise.resolve(allTopics));
 
   const result = await topicHelper.getAll();
   helpers.cache.topics.get.should.have.been.calledWith(config.allTopicsCacheKey);
-  topicHelper.fetchAll.should.have.been.called;
+  topicHelper.fetch.should.have.been.called;
   result.should.deep.equal(allTopics);
 });
 

--- a/test/lib/lib-helpers/topic.test.js
+++ b/test/lib/lib-helpers/topic.test.js
@@ -37,16 +37,17 @@ test.afterEach(() => {
 
 // fetch
 test('fetch returns contentful.fetchByContentTypes parsed as topic objects', async () => {
-  const fetchTopicsEntriesResult = { items: [textPostConfigFactory.getValidTextPostConfig()] };
+  const entries = [textPostConfigFactory.getValidTextPostConfig()];
+  const fetchEntriesResult = stubs.contentful.getFetchByContentTypesResultWithArray(entries);
   sandbox.stub(contentful, 'fetchByContentTypes')
-    .returns(Promise.resolve(fetchTopicsEntriesResult));
+    .returns(Promise.resolve(fetchEntriesResult));
   sandbox.stub(topicHelper, 'parseTopicFromContentfulEntry')
     .returns(Promise.resolve(topic));
 
   const result = await topicHelper.fetch();
   contentful.fetchByContentTypes.should.have.been.calledWith(config.topicContentTypes, {});
-  fetchTopicsEntriesResult.items.forEach((item) => {
-    topicHelper.parseTopicFromContentfulEntry.should.have.been.calledWith(item);
+  entries.forEach((entry) => {
+    topicHelper.parseTopicFromContentfulEntry.should.have.been.calledWith(entry);
   });
   result.data.should.deep.equal([topic]);
 });

--- a/test/lib/lib-helpers/topic.test.js
+++ b/test/lib/lib-helpers/topic.test.js
@@ -48,7 +48,7 @@ test('fetch returns contentful.fetchByContentTypes parsed as topic objects', asy
   fetchTopicsEntriesResult.items.forEach((item) => {
     topicHelper.parseTopicFromContentfulEntry.should.have.been.calledWith(item);
   });
-  result.should.deep.equal([topic]);
+  result.data.should.deep.equal([topic]);
 });
 
 test('fetch throws if contentful.fetchByContentTypes fails', async (t) => {
@@ -98,7 +98,7 @@ test('getAll returns fetch results if cache not set', async () => {
   sandbox.stub(helpers.cache.topics, 'get')
     .returns(Promise.resolve(null));
   sandbox.stub(topicHelper, 'fetch')
-    .returns(Promise.resolve(allTopics));
+    .returns(Promise.resolve({ data: allTopics }));
   sandbox.stub(helpers.cache.topics, 'set')
     .returns(Promise.resolve(allTopics));
 

--- a/test/lib/lib-helpers/topic.test.js
+++ b/test/lib/lib-helpers/topic.test.js
@@ -37,7 +37,7 @@ test.afterEach(() => {
 
 // fetchAll
 test('fetchAll returns contentful.fetchByContentTypes parsed as topic objects', async () => {
-  const fetchTopicsEntriesResult = [{ id: '132' }];
+  const fetchTopicsEntriesResult = { items: [textPostConfigFactory.getValidTextPostConfig()] };
   sandbox.stub(contentful, 'fetchByContentTypes')
     .returns(Promise.resolve(fetchTopicsEntriesResult));
   sandbox.stub(topicHelper, 'parseTopicFromContentfulEntry')
@@ -45,7 +45,7 @@ test('fetchAll returns contentful.fetchByContentTypes parsed as topic objects', 
 
   const result = await topicHelper.fetchAll();
   contentful.fetchByContentTypes.should.have.been.calledWith(config.topicContentTypes);
-  fetchTopicsEntriesResult.forEach((item) => {
+  fetchTopicsEntriesResult.items.forEach((item) => {
     topicHelper.parseTopicFromContentfulEntry.should.have.been.calledWith(item);
   });
   result.should.deep.equal([topic]);

--- a/test/lib/lib-helpers/util.test.js
+++ b/test/lib/lib-helpers/util.test.js
@@ -17,7 +17,7 @@ const stubs = require('../../utils/stubs');
 const config = require('../../../config/lib/helpers/util');
 
 // Module to test
-const reportbackHelper = require('../../../lib/helpers/util');
+const utilHelper = require('../../../lib/helpers/util');
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -43,42 +43,42 @@ test.afterEach(() => {
 // isValidQuantity
 test('isValidQuantity() validations', () => {
   // non decimal number should pass
-  reportbackHelper.isValidQuantity('1').should.be.true;
-  reportbackHelper.isValidQuantity(' 1').should.be.true;
-  reportbackHelper.isValidQuantity(' 1 ').should.be.true;
+  utilHelper.isValidQuantity('1').should.be.true;
+  utilHelper.isValidQuantity(' 1').should.be.true;
+  utilHelper.isValidQuantity(' 1 ').should.be.true;
   // decimal number should not pass
-  reportbackHelper.isValidQuantity('1.1').should.be.false;
-  reportbackHelper.isValidQuantity(' 1.1').should.be.false;
-  reportbackHelper.isValidQuantity(' 1.1 ').should.be.false;
-  reportbackHelper.isValidQuantity(' 0.9 ').should.be.false;
+  utilHelper.isValidQuantity('1.1').should.be.false;
+  utilHelper.isValidQuantity(' 1.1').should.be.false;
+  utilHelper.isValidQuantity(' 1.1 ').should.be.false;
+  utilHelper.isValidQuantity(' 0.9 ').should.be.false;
   // any text should not pass
-  reportbackHelper.isValidQuantity('a').should.be.false;
-  reportbackHelper.isValidQuantity(' 1a').should.be.false;
-  reportbackHelper.isValidQuantity('1,').should.be.false;
-  reportbackHelper.isValidQuantity('1 hundred').should.be.false;
+  utilHelper.isValidQuantity('a').should.be.false;
+  utilHelper.isValidQuantity(' 1a').should.be.false;
+  utilHelper.isValidQuantity('1,').should.be.false;
+  utilHelper.isValidQuantity('1 hundred').should.be.false;
 });
 
 // isValidText
 test('isValidText() validations', () => {
   // Text can't be empty
-  reportbackHelper.isValidText('').should.be.false;
-  reportbackHelper.isValidText('       ').should.be.false;
+  utilHelper.isValidText('').should.be.false;
+  utilHelper.isValidText('       ').should.be.false;
   // Text must meet length requirements
-  reportbackHelper.isValidText(stubs.getRandomString(config.minTextLength + 1)).should.be.true;
-  reportbackHelper.isValidText(stubs.getRandomString(config.minTextLength)).should.be.false;
+  utilHelper.isValidText(stubs.getRandomString(config.minTextLength + 1)).should.be.true;
+  utilHelper.isValidText(stubs.getRandomString(config.minTextLength)).should.be.false;
 });
 
 // trimText
 test('trimText() validations', () => {
   // It should trim spaces out of text
   const text1 = stubs.getRandomString();
-  reportbackHelper.trimText(`   ${text1}   `).should.be.equal(text1);
+  utilHelper.trimText(`   ${text1}   `).should.be.equal(text1);
   // If longer that maxTextLength it should ellipsify
   const text2 = stubs.getRandomString(config.maxTextLength + 10);
-  const result2 = reportbackHelper.trimText(text2);
+  const result2 = utilHelper.trimText(text2);
   result2.indexOf(config.ellipsis).should.be.equal(result2.length - config.ellipsis.length);
   // Text shouldn't be longer than 255|maxTextLength
   const text3 = stubs.getRandomString(config.maxTextLength + 100);
-  const result3 = reportbackHelper.trimText(text3);
+  const result3 = utilHelper.trimText(text3);
   result3.length.should.be.equal(config.maxTextLength);
 });

--- a/test/lib/lib-helpers/util.test.js
+++ b/test/lib/lib-helpers/util.test.js
@@ -40,6 +40,17 @@ test.afterEach(() => {
  * Tests
  */
 
+// getMeta
+test('getMeta returns an object with a pagination property', () => {
+  const total = 200;
+  const skip = 10;
+  const limit = 30;
+  const result = utilHelper.getMeta(total, skip, limit);
+  result.pagination.total.should.equal(total);
+  result.pagination.skip.should.equal(skip);
+  result.pagination.limit.should.equal(limit);
+});
+
 // isValidQuantity
 test('isValidQuantity() validations', () => {
   // non decimal number should pass

--- a/test/lib/middleware/broadcasts/index/broadcasts-get.test.js
+++ b/test/lib/middleware/broadcasts/index/broadcasts-get.test.js
@@ -33,33 +33,31 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('getBroadcasts should send helpers.broadcast.fetchAll result', async (t) => {
+test('getBroadcasts should send helpers.broadcast.fetch result', async (t) => {
   const next = sinon.stub();
   const middleware = getBroadcasts();
   const firstBroadcast = broadcastFactory.getValidCampaignBroadcast();
   const secondBroadcast = broadcastFactory.getValidCampaignBroadcast();
-  sandbox.stub(helpers.broadcast, 'fetchAll')
-    .returns(Promise.resolve([firstBroadcast, secondBroadcast]));
+  sandbox.stub(helpers.broadcast, 'fetch')
+    .returns(Promise.resolve({ data: [firstBroadcast, secondBroadcast] }));
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  helpers.broadcast.fetchAll.should.have.been.called;
-  t.context.req.data[0].name.should.equal(firstBroadcast.name);
-  t.context.req.data[1].name.should.equal(secondBroadcast.name);
+  helpers.broadcast.fetch.should.have.been.called;
   t.context.res.send.should.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('getBroadcasts should send errorResponse if helpers.broadcast.getAll fails', async (t) => {
+test('getBroadcasts should send errorResponse if helpers.broadcast.fetch fails', async (t) => {
   const next = sinon.stub();
   const middleware = getBroadcasts();
   const error = new Error('o noes');
-  sandbox.stub(helpers.broadcast, 'fetchAll')
+  sandbox.stub(helpers.broadcast, 'fetch')
     .returns(Promise.reject(error));
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  helpers.broadcast.fetchAll.should.have.been.called;
+  helpers.broadcast.fetch.should.have.been.called;
   t.context.res.send.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
 });

--- a/test/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.test.js
+++ b/test/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.test.js
@@ -28,9 +28,10 @@ const sandbox = sinon.sandbox.create();
 test.beforeEach((t) => {
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);
+  sandbox.stub(helpers.response, 'sendIndexData')
+    .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
   t.context.res = httpMocks.createResponse();
-  sandbox.spy(t.context.res, 'send');
 });
 
 test.afterEach((t) => {
@@ -47,7 +48,8 @@ test('getDefaultTopicTriggers should send helpers.defaultTopicTrigger.getAll res
   // test
   await middleware(t.context.req, t.context.res, next);
   helpers.defaultTopicTrigger.getAll.should.have.been.called;
-  t.context.res.send.should.have.been.called;
+  helpers.response.sendIndexData
+    .should.have.been.calledWith(t.context.res, defaultTopicTriggerStubs);
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
@@ -62,6 +64,6 @@ test('getDefaultTopicTriggers should send errorResponse if helpers.defaultTopicT
   // test
   await middleware(t.context.req, t.context.res, next);
   helpers.defaultTopicTrigger.getAll.should.have.been.called;
-  t.context.res.send.should.not.have.been.called;
+  helpers.response.sendIndexData.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
 });

--- a/test/lib/middleware/topics/index/topics-get.test.js
+++ b/test/lib/middleware/topics/index/topics-get.test.js
@@ -11,7 +11,6 @@ const underscore = require('underscore');
 
 const stubs = require('../../../../utils/stubs');
 const helpers = require('../../../../../lib/helpers');
-const defaultTopicTriggerFactory = require('../../../../utils/factories/defaultTopicTrigger');
 const topicFactory = require('../../../../utils/factories/topic');
 
 chai.should();
@@ -25,9 +24,10 @@ const sandbox = sinon.sandbox.create();
 test.beforeEach((t) => {
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);
+  sandbox.stub(helpers.response, 'sendIndexData')
+    .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
   t.context.res = httpMocks.createResponse();
-  sandbox.spy(t.context.res, 'send');
 });
 
 test.afterEach((t) => {
@@ -41,23 +41,25 @@ test('getTopics should send helpers.topic.fetch result', async (t) => {
   const triggers = [stubs.getRandomWord()];
   const firstTopic = topicFactory.getValidTopic();
   const secondTopic = topicFactory.getValidTopic();
+  const topics = [firstTopic, secondTopic];
+  const fetchResult = stubs.contentful.getFetchByContentTypesResultWithArray(topics);
   sandbox.stub(helpers.topic, 'fetch')
-    .returns(Promise.resolve({ data: [firstTopic, secondTopic] }));
+    .returns(Promise.resolve(fetchResult));
   sandbox.stub(helpers.defaultTopicTrigger, 'getByTopicId')
-    .returns(Promise.resolve(defaultTopicTriggerFactory.getValidDefaultTopicTriggerWithTopic()));
+    .returns(Promise.resolve(fetchResult));
   sandbox.stub(helpers.defaultTopicTrigger, 'getTriggersFromDefaultTopicTriggers')
     .returns(triggers);
+  const queryParams = { skip: 20 };
+  t.context.req.query = queryParams;
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  helpers.topic.fetch.should.have.been.called;
+  helpers.topic.fetch.should.have.been.calledWith(queryParams);
   helpers.defaultTopicTrigger.getByTopicId.should.have.been.calledWith(firstTopic.id);
   helpers.defaultTopicTrigger.getByTopicId.should.have.been.calledWith(secondTopic.id);
-  t.context.req.data[0].name.should.equal(firstTopic.name);
-  t.context.req.data[1].name.should.equal(secondTopic.name);
-  t.context.req.data[0].triggers.should.equal(triggers);
-  t.context.req.data[1].triggers.should.equal(triggers);
-  t.context.res.send.should.have.been.called;
+
+  helpers.response.sendIndexData
+    .should.have.been.calledWith(t.context.res, fetchResult.data, fetchResult.meta);
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
@@ -71,6 +73,6 @@ test('getTopics should send errorResponse if helpers.topic.fetch fails', async (
   // test
   await middleware(t.context.req, t.context.res, next);
   helpers.topic.fetch.should.have.been.called;
-  t.context.res.send.should.not.have.been.called;
+  helpers.response.sendIndexData.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
 });

--- a/test/lib/middleware/topics/index/topics-get.test.js
+++ b/test/lib/middleware/topics/index/topics-get.test.js
@@ -35,14 +35,14 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('getTopics should send helpers.topic.getAll result', async (t) => {
+test('getTopics should send helpers.topic.fetch result', async (t) => {
   const next = sinon.stub();
   const middleware = getTopics();
   const triggers = [stubs.getRandomWord()];
   const firstTopic = topicFactory.getValidTopic();
   const secondTopic = topicFactory.getValidTopic();
-  sandbox.stub(helpers.topic, 'getAll')
-    .returns(Promise.resolve([firstTopic, secondTopic]));
+  sandbox.stub(helpers.topic, 'fetch')
+    .returns(Promise.resolve({ data: [firstTopic, secondTopic] }));
   sandbox.stub(helpers.defaultTopicTrigger, 'getByTopicId')
     .returns(Promise.resolve(defaultTopicTriggerFactory.getValidDefaultTopicTriggerWithTopic()));
   sandbox.stub(helpers.defaultTopicTrigger, 'getTriggersFromDefaultTopicTriggers')
@@ -50,7 +50,7 @@ test('getTopics should send helpers.topic.getAll result', async (t) => {
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  helpers.topic.getAll.should.have.been.called;
+  helpers.topic.fetch.should.have.been.called;
   helpers.defaultTopicTrigger.getByTopicId.should.have.been.calledWith(firstTopic.id);
   helpers.defaultTopicTrigger.getByTopicId.should.have.been.calledWith(secondTopic.id);
   t.context.req.data[0].name.should.equal(firstTopic.name);
@@ -61,16 +61,16 @@ test('getTopics should send helpers.topic.getAll result', async (t) => {
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('getTopics should send errorResponse if helpers.topic.getAll fails', async (t) => {
+test('getTopics should send errorResponse if helpers.topic.fetch fails', async (t) => {
   const next = sinon.stub();
   const middleware = getTopics();
   const error = new Error('o noes');
-  sandbox.stub(helpers.topic, 'getAll')
+  sandbox.stub(helpers.topic, 'fetch')
     .returns(Promise.reject(error));
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  helpers.topic.getAll.should.have.been.called;
+  helpers.topic.fetch.should.have.been.called;
   t.context.res.send.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
 });

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -34,6 +34,19 @@ function getBroadcastName() {
 }
 
 /**
+ * @param {Array} data
+ * @return {Object}
+ */
+function getFetchByContentTypesResultWithArray(data) {
+  return {
+    meta: {
+      total: data.length,
+    },
+    data,
+  };
+}
+
+/**
  * @return {String}
  */
 function getRandomWord() {
@@ -260,6 +273,7 @@ module.exports = {
     return msg;
   },
   contentful: {
+    getFetchByContentTypesResultWithArray,
     getAllTemplatesForCampaignId: function getAllTemplatesForCampaignId() {
       return module.exports.getJSONstub('all-campaign-fields');
     },


### PR DESCRIPTION
#### What's this PR do?
Adds a `meta` object property to the result in addition to the `data` array property for all index endpoints

* Adds support for a `skip` query parameter to `GET /broadcasts` and `GET /topics`.

* No longer caches the `GET /topics` index query per https://github.com/DoSomething/gambit-conversations/pull/371. Eventually we'll accumulate enough topics that we'll want to page through results... caching pages of results isn't required and adds additional complexity for something we don't need.

#### How should this be reviewed?
Verify that passing `skip` query parameters to the `GET /broadcasts` and `GET /topics` endpoints.
 
#### Any background context you want to provide?
We still need a cached list of all topics to easily find topics by campaign.. but ideally this should get refactored by creating separate `contentful.fetch` functions to make Contentful queries that find topics by the nested `campaignId` field. I didn't go this route at first because we can't execute a single Contentful query to find by fields over multiple content types, which we need to find topics  by campaign id. An appealing alternative to making the multiple Contentful requests per content type is looking into moving these endpoints into [GraphQL](https://github.com/dosomething/graphql) to make it easier to link entities.  

#### Relevant tickets
https://www.pivotaltracker.com/story/show/158080999

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
