### PR TITLE
Consolidate content type helper configs into contentfulEntry config

### DIFF
--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -4,6 +4,7 @@ module.exports = {
   contentTypes: {
     askYesNo: {
       type: 'askYesNo',
+      broadcastable: true,
       templates: [
         'saidYes',
         'saidNo',
@@ -11,18 +12,23 @@ module.exports = {
         'autoReply',
       ],
     },
-    autoReplyBroadcast: {
-      type: 'autoReplyBroadcast',
+    autoReply: {
+      type: 'autoReply',
+      broadcastable: false,
       templates: [
         'autoReply',
       ],
     },
+    autoReplyBroadcast: {
+      type: 'autoReplyBroadcast',
+      broadcastable: true,
+    },
     // Ideally we'd backfill all legacy entries as their new types, but we likely can't change the
     // the type of a Contentful entry without changing its id (if that's the case - we'd need to
     // bulk update all documents in the Conversations messages DB)
-    legacy: {
+    legacyBroadcast: {
       type: 'broadcast',
-      templates: [],
+      broadcastable: true,
     },
   },
 };

--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -14,7 +14,6 @@ module.exports = {
     },
     autoReply: {
       type: 'autoReply',
-      broadcastable: false,
       templates: [
         'autoReply',
       ],
@@ -23,9 +22,8 @@ module.exports = {
       type: 'autoReplyBroadcast',
       broadcastable: true,
     },
-    externalPostConfig: {
-      type: 'externalPostConfig',
-      postType: 'external',
+    defaultTopicTrigger: {
+      type: 'defaultTopicTrigger',
     },
     message: {
       type: 'message',
@@ -38,9 +36,15 @@ module.exports = {
       type: 'textPostConfig',
       postType: 'text',
     },
+    // Legacy types:
     // Ideally we'd backfill all legacy entries as their new types, but we likely can't change the
     // the type of a Contentful entry without changing its id (if that's the case - we'd need to
     // bulk update all documents in the Conversations messages DB)
+    // This externalPostConfig type will deprecated by an autoReply:
+    externalPostConfig: {
+      type: 'externalPostConfig',
+      postType: 'external',
+    },
     legacyBroadcast: {
       type: 'broadcast',
       broadcastable: true,

--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -23,6 +23,21 @@ module.exports = {
       type: 'autoReplyBroadcast',
       broadcastable: true,
     },
+    externalPostConfig: {
+      type: 'externalPostConfig',
+      postType: 'external',
+    },
+    message: {
+      type: 'message',
+    },
+    photoPostConfig: {
+      type: 'photoPostConfig',
+      postType: 'photo',
+    },
+    textPostConfig: {
+      type: 'textPostConfig',
+      postType: 'text',
+    },
     // Ideally we'd backfill all legacy entries as their new types, but we likely can't change the
     // the type of a Contentful entry without changing its id (if that's the case - we'd need to
     // bulk update all documents in the Conversations messages DB)

--- a/config/lib/helpers/defaultTopicTrigger.js
+++ b/config/lib/helpers/defaultTopicTrigger.js
@@ -2,7 +2,4 @@
 
 module.exports = {
   allDefaultTopicTriggersCacheKey: 'all',
-  contentTypes: [
-    'defaultTopicTrigger',
-  ],
 };

--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -1,34 +1,5 @@
 'use strict';
 
-// @see documentation/endpoints/topics
-const contentTypes = {
-  askYesNo: {
-    type: 'askYesNo',
-    isBroadcast: true,
-    postType: null,
-  },
-  autoReply: {
-    type: 'autoReply',
-    isBroadcast: true,
-    postType: null,
-  },
-  externalPostConfig: {
-    type: 'externalPostConfig',
-    isBroadcast: false,
-    postType: 'external',
-  },
-  photoPostConfig: {
-    type: 'photoPostConfig',
-    isBroadcast: false,
-    postType: 'photo',
-  },
-  textPostConfig: {
-    type: 'textPostConfig',
-    isBroadcast: false,
-    postType: 'text',
-  },
-};
-
 const defaultText = {
   declined: 'Text MENU if you\'d like to find a different action to take.',
   invalidInput: 'Sorry, I didn\'t get that.',
@@ -49,7 +20,6 @@ const photoPostDefaultText = {
 
 module.exports = {
   allTopicsCacheKey: 'all',
-  contentTypes,
   defaultPostType: 'photo',
   /*
    * Maps each content type with a map of templateNames and its corresponding field name and

--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -7,8 +7,8 @@ const contentTypes = {
     isBroadcast: true,
     postType: null,
   },
-  autoReplyBroadcast: {
-    type: 'autoReplyBroadcast',
+  autoReply: {
+    type: 'autoReply',
     isBroadcast: true,
     postType: null,
   },

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -3,14 +3,13 @@
 const logger = require('winston');
 const contentful = require('../contentful');
 const helpers = require('../helpers');
-const config = require('../../config/lib/helpers/broadcast');
 
 /**
  * @return {Array}
  */
 function getContentTypes() {
-  const contentTypeConfigs = Object.values(config.contentTypes);
-  return contentTypeConfigs.map(contentTypeConfig => contentTypeConfig.type);
+  const configs = Object.values(helpers.contentfulEntry.getContentTypeConfigs());
+  return configs.filter(config => config.broadcastable).map(config => config.type);
 }
 
 /**
@@ -66,20 +65,16 @@ function getById(broadcastId, resetCache = false) {
  */
 function parseBroadcastFromContentfulEntry(contentfulEntry) {
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
-  const contentTypeConfigs = config.contentTypes;
-
   // A nice to have TODO is migrating all legacy broadcast entries into the respective new type, so
   // we can remove check and the function it calls entirely.
-  if (contentType === contentTypeConfigs.legacy.type) {
+  if (contentType === 'broadcast') {
     return module.exports.parseLegacyBroadcastFromContentfulEntry(contentfulEntry);
   }
 
   const data = helpers.contentfulEntry.getSummaryFromContentfulEntry(contentfulEntry);
   const message = module.exports
     .parseBroadcastMessageFromContentfulEntryAndTemplateName(contentfulEntry, contentType);
-  const fieldNames = contentTypeConfigs[contentType].templates;
-  const templates = module.exports
-    .parseTemplatesFromContentfulEntryAndFieldNames(contentfulEntry, fieldNames);
+  const templates = helpers.contentfulEntry.getMessageTemplatesFromContentfulEntry(contentfulEntry);
 
   return Promise.resolve(Object.assign(data, { message, templates }));
 }
@@ -132,28 +127,6 @@ function parseBroadcastMessageFromContentfulEntryAndTemplateName(contentfulEntry
     .getMessageTemplateFromContentfulEntryAndTemplateName(broadcastMessageEntry, templateName);
 }
 
-/**
- * @param {Object}
- * @param {String}
- * @return {Object}
- */
-function parseTemplatesFromContentfulEntryAndFieldNames(contentfulEntry, fieldNames) {
-  const data = {};
-  if (!contentfulEntry) {
-    return data;
-  }
-
-  fieldNames.forEach((fieldName) => {
-    const messageEntry = contentfulEntry.fields[fieldName];
-    if (!messageEntry) {
-      return;
-    }
-    data[fieldName] = helpers.contentfulEntry
-      .getMessageTemplateFromContentfulEntryAndTemplateName(messageEntry, fieldName);
-  });
-  return data;
-}
-
 module.exports = {
   fetch,
   fetchById,
@@ -162,5 +135,4 @@ module.exports = {
   parseBroadcastFromContentfulEntry,
   parseBroadcastMessageFromContentfulEntryAndTemplateName,
   parseLegacyBroadcastFromContentfulEntry,
-  parseTemplatesFromContentfulEntryAndFieldNames,
 };

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -67,7 +67,8 @@ function parseBroadcastFromContentfulEntry(contentfulEntry) {
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
   // A nice to have TODO is migrating all legacy broadcast entries into the respective new type, so
   // we can remove check and the function it calls entirely.
-  if (contentType === 'broadcast') {
+  const contentTypeConfigs = helpers.contentfulEntry.getContentTypeConfigs();
+  if (contentType === contentTypeConfigs.legacyBroadcast.type) {
     return module.exports.parseLegacyBroadcastFromContentfulEntry(contentfulEntry);
   }
 

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -106,6 +106,14 @@ function getMessageTemplatesFromContentfulEntry(contentfulEntry) {
  * @param {Object} contentfulEntry
  * @return {Boolean}
  */
+function isAutoReply(contentfulEntry) {
+  return contentful.isContentType(contentfulEntry, config.contentTypes.autoReply.type);
+}
+
+/**
+ * @param {Object} contentfulEntry
+ * @return {Boolean}
+ */
 function isDefaultTopicTrigger(contentfulEntry) {
   return contentful.isContentType(contentfulEntry, 'defaultTopicTrigger');
 }
@@ -115,7 +123,7 @@ function isDefaultTopicTrigger(contentfulEntry) {
  * @return {Boolean}
  */
 function isMessage(contentfulEntry) {
-  return contentful.isContentType(contentfulEntry, 'message');
+  return contentful.isContentType(contentfulEntry, config.contentTypes.message.type);
 }
 
 module.exports = {
@@ -124,6 +132,7 @@ module.exports = {
   getMessageTemplateFromContentfulEntryAndTemplateName,
   getMessageTemplatesFromContentfulEntry,
   getSummaryFromContentfulEntry,
+  isAutoReply,
   isDefaultTopicTrigger,
   isMessage,
   parseContentfulEntry,

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -96,7 +96,7 @@ function getMessageTemplatesFromContentfulEntry(contentfulEntry) {
     if (!messageEntry) {
       return;
     }
-    result[fieldName] = helpers.contentfulEntry
+    result[fieldName] = module.exports
       .getMessageTemplateFromContentfulEntryAndTemplateName(messageEntry, fieldName);
   });
   return result;

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -3,6 +3,14 @@
 const logger = require('winston');
 const contentful = require('../contentful');
 const helpers = require('../helpers');
+const config = require('../../config/lib/helpers/contentfulEntry');
+
+/**
+ * @return {Array}
+ */
+function getContentTypeConfigs() {
+  return config.contentTypes;
+}
 
 /**
  * @param {String} contentfulId
@@ -70,6 +78,31 @@ function getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, t
 }
 
 /**
+ * @param {Object}
+ * @param {String}
+ * @return {Object}
+ */
+function getMessageTemplatesFromContentfulEntry(contentfulEntry) {
+  const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
+  const fieldNames = config.contentTypes[contentType].templates;
+  const result = {};
+
+  if (!contentfulEntry || !fieldNames) {
+    return result;
+  }
+
+  fieldNames.forEach((fieldName) => {
+    const messageEntry = contentfulEntry.fields[fieldName];
+    if (!messageEntry) {
+      return;
+    }
+    result[fieldName] = helpers.contentfulEntry
+      .getMessageTemplateFromContentfulEntryAndTemplateName(messageEntry, fieldName);
+  });
+  return result;
+}
+
+/**
  * @param {Object} contentfulEntry
  * @return {Boolean}
  */
@@ -87,7 +120,9 @@ function isMessage(contentfulEntry) {
 
 module.exports = {
   getById,
+  getContentTypeConfigs,
   getMessageTemplateFromContentfulEntryAndTemplateName,
+  getMessageTemplatesFromContentfulEntry,
   getSummaryFromContentfulEntry,
   isDefaultTopicTrigger,
   isMessage,

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -114,6 +114,15 @@ function isAutoReply(contentfulEntry) {
  * @param {Object} contentfulEntry
  * @return {Boolean}
  */
+function isBroadcastable(contentfulEntry) {
+  const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
+  return config.contentTypes[contentType].broadcastable;
+}
+
+/**
+ * @param {Object} contentfulEntry
+ * @return {Boolean}
+ */
 function isDefaultTopicTrigger(contentfulEntry) {
   return contentful.isContentType(contentfulEntry, 'defaultTopicTrigger');
 }
@@ -133,6 +142,7 @@ module.exports = {
   getMessageTemplatesFromContentfulEntry,
   getSummaryFromContentfulEntry,
   isAutoReply,
+  isBroadcastable,
   isDefaultTopicTrigger,
   isMessage,
   parseContentfulEntry,

--- a/lib/helpers/defaultTopicTrigger.js
+++ b/lib/helpers/defaultTopicTrigger.js
@@ -11,7 +11,8 @@ const config = require('../../config/lib/helpers/defaultTopicTrigger');
  * @return {Array}
  */
 function getContentTypes() {
-  return config.contentTypes;
+  const configs = helpers.contentfulEntry.getContentTypeConfigs();
+  return [configs.defaultTopicTrigger.type];
 }
 
 /**

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -9,8 +9,14 @@ const config = require('../../config/lib/helpers/topic');
  * @return {Array}
  */
 function getContentTypes() {
-  const contentTypeConfigs = Object.values(config.contentTypes);
-  return contentTypeConfigs.map(contentTypeConfig => contentTypeConfig.type);
+  const configs = Object.values(helpers.contentfulEntry.getContentTypeConfigs());
+  // Return any configs that have templates set, or a postType.
+  // We'll eventually refactor this config to only check for existence of templates, with each item
+  // corresponding to a reference field to a message or changeTopicMessage entry, like how it does
+  // in an askYesNo or autoReply topic (vs a textPostConfig or photoPostConfig, where we're using
+  // text fields and the fieldName map defined in the topic helper config).
+  return configs.filter(typeConfig => typeConfig.templates || typeConfig.postType)
+    .map(typeConfig => typeConfig.type);
 }
 
 /**
@@ -155,16 +161,22 @@ function parseTemplateFromContentfulEntryAndTemplateName(contentfulEntry, templa
  * @param {Object} entry
  * @return {Object}
  */
-function parseTemplatesFromContentfulEntryAndCampaign(entry, campaign) {
+function parseTemplatesFromContentfulEntryAndCampaign(contentfulEntry, campaign) {
+  if (helpers.contentfulEntry.isAutoReply(contentfulEntry)) {
+    return helpers.contentfulEntry.getMessageTemplatesFromContentfulEntry(contentfulEntry);
+  }
+  const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
   const data = {};
-  const contentType = contentful.getContentTypeFromContentfulEntry(entry);
   const templateNames = Object.keys(config.templatesByContentType[contentType]);
   templateNames.forEach((templateName) => {
     data[templateName] = module.exports
-      .parseTemplateFromContentfulEntryAndTemplateName(entry, templateName);
-    data[templateName].rendered = helpers
+      .parseTemplateFromContentfulEntryAndTemplateName(contentfulEntry, templateName);
+    data[templateName].text = helpers
       .replacePhoenixCampaignVars(data[templateName].raw, campaign);
+    // TODO: Remove rendered property once Gambit Conversations references text.
+    data[templateName].rendered = data[templateName].text;
   });
+
   return data;
 }
 
@@ -173,7 +185,8 @@ function parseTemplatesFromContentfulEntryAndCampaign(entry, campaign) {
  * @return {String}
  */
 function getPostTypeFromContentType(contentType) {
-  return config.contentTypes[contentType].postType;
+  const contentTypeConfigs = helpers.contentfulEntry.getContentTypeConfigs();
+  return contentTypeConfigs[contentType].postType;
 }
 
 /**
@@ -184,9 +197,12 @@ function parseTopicFromContentfulEntry(contentfulEntry) {
   const topicId = contentful.getContentfulIdFromContentfulEntry(contentfulEntry);
   logger.debug('parseTopicFromContentfulEntry', { topicId });
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
-  if (config.contentTypes[contentType].isBroadcast) {
+  const contentTypeConfigs = helpers.contentfulEntry.getContentTypeConfigs();
+
+  if (contentTypeConfigs[contentType].broadcastable) {
     return helpers.broadcast.parseBroadcastFromContentfulEntry(contentfulEntry);
   }
+
   const data = {
     id: topicId,
     name: contentful.getNameTextFromContentfulEntry(contentfulEntry),

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -194,21 +194,14 @@ function getPostTypeFromContentType(contentType) {
  * @return {Promise}
  */
 function parseTopicFromContentfulEntry(contentfulEntry) {
-  const topicId = contentful.getContentfulIdFromContentfulEntry(contentfulEntry);
-  logger.debug('parseTopicFromContentfulEntry', { topicId });
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
-  const contentTypeConfigs = helpers.contentfulEntry.getContentTypeConfigs();
 
-  if (contentTypeConfigs[contentType].broadcastable) {
+  if (helpers.contentfulEntry.isBroadcastable(contentfulEntry)) {
     return helpers.broadcast.parseBroadcastFromContentfulEntry(contentfulEntry);
   }
 
-  const data = {
-    id: topicId,
-    name: contentful.getNameTextFromContentfulEntry(contentfulEntry),
-    type: contentType,
-    postType: module.exports.getPostTypeFromContentType(contentType),
-  };
+  const data = helpers.contentfulEntry.getSummaryFromContentfulEntry(contentfulEntry);
+  data.postType = module.exports.getPostTypeFromContentType(contentType);
   const campaignConfigEntry = contentfulEntry.fields.campaign;
   let promise = Promise.resolve(null);
   let campaignId;

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -10,6 +10,7 @@ const sinon = require('sinon');
 const contentful = require('../../../lib/contentful');
 const stubs = require('../../utils/stubs');
 const askYesNoEntryFactory = require('../../utils/factories/contentful/askYesNo');
+const messageFactory = require('../../utils/factories/contentful/message');
 
 // stubs
 const stubEntryDate = Date.now();
@@ -30,8 +31,6 @@ const sandbox = sinon.sandbox.create();
 test.beforeEach(() => {
   sandbox.stub(contentful, 'getContentfulIdFromContentfulEntry')
     .returns(stubEntryId);
-  sandbox.stub(contentful, 'getContentTypeFromContentfulEntry')
-    .returns(stubContentType);
   sandbox.stub(contentful, 'getNameTextFromContentfulEntry')
     .returns(stubNameText);
 });
@@ -42,6 +41,8 @@ test.afterEach(() => {
 
 // getSummaryFromContentfulEntry
 test('getSummaryFromContentfulEntry returns an object with name and type properties', () => {
+  sandbox.stub(contentful, 'getContentTypeFromContentfulEntry')
+    .returns(stubContentType);
   const result = contentfulEntryHelper.getSummaryFromContentfulEntry(stubEntry);
   result.id.should.equal(stubEntryId);
   result.type.should.equal(stubContentType);
@@ -50,34 +51,30 @@ test('getSummaryFromContentfulEntry returns an object with name and type propert
   result.updatedAt.should.equal(stubEntryDate);
 });
 
-// isDefaultTopicTrigger
-test('isDefaultTopicTrigger is truthy if contentful.isContentType', (t) => {
-  sandbox.stub(contentful, 'isContentType')
-    .returns(true);
-  t.truthy(contentfulEntryHelper.isDefaultTopicTrigger(stubEntry));
+// isBroadcastable
+test('isBroadcastable is returns whether contentType is broadcastable', (t) => {
+  const askYesNoEntry = askYesNoEntryFactory.getValidAskYesNo();
+  t.truthy(contentfulEntryHelper.isBroadcastable(askYesNoEntry));
+  const messageEntry = messageFactory.getValidMessage();
+  t.falsy(contentfulEntryHelper.isBroadcastable(messageEntry));
 });
 
+// isDefaultTopicTrigger
 test('isDefaultTopicTrigger is falsy if not contentful.isContentType', (t) => {
   sandbox.stub(contentful, 'isContentType')
     .returns(false);
   t.falsy(contentfulEntryHelper.isDefaultTopicTrigger(stubEntry));
 });
 
-// isMessage
-test('isMessage is truthy if contentful.isContentType', (t) => {
+test('isDefaultTopicTrigger is truthy if contentful.isContentType', (t) => {
   sandbox.stub(contentful, 'isContentType')
     .returns(true);
-  t.truthy(contentfulEntryHelper.isMessage(stubEntry));
+  t.truthy(contentfulEntryHelper.isDefaultTopicTrigger(stubEntry));
 });
 
-test('isMessage is falsy if not contentful.isContentType', (t) => {
-  sandbox.stub(contentful, 'isContentType')
-    .returns(false);
-  t.falsy(contentfulEntryHelper.isMessage(stubEntry));
-});
-
-test('isMessage returns false if not contentful.isContentType result with args entry and message ', (t) => {
-  sandbox.stub(contentful, 'isContentType')
-    .returns(false);
+// isMessage
+test('isMessage returns whether content type is message', (t) => {
+  const messageEntry = messageFactory.getValidMessage();
+  t.truthy(contentfulEntryHelper.isMessage(messageEntry));
   t.falsy(contentfulEntryHelper.isMessage(stubEntry));
 });

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -10,6 +10,7 @@ const sinon = require('sinon');
 const contentful = require('../../../lib/contentful');
 const stubs = require('../../utils/stubs');
 const askYesNoEntryFactory = require('../../utils/factories/contentful/askYesNo');
+const autoReplyFactory = require('../../utils/factories/contentful/autoReply');
 const messageFactory = require('../../utils/factories/contentful/message');
 
 // stubs
@@ -51,8 +52,16 @@ test('getSummaryFromContentfulEntry returns an object with name and type propert
   result.updatedAt.should.equal(stubEntryDate);
 });
 
+// isAutoReply
+test('isAutoReply  returns whether contentType is autoReply', (t) => {
+  const askYesNoEntry = askYesNoEntryFactory.getValidAskYesNo();
+  t.falsy(contentfulEntryHelper.isAutoReply(askYesNoEntry));
+  const autoReplyEntry = autoReplyFactory.getValidAutoReply();
+  t.truthy(contentfulEntryHelper.isAutoReply(autoReplyEntry));
+});
+
 // isBroadcastable
-test('isBroadcastable is returns whether contentType is broadcastable', (t) => {
+test('isBroadcastable returns whether contentType is broadcastable', (t) => {
   const askYesNoEntry = askYesNoEntryFactory.getValidAskYesNo();
   t.truthy(contentfulEntryHelper.isBroadcastable(askYesNoEntry));
   const messageEntry = messageFactory.getValidMessage();

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -63,7 +63,6 @@ test('isDefaultTopicTrigger is falsy if not contentful.isContentType', (t) => {
   t.falsy(contentfulEntryHelper.isDefaultTopicTrigger(stubEntry));
 });
 
-
 // isMessage
 test('isMessage is truthy if contentful.isContentType', (t) => {
   sandbox.stub(contentful, 'isContentType')

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -11,14 +11,16 @@ const contentful = require('../../../lib/contentful');
 const stubs = require('../../utils/stubs');
 const askYesNoEntryFactory = require('../../utils/factories/contentful/askYesNo');
 const autoReplyFactory = require('../../utils/factories/contentful/autoReply');
+const autoReplyBroadcastFactory = require('../../utils/factories/contentful/autoReplyBroadcast');
+const defaultTopicTriggerFactory = require('../../utils/factories/contentful/defaultTopicTrigger');
 const messageFactory = require('../../utils/factories/contentful/message');
 
 // stubs
-const stubEntryDate = Date.now();
-const stubEntry = askYesNoEntryFactory.getValidAskYesNo(stubEntryDate);
-const stubEntryId = stubs.getContentfulId();
-const stubContentType = stubs.getTopicContentType();
-const stubNameText = stubs.getBroadcastName();
+const askYesNoEntry = askYesNoEntryFactory.getValidAskYesNo();
+const autoReplyEntry = autoReplyFactory.getValidAutoReply();
+const autoReplyBroadcastEntry = autoReplyBroadcastFactory.getValidAutoReplyBroadcast();
+const defaultTopicTriggerEntry = defaultTopicTriggerFactory.getValidDefaultTopicTrigger();
+const messageEntry = messageFactory.getValidMessage();
 
 // Module to test
 const contentfulEntryHelper = require('../../../lib/helpers/contentfulEntry');
@@ -26,24 +28,34 @@ const contentfulEntryHelper = require('../../../lib/helpers/contentfulEntry');
 chai.should();
 chai.use(sinonChai);
 
-
 const sandbox = sinon.sandbox.create();
-
-test.beforeEach(() => {
-  sandbox.stub(contentful, 'getContentfulIdFromContentfulEntry')
-    .returns(stubEntryId);
-  sandbox.stub(contentful, 'getNameTextFromContentfulEntry')
-    .returns(stubNameText);
-});
 
 test.afterEach(() => {
   sandbox.restore();
 });
 
+// getMessageTemplatesFromContentfulEntry
+test('getMessageTemplatesFromContentfulEntry returns an object with templates values if content type config has templates', () => {
+  const result = contentfulEntryHelper.getMessageTemplatesFromContentfulEntry(autoReplyEntry);
+  result.autoReply.text.should.equal(autoReplyEntry.fields.autoReply.fields.text);
+});
+
+test('getMessageTemplatesFromContentfulEntry returns an empty object if content type config does not have templates', () => {
+  const result = contentfulEntryHelper
+    .getMessageTemplatesFromContentfulEntry(autoReplyBroadcastEntry);
+  result.should.deep.equal({});
+});
+
 // getSummaryFromContentfulEntry
 test('getSummaryFromContentfulEntry returns an object with name and type properties', () => {
+  const stubEntryDate = Date.now();
+  const stubEntry = askYesNoEntryFactory.getValidAskYesNo(stubEntryDate);
+  const stubEntryId = stubs.getContentfulId();
+  const stubContentType = stubs.getTopicContentType();
+  const stubNameText = stubs.getBroadcastName();
   sandbox.stub(contentful, 'getContentTypeFromContentfulEntry')
     .returns(stubContentType);
+
   const result = contentfulEntryHelper.getSummaryFromContentfulEntry(stubEntry);
   result.id.should.equal(stubEntryId);
   result.type.should.equal(stubContentType);
@@ -53,37 +65,25 @@ test('getSummaryFromContentfulEntry returns an object with name and type propert
 });
 
 // isAutoReply
-test('isAutoReply  returns whether contentType is autoReply', (t) => {
-  const askYesNoEntry = askYesNoEntryFactory.getValidAskYesNo();
+test('isAutoReply returns whether content type is autoReply', (t) => {
   t.falsy(contentfulEntryHelper.isAutoReply(askYesNoEntry));
-  const autoReplyEntry = autoReplyFactory.getValidAutoReply();
   t.truthy(contentfulEntryHelper.isAutoReply(autoReplyEntry));
 });
 
 // isBroadcastable
-test('isBroadcastable returns whether contentType is broadcastable', (t) => {
-  const askYesNoEntry = askYesNoEntryFactory.getValidAskYesNo();
+test('isBroadcastable returns whether content type is broadcastable', (t) => {
   t.truthy(contentfulEntryHelper.isBroadcastable(askYesNoEntry));
-  const messageEntry = messageFactory.getValidMessage();
   t.falsy(contentfulEntryHelper.isBroadcastable(messageEntry));
 });
 
 // isDefaultTopicTrigger
-test('isDefaultTopicTrigger is falsy if not contentful.isContentType', (t) => {
-  sandbox.stub(contentful, 'isContentType')
-    .returns(false);
-  t.falsy(contentfulEntryHelper.isDefaultTopicTrigger(stubEntry));
-});
-
-test('isDefaultTopicTrigger is truthy if contentful.isContentType', (t) => {
-  sandbox.stub(contentful, 'isContentType')
-    .returns(true);
-  t.truthy(contentfulEntryHelper.isDefaultTopicTrigger(stubEntry));
+test('isDefaultTopicTrigger returns whether content type is defaultTopicTrigger', (t) => {
+  t.truthy(contentfulEntryHelper.isDefaultTopicTrigger(defaultTopicTriggerEntry));
+  t.falsy(contentfulEntryHelper.isDefaultTopicTrigger(messageEntry));
 });
 
 // isMessage
 test('isMessage returns whether content type is message', (t) => {
-  const messageEntry = messageFactory.getValidMessage();
   t.truthy(contentfulEntryHelper.isMessage(messageEntry));
-  t.falsy(contentfulEntryHelper.isMessage(stubEntry));
+  t.falsy(contentfulEntryHelper.isMessage(autoReplyEntry));
 });

--- a/test/lib/lib-helpers/defaultTopicTrigger.test.js
+++ b/test/lib/lib-helpers/defaultTopicTrigger.test.js
@@ -31,10 +31,17 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
+test.afterEach(() => {
+  sandbox.restore();
+});
+
 // fetch
 test('fetch returns contentful.fetchByContentTypes parsed as defaultTopicTrigger objects', async () => {
   const entries = [firstEntry, secondEntry];
+  const types = ['defaultTopicTrigger'];
   const fetchEntriesResult = stubs.contentful.getFetchByContentTypesResultWithArray(entries);
+  sandbox.stub(defaultTopicTriggerHelper, 'getContentTypes')
+    .returns(types);
   sandbox.stub(contentful, 'fetchByContentTypes')
     .returns(Promise.resolve(fetchEntriesResult));
   sandbox.stub(defaultTopicTriggerHelper, 'parseDefaultTopicTriggerFromContentfulEntry')
@@ -45,7 +52,7 @@ test('fetch returns contentful.fetchByContentTypes parsed as defaultTopicTrigger
 
   const result = await defaultTopicTriggerHelper.fetch();
   contentful.fetchByContentTypes
-    .should.have.been.calledWith(config.contentTypes);
+    .should.have.been.calledWith(types);
   defaultTopicTriggerHelper.parseDefaultTopicTriggerFromContentfulEntry
     .should.have.been.calledWith(firstEntry);
   defaultTopicTriggerHelper.parseDefaultTopicTriggerFromContentfulEntry

--- a/test/lib/lib-helpers/topic.test.js
+++ b/test/lib/lib-helpers/topic.test.js
@@ -222,7 +222,8 @@ test('getFieldValueFromContentfulEntryAndTemplateName returns the entry field va
 // getPostTypeFromContentType
 test('getPostTypeFromContentType returns postType string property from contentTypeConfig', () => {
   const result = topicHelper.getPostTypeFromContentType(topicContentType);
-  result.should.equal(config.contentTypes[topicContentType].postType);
+  const contentTypeConfigs = helpers.contentfulEntry.getContentTypeConfigs();
+  result.should.equal(contentTypeConfigs[topicContentType].postType);
 });
 
 // parseTopicFromContentfulEntry

--- a/test/utils/factories/contentful/autoReply.js
+++ b/test/utils/factories/contentful/autoReply.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const stubs = require('../../stubs');
+const messageFactory = require('./message');
+
+function getValidAutoReply(date = Date.now()) {
+  const data = {
+    sys: stubs.contentful.getSysWithTypeAndDate('autoReply', date),
+    fields: {
+      name: stubs.getBroadcastName(),
+      autoReply: messageFactory.getValidMessage(),
+    },
+  };
+  return data;
+}
+
+module.exports = {
+  getValidAutoReply,
+};

--- a/test/utils/factories/contentful/autoReply.js
+++ b/test/utils/factories/contentful/autoReply.js
@@ -9,6 +9,7 @@ function getValidAutoReply(date = Date.now()) {
     fields: {
       name: stubs.getBroadcastName(),
       autoReply: messageFactory.getValidMessage(),
+      // TODO: Add a campaign reference field, returning a campaign factory's valid campaign.
     },
   };
   return data;

--- a/test/utils/factories/contentful/autoReplyBroadcast.js
+++ b/test/utils/factories/contentful/autoReplyBroadcast.js
@@ -2,6 +2,7 @@
 
 const stubs = require('../../stubs');
 const messageFactory = require('./message');
+const autoReplyFactory = require('./autoReply');
 
 function getValidAutoReplyBroadcast() {
   const data = {
@@ -15,7 +16,7 @@ function getValidAutoReplyBroadcast() {
     },
     fields: {
       broadcast: messageFactory.getValidMessage(),
-      autoReply: messageFactory.getValidMessage(),
+      topic: autoReplyFactory.getValidAutoReply(),
     },
   };
   return data;


### PR DESCRIPTION
#### What's this PR do?
Cleanup in anticipation of refactoring `autoReplyBroadcast` per the new `autoReplyBroadcast` and `autoReply` content types. 

* Moves the `config.contentType` definitions for the broadcast, defaultTopicTrigger, and topic helpers into the contentfulEntry helper, as an `askYesNo` can serve as both a broadcast (it's `broadcastable`) and as a topic (it has `templates`)

* Moves the `parseTemplatesFromContentfulEntryAndFieldNames` function out of broadcast helper and into contentfulEntry to be reused by other content types that will use the same pattern of creating a `message` or `changeTopicMessage` reference field and adding it to the `templates` array to render a topic's templates

#### How should this be reviewed?
Spot check types returned:

* `GET /broadcasts` will return `broadcast` and `autoReplyBroadcast` entries
* `GET /topics` will return `broadcast` and `autoReplyBroadcast` entries
* `GET /defaultTopicTriggers` will return `defaultTopicTrigger` entries only

#### Any background context you want to provide?
Wanted to open this up as a smaller PR before adding a `topic` property to an `autoReplyBroadcast`, which would reference an `autoReply` entry.

#### Relevant tickets
https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [x] Tested on staging.
