### PR TITLE
Fixes bug in GET /broadcasts response for draft entries without a broadcast reference

### DIFF
--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -65,13 +65,15 @@ function getById(broadcastId, resetCache = false) {
  * @return {Object}
  */
 function parseBroadcastInfoFromContentfulEntry(contentfulEntry) {
-  return {
+  const result = {
     id: contentful.getContentfulIdFromContentfulEntry(contentfulEntry),
     name: contentful.getNameTextFromContentfulEntry(contentfulEntry),
     type: contentful.getContentTypeFromContentfulEntry(contentfulEntry),
     createdAt: contentfulEntry.sys.createdAt,
     updatedAt: contentfulEntry.sys.updatedAt,
   };
+  logger.debug('parseBroadcastInfoFromContentfulEntry', { result });
+  return result;
 }
 
 /**
@@ -134,6 +136,9 @@ function parseLegacyBroadcastFromContentfulEntry(contentfulEntry) {
  */
 function parseBroadcastMessageFromContentfulEntryAndTemplateName(contentfulEntry, templateName) {
   const broadcastMessageEntry = contentfulEntry.fields.broadcast;
+  if (!broadcastMessageEntry) {
+    return null;
+  }
   return helpers.contentfulEntry
     .getMessageTemplateFromContentfulEntryAndTemplateName(broadcastMessageEntry, templateName);
 }

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -10,6 +10,7 @@ const sinon = require('sinon');
 const contentful = require('../../../lib/contentful');
 const helpers = require('../../../lib/helpers');
 const stubs = require('../../utils/stubs');
+const autoReplyBroadcastEntryFactory = require('../../utils/factories/contentful/autoReplyBroadcast');
 const broadcastEntryFactory = require('../../utils/factories/contentful/broadcast');
 const broadcastFactory = require('../../utils/factories/broadcast');
 
@@ -135,6 +136,18 @@ test('parseBroadcastMessageFromContentfulEntryAndTemplateName returns null if co
   const result = broadcastHelper
     .parseBroadcastMessageFromContentfulEntryAndTemplateName(broadcastEntry);
   t.is(result, null);
+});
+
+test('parseBroadcastMessageFromContentfulEntryAndTemplateName returns getMessageTemplateFromContentfulEntryAndTemplateName', () => {
+  const autoReplyBroadcast = autoReplyBroadcastEntryFactory.getValidAutoReplyBroadcast();
+  const templateName = stubs.getRandomWord();
+  const messageTemplate = { text: stubs.getRandomMessageText(), template: templateName };
+  sandbox.stub(helpers.contentfulEntry, 'getMessageTemplateFromContentfulEntryAndTemplateName')
+    .returns(messageTemplate);
+
+  const result = broadcastHelper
+    .parseBroadcastMessageFromContentfulEntryAndTemplateName(autoReplyBroadcast, templateName);
+  result.should.equal(messageTemplate);
 });
 
 // parseLegacyBroadcastFromContentfulEntry

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -130,6 +130,13 @@ test('getById returns fetchById if resetCache arg is true', async () => {
   result.should.deep.equal(broadcast);
 });
 
+// parseBroadcastMessageFromContentfulEntryAndTemplateName
+test('parseBroadcastMessageFromContentfulEntryAndTemplateName returns null if contentfulEntry does not have broadcast set', (t) => {
+  const result = broadcastHelper
+    .parseBroadcastMessageFromContentfulEntryAndTemplateName(broadcastEntry);
+  t.is(result, null);
+});
+
 // parseLegacyBroadcastFromContentfulEntry
 test('parseLegacyBroadcastFromContentfulEntry returns an object with null topic if campaign broadcast', async (t) => {
   sandbox.stub(contentful, 'getAttachmentsFromContentfulEntry')

--- a/test/utils/factories/contentful/autoReplyBroadcast.js
+++ b/test/utils/factories/contentful/autoReplyBroadcast.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const stubs = require('../../stubs');
+const messageFactory = require('./message');
+
+function getValidAutoReplyBroadcast() {
+  const data = {
+    sys: {
+      id: stubs.getContentfulId(),
+      contentType: {
+        sys: {
+          id: 'autoReplyBroadcast',
+        },
+      },
+    },
+    fields: {
+      broadcast: messageFactory.getValidMessage(),
+      autoReply: messageFactory.getValidMessage(),
+    },
+  };
+  return data;
+}
+
+module.exports = {
+  getValidAutoReplyBroadcast,
+};

--- a/test/utils/factories/contentful/message.js
+++ b/test/utils/factories/contentful/message.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const stubs = require('../../stubs');
+
+function getValidMessage() {
+  const data = {
+    sys: {
+      id: stubs.getContentfulId(),
+      contentType: {
+        sys: {
+          id: 'message',
+        },
+      },
+    },
+    fields: {
+      text: stubs.getRandomMessageText(),
+      attachments: [
+        {
+          sys: {
+            id: stubs.getContentfulId(),
+          },
+          fields: {
+            file: stubs.getAttachment(),
+          },
+        },
+      ],
+    },
+  };
+  return data;
+}
+
+module.exports = {
+  getValidMessage,
+};


### PR DESCRIPTION
#### What's this PR do?
Adds check for a `broadcast` field in the `parseBroadcastMessageFromContentfulEntryAndTemplateName` broadcast helper function, returning null if it doesn't exist. 

#### How should this be reviewed?
Create a draft `autoReplyBroadcast` entry without any fields. Verify that a `GET /broadcasts` query includes the entry, returning it with a null `message` property.

#### Any background context you want to provide?
This field is required, so this error wouldn't happen on production -- but does require us to check for its existence to avoid 500 errors in QA.

#### Relevant tickets
Fixes https://dosomething.slack.com/archives/C1V0M6RPE/p1533575475000182

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
