### PR TITLE
Finalizing askYesNo and autoReplyBroadcast template fields [pr]

### DIFF
--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -3,8 +3,13 @@
 /**
  * This maps the fields in our Contentful types into broadcast, topic, and defaultTopicTriggers.
  *
- * Content types with templates set are returned as topics. Each item in the templates array is a
- * single value text field to be used as a bot reply template while in the topic.
+ * Content types with either a templates or postType property set are returned as topics.
+ * If the type contains a templates array, each array item should correspond to a single value text
+ * field defined on the content type, which is used as a bot reply template in the topic.
+ * If the type contains a postType string property instead, its an older content type and its
+ * templates are configured via config/lib/helpers/topic. Ideally we should consolidate, but it'd
+ * take a bit of refactoring as the topic helper config contains default values for certain text
+ * fields to use if the field values are blank.
  *
  * A broadcastable content type currently requires a text field named "text" and attachments field
  * named "attachments" to define content for the outbound broadcast.

--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -1,5 +1,15 @@
 'use strict';
 
+/**
+ * This maps the fields in our Contentful types into broadcast, topic, and defaultTopicTriggers.
+ *
+ * Content types with templates set are returned as topics. Each item in the templates array is a
+ * single value text field to be used as a bot reply template while in the topic.
+ *
+ * A broadcastable content type currently requires a text field named "text" and attachments field
+ * named "attachments" to define content for the outbound broadcast.
+ *
+ */
 module.exports = {
   contentTypes: {
     askYesNo: {
@@ -9,7 +19,6 @@ module.exports = {
         'saidYes',
         'saidNo',
         'invalidAskYesNoResponse',
-        'autoReply',
       ],
     },
     autoReply: {

--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -19,6 +19,7 @@ module.exports = {
         'saidYes',
         'saidNo',
         'invalidAskYesNoResponse',
+        'autoReply',
       ],
     },
     autoReply: {

--- a/documentation/endpoints/broadcasts.md
+++ b/documentation/endpoints/broadcasts.md
@@ -13,8 +13,8 @@ Name | Type | Description
 `message.text` | String |
 `message.attachments` | Array |
 `message.template` | String |
-`message.topic` | Object | If an id property exists, its saved to the [conversation topic](https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/topics.md) when broadcast is sent
-`templates` | Object | Defines replies for when this broadcast is saved as a [conversation topic](https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/topics.md) -- used in `askYesNo`, which will update the conversation topic again if user answers yes
+`message.topic` | Object | If an id property exists, its saved to the [conversation topic](https://github.com/DoSomething/gambit-campaigns/blob/master/documentation/endpoints/topics.md) when broadcast is sent
+`templates` | Object | Defines replies for when this broadcast is saved as a [conversation topic](https://github.com/DoSomething/gambit-campaigns/blob/master/documentation/endpoints/topics.md) -- used in `askYesNo`, which will update the conversation topic again if user answers yes
 
 Legacy fields (only used for type `broadcast`)
 

--- a/documentation/endpoints/broadcasts.md
+++ b/documentation/endpoints/broadcasts.md
@@ -8,15 +8,21 @@ Name | Type | Description
 -----|------|------------
 `id` | String | The Contentful entry id
 `name` | String | Internal name used to reference the broadcast
-`type` | String | The Contentful entry type, e.g. `autoReplyBroadcast`, `broadcast`
+`type` | String | The Contentful entry type, e.g. `askYesNo`, `autoReplyBroadcast`, `broadcast`
 `message` | Object | Contains the [outbound message content](https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/messages.md) to send to user
 `message.text` | String |
 `message.attachments` | Array |
 `message.template` | String |
-`topic` | String | If set, updates the conversation topic to this string.*
-`campaignId` | Number | If set, updates the conversation topic to the given campaign's topic.*
+`message.topic` | Object | If an id property exists, its saved to the [conversation topic](https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/topics.md) when broadcast is sent
+`templates` | Object | Defines replies for when this broadcast is saved as a [conversation topic](https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/topics.md) -- used in `askYesNo`, which will update the conversation topic again if user answers yes
 
-* Note: These fields will likely be deprecated by a `topicId` per https://www.pivotaltracker.com/story/show/157369418
+Legacy fields (only used for type `broadcast`)
+
+Name | Type | Description
+-----|------|------------
+`topic` | String | (Legacy) If set, updates the conversation topic to this string.*
+`campaignId` | Number | (Legacy) If set, updates the conversation topic to the given campaign's topic.*
+
 
 
 ## Retrieve broadcasts
@@ -64,18 +70,37 @@ curl http://localhost:5000/v1/broadcasts?skip=20
       "topic": "survey_response"
     },
     {
-      "id": "4C2gkDV8oUAaewSMYeokEC",
-      "name": "VoterRegistration2018_Jul8_OhioSpecialHouseGeneralReminder",
-      "type": "broadcast",
-      "createdAt": "2018-07-06T18:28:51.478Z",
-      "updatedAt": "2018-07-06T18:31:55.968Z",
+      "id": "2X4r3fZrTGA2mGemowgiEI",
+      "name": "askYesNo test",
+      "type": "askYesNo",
+      "createdAt": "2018-08-06T23:34:56.395Z",
+      "updatedAt": "2018-08-08T22:20:14.822Z",
       "message": {
-        "text": "It's Freddie! Guess what -- Ohio needs YOU. Voters have the power to make a huge difference in your state, so make sure you're registered to vote in Ohio's special house general election before tonight's deadline! It takes just 2 mins: https://vote.dosomething.org/?r=user:{{user.id}},campaignID:8017,campaignRunID:8022,source:sms,source_details:broadcastID_4C2gkDV8oUAaewSMYeokEC",
+        "text": "Join Pump it Up? \n\nYes No",
         "attachments": [],
-        "template": "rivescript"
+        "template": "askYesNo",
+        "topic": {}
       },
-      "campaignId": null,
-      "topic": "survey_response"
+      "templates": {
+        "saidYes": {
+          "text": "Great! Text START to submit a photo.",
+          "topic": {
+            "id": "4xXe9sQqmIeiWauSUu6kAY"
+          }
+        },
+        "saidNo": {
+          "text": "Ok, we'll check in with you later.",
+          "topic": {}
+        },
+        "invalidAskYesNoResponse": {
+          "text": "Sorry, I didn't get that - did you want to join for Pump It Up? Yes or No",
+          "topic": {}
+        },
+        "autoReply": {
+          "text": "Sorry, I didn't understand that. Text Q if you have a question.",
+          "topic": {}
+        }
+      },
     },
     ...
   },

--- a/documentation/endpoints/topics.md
+++ b/documentation/endpoints/topics.md
@@ -110,13 +110,9 @@ curl http://localhost:5000/v1/topics?skip=5
       "updatedAt": "2018-08-08T22:20:14.822Z",
       "message": {
         "text": "Join Pump it Up? \n\nYes No",
-        "attachments": [
-          
-        ],
+        "attachments": [],
         "template": "askYesNo",
-        "topic": {
-          
-        }
+        "topic": {}
       },
       "templates": {
         "saidYes": {
@@ -127,21 +123,15 @@ curl http://localhost:5000/v1/topics?skip=5
         },
         "saidNo": {
           "text": "Ok, we'll check in with you later.",
-          "topic": {
-            
-          }
+          "topic": {}
         },
         "invalidAskYesNoResponse": {
           "text": "Sorry, I didn't get that - did you want to join for Pump It Up? Yes or No",
-          "topic": {
-            
-          }
+          "topic": {}
         },
         "autoReply": {
           "text": "Sorry, I didn't understand that. Text Q if you have a question.",
-          "topic": {
-            
-          }
+          "topic": {}
         }
       },
       "triggers": [
@@ -240,101 +230,7 @@ curl http://localhost:5000/v1/topics/6swLaA7HKE8AGI6iQuWk4y?cache=false \
         "override": true,
         "rendered": "Over 111,000 people have joined the movement to bring positivity to their schools. All it takes is posting encouraging notes in places that can trigger low self-esteem. Take 5 mins to post a note today. \n\nThen, text START to share a photo of the messages you posted (and you'll be entered to win a $2000 scholarship)!"
       },
-      "webStartPhotoPost": {
-        "raw": "Hey - this is Freddie from DoSomething. Thanks for joining a movement to spread positivity in school. You can do something simple to make a big impact for a stranger.\n\nLet's do this: post encouraging notes in places that can trigger low self-esteem, like school bathrooms.\n\nThen, text  {{cmd_reportback}}  to share a photo of the messages you posted (and you'll be entered to win a $2000 scholarship)!",
-        "override": true,
-        "rendered": "Hey - this is Freddie from DoSomething. Thanks for joining a movement to spread positivity in school. You can do something simple to make a big impact for a stranger.\n\nLet's do this: post encouraging notes in places that can trigger low self-esteem, like school bathrooms.\n\nThen, text  START  to share a photo of the messages you posted (and you'll be entered to win a $2000 scholarship)!"
-      },
-      "startPhotoPostAutoReply": {
-        "raw": "Sorry, I didn't get that.\n\nText {{cmd_reportback}} when you're ready to submit a post for {{title}}.",
-        "override": false,
-        "rendered": "Sorry, I didn't get that.\n\nText START when you're ready to submit a post for Mirror Messages."
-      },
-      "completedPhotoPost": {
-        "raw": "Great! We've got you down for {{quantity}} messages posted.\n\nTo submit another post for Mirror Messages, text {{cmd_reportback}}.",
-        "override": true,
-        "rendered": "Great! We've got you down for {{quantity}} messages posted.\n\nTo submit another post for Mirror Messages, text START."
-      },
-      "completedPhotoPostAutoReply": {
-        "raw": "Sorry I didn't get that.  If you've posted more messages, text {{cmd_reportback}}.\n\nText Q if you have a question, or text MENU to find a different action to take.",
-        "override": true,
-        "rendered": "Sorry I didn't get that.  If you've posted more messages, text START.\n\nText Q if you have a question, or text MENU to find a different action to take."
-      },
-      "askQuantity": {
-        "raw": "Sweet! First, what's the total number of messages you posted?\n\nBe sure to text in a number not a word (i.e. “4”, not “four”)",
-        "override": true,
-        "rendered": "Sweet! First, what's the total number of messages you posted?\n\nBe sure to text in a number not a word (i.e. “4”, not “four”)"
-      },
-      "invalidQuantity": {
-        "raw": "Sorry, that isn't a valid number. What's the total number of messages you posted? Be sure to text in a number not a word (i.e. “4”, not “four”)",
-        "override": true,
-        "rendered": "Sorry, that isn't a valid number. What's the total number of messages you posted? Be sure to text in a number not a word (i.e. “4”, not “four”)"
-      },
-      "askPhoto": {
-        "raw": "Send us your best pic of yourself and the messages you posted.",
-        "override": true,
-        "rendered": "Send us your best pic of yourself and the messages you posted."
-      },
-      "invalidPhoto": {
-        "raw": "Sorry, I didn't get that.\n\nSend us your best pic of yourself and the messages you posted. \n\nIf you have a question, text Q.",
-        "override": true,
-        "rendered": "Sorry, I didn't get that.\n\nSend us your best pic of yourself and the messages you posted. \n\nIf you have a question, text Q."
-      },
-      "askCaption": {
-        "raw": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.",
-        "override": false,
-        "rendered": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please."
-      },
-      "invalidCaption": {
-        "raw": "Sorry, I didn't get that.\n\nText back a caption for your photo -- keep it short & sweet, under 60 characters please. (but more than 3!)",
-        "override": false,
-        "rendered": "Sorry, I didn't get that.\n\nText back a caption for your photo -- keep it short & sweet, under 60 characters please. (but more than 3!)"
-      },
-      "askWhyParticipated": {
-        "raw": "Last question: Why was participating in {{title}} important to you? (No need to write an essay, one sentence is good).",
-        "override": false,
-        "rendered": "Last question: Why was participating in Mirror Messages important to you? (No need to write an essay, one sentence is good)."
-      },
-      "invalidWhyParticipated": {
-        "raw": "Sorry, I didn't get that.\n\nLast question: Why was participating in {{title}} important to you? (No need to write an essay, one sentence is good).",
-        "override": false,
-        "rendered": "Sorry, I didn't get that.\n\nLast question: Why was participating in Mirror Messages important to you? (No need to write an essay, one sentence is good)."
-      },
-      "memberSupport": {
-        "raw": "Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to continue {{title}}, text back {{keyword}}",
-        "override": false,
-        "rendered": "Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to continue Mirror Messages, text back MIRROR"
-      },
-      "campaignClosed": {
-        "raw": "Sorry, {{title}} is no longer available.\n\nText {{cmd_member_support}} for help.",
-        "override": false,
-        "rendered": "Sorry, Mirror Messages is no longer available.\n\nText Q for help."
-      },
-      "askSignup": {
-        "raw": "{{tagline}}\n\nWant to join {{title}}?\n\nYes or No",
-        "override": false,
-        "rendered": "Boost a stranger's self-esteem with just a sticky note!\n\nWant to join Mirror Messages?\n\nYes or No"
-      },
-      "declinedSignup": {
-        "raw": "Ok! Text MENU if you'd like to find a different action to take.",
-        "override": false,
-        "rendered": "Ok! Text MENU if you'd like to find a different action to take."
-      },
-      "invalidAskSignupResponse": {
-        "raw": "Sorry, I didn't get that. Did you want to join {{title}}?\n\nYes or No",
-        "override": false,
-        "rendered": "Sorry, I didn't get that. Did you want to join Mirror Messages?\n\nYes or No"
-      },
-      "askContinue": {
-        "raw": "Ready to get back to {{title}}?\n\nYes or No",
-        "override": false,
-        "rendered": "Ready to get back to Mirror Messages?\n\nYes or No"
-      },
-      "declinedContinue": {
-        "raw": "Right on, we'll check in with you about {{title}} later.\n\nText MENU if you'd like to find a different action to take.",
-        "override": false,
-        "rendered": "Right on, we'll check in with you about Mirror Messages later.\n\nText MENU if you'd like to find a different action to take."
-      },
+      ...
       "invalidAskContinueResponse": {
         "raw": "Sorry, I didn't get that. Did you want to join {{title}}?\n\nYes or No",
         "override": false,

--- a/documentation/endpoints/topics.md
+++ b/documentation/endpoints/topics.md
@@ -8,13 +8,10 @@ A conversation topic may be set to one of the following Contentful content types
 * `textPostConfig` - creates a signup and sends replies to create text post for a campaign
 * `externalPostConfig` - creates a signup for a campaign, but does not create a post via messaging. The campaign post is created externally when user visits the link included in the templates of an `externalPostConfig` topic.
 
+Under construction
 
-### Broadcast topics
-
-[under construction](https://i.amz.mshcdn.com/xxwMNSb7PAnpcIOmwhIU1dh80SA=/fit-in/1200x9600/https%3A%2F%2Fblueprint-api-production.s3.amazonaws.com%2Fuploads%2Fcard%2Fimage%2F168421%2Ftumblr_ks4m18IymX1qz4u07o1_250.gif)
-
-* `autoReplyBroadcast` - replies with an `autoReply` template after sending an outbound broadcast
-* `askYesNo` - asks yes/no question
+* `autoReply` - repeats a single `autoReply` template, creates a signup if campaign is set. This will deprecate the `externalPostConfig` type.
+* `askYesNo` - asks yes/no question (and can be sent as a [broadcast](./topics.md))
 
 Fields:
 
@@ -26,8 +23,9 @@ Name | Type | Description
 `campaign` | Object | The campaign this topic should create a signup and post for.
 `templates` | Object | Collection of outbound message templates that can be sent from this topic.
 `templates.raw` | String | The field value stored in Contentful to return for the template, or a hardcoded default value if the field value is not set
-`templates.rendered` | String | The `raw` value replaced with any campaign or command tags. See https://github.com/DoSomething/gambit-admin/wiki/Tags
+`templates.text` | String | The `raw` value replaced with any campaign or command tags. See https://github.com/DoSomething/gambit-admin/wiki/Tags
 `templates.override` | Boolean | Whether the `raw` value is set from a Contentful field value (override is `true`), or from a hardcoded default (override is `false`)
+`templates.topic` | Object | If an id is present, this reply template should update the conversation topic accordingly.
 `triggers` | Array | List of defaultTopicTriggers that change user conversation to this topic
 
 ## Retrieve topics
@@ -98,44 +96,56 @@ curl http://localhost:5000/v1/topics?skip=5
           "override": false,
           "rendered": "Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to continue Lose Your V-Card, text back VCARD"
         },
-        "campaignClosed": {
-          "raw": "Want to make your voice heard? Take 2 mins to make sure you’re registered to vote: {{{custom_url}}}\n\nThis year DoSomething.org is unleashing the power of young people to make change online, in their communities, and at all levels of govt. Stay tuned for updates on how you can get involved!",
-          "override": true,
-          "rendered": "Want to make your voice heard? Take 2 mins to make sure you’re registered to vote: {{{custom_url}}}\n\nThis year DoSomething.org is unleashing the power of young people to make change online, in their communities, and at all levels of govt. Stay tuned for updates on how you can get involved!"
-        },
-        "askSignup": {
-          "raw": "{{tagline}}\n\nWant to join {{title}}?\n\nYes or No",
-          "override": false,
-          "rendered": "Help your friends register to vote!\n\nWant to join Lose Your V-Card?\n\nYes or No"
-        },
-        "declinedSignup": {
-          "raw": "Okay, that's the last you'll hear from me today! But before I go, I wanted to give you one action you can do in under 2 mins (for the chance to win a scholarship). We're creating the largest crowd-sourced guide with tips to beat bullying. Want to share a tip? Text POWER now. ",
-          "override": true,
-          "rendered": "Okay, that's the last you'll hear from me today! But before I go, I wanted to give you one action you can do in under 2 mins (for the chance to win a scholarship). We're creating the largest crowd-sourced guide with tips to beat bullying. Want to share a tip? Text POWER now. "
-        },
-        "invalidAskSignupResponse": {
-          "raw": "Sorry, I didn't get that. Did you want to join {{title}}?\n\nYes or No",
-          "override": false,
-          "rendered": "Sorry, I didn't get that. Did you want to join Lose Your V-Card?\n\nYes or No"
-        },
-        "askContinue": {
-          "raw": "Ready to get back to {{title}}?\n\nYes or No",
-          "override": false,
-          "rendered": "Ready to get back to Lose Your V-Card?\n\nYes or No"
-        },
-        "declinedContinue": {
-          "raw": "Right on, we'll check in with you about {{title}} later.\n\nText MENU if you'd like to find a different action to take.",
-          "override": false,
-          "rendered": "Right on, we'll check in with you about Lose Your V-Card later.\n\nText MENU if you'd like to find a different action to take."
-        },
-        "invalidAskContinueResponse": {
-          "raw": "Sorry, I didn't get that. Did you want to join {{title}}?\n\nYes or No",
-          "override": false,
-          "rendered": "Sorry, I didn't get that. Did you want to join Lose Your V-Card?\n\nYes or No"
-        }
+        ...
       },
       "triggers": [
         "vcard",
+      ]
+    },
+      {
+      "id": "2X4r3fZrTGA2mGemowgiEI",
+      "name": "askYesNo test",
+      "type": "askYesNo",
+      "createdAt": "2018-08-06T23:34:56.395Z",
+      "updatedAt": "2018-08-08T22:20:14.822Z",
+      "message": {
+        "text": "Join Pump it Up? \n\nYes No",
+        "attachments": [
+          
+        ],
+        "template": "askYesNo",
+        "topic": {
+          
+        }
+      },
+      "templates": {
+        "saidYes": {
+          "text": "Great! Text START to submit a photo.",
+          "topic": {
+            "id": "4xXe9sQqmIeiWauSUu6kAY"
+          }
+        },
+        "saidNo": {
+          "text": "Ok, we'll check in with you later.",
+          "topic": {
+            
+          }
+        },
+        "invalidAskYesNoResponse": {
+          "text": "Sorry, I didn't get that - did you want to join for Pump It Up? Yes or No",
+          "topic": {
+            
+          }
+        },
+        "autoReply": {
+          "text": "Sorry, I didn't understand that. Text Q if you have a question.",
+          "topic": {
+            
+          }
+        }
+      },
+      "triggers": [
+        
       ]
     },
     {
@@ -160,106 +170,7 @@ curl http://localhost:5000/v1/topics?skip=5
           "override": true,
           "rendered": "Secondhand smoke causes cancer, which is why thousands of colleges have gone tobacco-free. Problem is, 3,273 campuses still allow tobacco, which means secondhand smoke is harming everyone on campus including our beloved mascots. \n\nTell your college (or a college near you) to pledge to go tobacco-free by telling them to #SaveTheMascots by clicking here: http://bit.ly/2GE8APl\n\nTake a screenshot of the post you share, then text START to share it with us (and enter for a chance to win a $2500 scholarship)!"
         },
-        "webStartPhotoPost": {
-          "raw": "Thanks for joining DoSomething.org's #SaveTheMascots! Ready to take a quick action (and enter for the chance to win a $2500 scholarship)? \n\nSecondhand smoke causes cancer, which is why thousands of colleges have gone tobacco-free. Problem is, 3,273 campuses still allow tobacco, which means secondhand smoke is harming everyone on campus including our beloved mascots. \n\nTell your college (or a college near you) to pledge to go tobacco-free by clicking here: http://bit.ly/2GE8APl\n\nTake a screenshot of the post you share, then text {{cmd_reportback}} to share it with us (and enter for the scholarship).",
-          "override": true,
-          "rendered": "Thanks for joining DoSomething.org's #SaveTheMascots! Ready to take a quick action (and enter for the chance to win a $2500 scholarship)? \n\nSecondhand smoke causes cancer, which is why thousands of colleges have gone tobacco-free. Problem is, 3,273 campuses still allow tobacco, which means secondhand smoke is harming everyone on campus including our beloved mascots. \n\nTell your college (or a college near you) to pledge to go tobacco-free by clicking here: http://bit.ly/2GE8APl\n\nTake a screenshot of the post you share, then text START to share it with us (and enter for the scholarship)."
-        },
-        "startPhotoPostAutoReply": {
-          "raw": "Sorry, I didn't understand that. Text {{cmd_reportback}} when you have asked your college (or one near you) to go tobacco-free!\n\nIf you have a question, text Q.",
-          "override": true,
-          "rendered": "Sorry, I didn't understand that. Text START when you have asked your college (or one near you) to go tobacco-free!\n\nIf you have a question, text Q."
-        },
-        "completedPhotoPost": {
-          "raw": "Thanks for urging the college or university to pledge to join the movement to have tobacco-free campuses! \n\nInterested in taking more actions and learning about other scholarship opportunities? Text MENU.",
-          "override": true,
-          "rendered": "Thanks for urging the college or university to pledge to join the movement to have tobacco-free campuses! \n\nInterested in taking more actions and learning about other scholarship opportunities? Text MENU."
-        },
-        "completedPhotoPostAutoReply": {
-          "raw": "Sorry, I didn't understand that.\n\nText {{cmd_reportback}} if you have shared more posts urging colleges or universities to join the movement to have tobacco free campuses! \n\nIf you have a question, text Q.",
-          "override": true,
-          "rendered": "Sorry, I didn't understand that.\n\nText START if you have shared more posts urging colleges or universities to join the movement to have tobacco free campuses! \n\nIf you have a question, text Q."
-        },
-        "askQuantity": {
-          "raw": "Sweet! First, what's the total number of posts you shared?\n\nBe sure to text in a number not a word (i.e. “4”, not “four”)",
-          "override": true,
-          "rendered": "Sweet! First, what's the total number of posts you shared?\n\nBe sure to text in a number not a word (i.e. “4”, not “four”)"
-        },
-        "invalidQuantity": {
-          "raw": "Sorry, that's not a valid number.\n\nWhat's the total number of posts you have shared?\n\nIf you have a question, text Q.",
-          "override": true,
-          "rendered": "Sorry, that's not a valid number.\n\nWhat's the total number of posts you have shared?\n\nIf you have a question, text Q."
-        },
-        "askPhoto": {
-          "raw": "Nice! Send back a screenshot of the tweet you posted asking your college (or one near you) to go tobacco-free.",
-          "override": true,
-          "rendered": "Nice! Send back a screenshot of the tweet you posted asking your college (or one near you) to go tobacco-free."
-        },
-        "invalidPhoto": {
-          "raw": "Sorry, I didn't get that.\n\nSend a photo of the posts you have shared.\n\nIf you have a question, text Q - I'll get back to you within 24 hours.",
-          "override": true,
-          "rendered": "Sorry, I didn't get that.\n\nSend a photo of the posts you have shared.\n\nIf you have a question, text Q - I'll get back to you within 24 hours."
-        },
-        "askCaption": {
-          "raw": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.",
-          "override": false,
-          "rendered": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please."
-        },
-        "invalidCaption": {
-          "raw": "Sorry, I didn't get that.\n\nText back a caption for your photo -- keep it short & sweet, under 60 characters please. (but more than 3!)",
-          "override": false,
-          "rendered": "Sorry, I didn't get that.\n\nText back a caption for your photo -- keep it short & sweet, under 60 characters please. (but more than 3!)"
-        },
-        "askWhyParticipated": {
-          "raw": "Last question: Why was participating in {{title}} important to you? (No need to write an essay, one sentence is good).",
-          "override": false,
-          "rendered": "Last question: Why was participating in #SaveTheMascots important to you? (No need to write an essay, one sentence is good)."
-        },
-        "invalidWhyParticipated": {
-          "raw": "Sorry, I didn't get that.\n\nLast question: Why was participating in {{title}} important to you? (No need to write an essay, one sentence is good).",
-          "override": false,
-          "rendered": "Sorry, I didn't get that.\n\nLast question: Why was participating in #SaveTheMascots important to you? (No need to write an essay, one sentence is good)."
-        },
-        "memberSupport": {
-          "raw": "Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to continue {{title}}, text back {{keyword}}",
-          "override": false,
-          "rendered": "Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to continue #SaveTheMascots, text back MASCOT"
-        },
-        "campaignClosed": {
-          "raw": "Sorry, {{title}} is no longer available.\n\nText {{cmd_member_support}} for help.",
-          "override": false,
-          "rendered": "Sorry, #SaveTheMascots is no longer available.\n\nText Q for help."
-        },
-        "askSignup": {
-          "raw": "{{tagline}}\n\nWant to join {{title}}?\n\nYes or No",
-          "override": false,
-          "rendered": "Help us make every college campus tobacco-free.\n\nWant to join #SaveTheMascots?\n\nYes or No"
-        },
-        "declinedSignup": {
-          "raw": "Ok! Text MENU if you'd like to find a different action to take.",
-          "override": false,
-          "rendered": "Ok! Text MENU if you'd like to find a different action to take."
-        },
-        "invalidAskSignupResponse": {
-          "raw": "Sorry, I didn't get that. Did you want to join {{title}}?\n\nYes or No",
-          "override": false,
-          "rendered": "Sorry, I didn't get that. Did you want to join #SaveTheMascots?\n\nYes or No"
-        },
-        "askContinue": {
-          "raw": "Ready to get back to {{title}}?\n\nYes or No",
-          "override": false,
-          "rendered": "Ready to get back to #SaveTheMascots?\n\nYes or No"
-        },
-        "declinedContinue": {
-          "raw": "Right on, we'll check in with you about {{title}} later.\n\nText MENU if you'd like to find a different action to take.",
-          "override": false,
-          "rendered": "Right on, we'll check in with you about #SaveTheMascots later.\n\nText MENU if you'd like to find a different action to take."
-        },
-        "invalidAskContinueResponse": {
-          "raw": "Sorry, I didn't get that. Did you want to join {{title}}?\n\nYes or No",
-          "override": false,
-          "rendered": "Sorry, I didn't get that. Did you want to join #SaveTheMascots?\n\nYes or No"
-        }
+        ...
       },
       "triggers": [
         "mascot",

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -108,6 +108,8 @@ function getLegacyBroadcastDataFromContentfulEntry(contentfulEntry) {
     const campaignConfigEntry = contentfulEntry.fields.campaign;
     data.campaignId = Number(contentful.getCampaignIdFromContentfulEntry(campaignConfigEntry));
     data.topic = null;
+    // Ancient legacy broadcasts didn't require the template field, because at the time, we only
+    // supported askSignup broadcasts.
     data.message.template = contentfulEntry.fields.template || 'askSignup';
   }
   return data;

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -69,12 +69,12 @@ function parseBroadcastFromContentfulEntry(contentfulEntry) {
   // type to avoid this check, but it likely is not possible to change type of an existing entry.
   if (helpers.contentfulEntry.isLegacyBroadcast(contentfulEntry)) {
     return Promise.resolve(Object.assign(data, module.exports
-      .parseLegacyBroadcastFromContentfulEntry(contentfulEntry)));
+      .getLegacyBroadcastDataFromContentfulEntry(contentfulEntry)));
   }
-
+  // Parse the outbound broadcast message to send.
   const message = helpers.contentfulEntry
     .getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, data.type);
-  logger.debug('getMessageTemplateFromContentfulEntryAndTemplateName', { message });
+  // Parse topic templates if they exist.
   const templates = helpers.contentfulEntry.getTopicTemplatesFromContentfulEntry(contentfulEntry);
   return Promise.resolve(Object.assign(data, { message, templates }));
 }
@@ -86,7 +86,7 @@ function parseBroadcastFromContentfulEntry(contentfulEntry) {
  * @param {Object} contentfulEntry
  * @return {Object}
  */
-function parseLegacyBroadcastFromContentfulEntry(contentfulEntry) {
+function getLegacyBroadcastDataFromContentfulEntry(contentfulEntry) {
   const data = {
     message: {
       text: contentfulEntry.fields.message,
@@ -118,6 +118,6 @@ module.exports = {
   fetchById,
   getById,
   getContentTypes,
+  getLegacyBroadcastDataFromContentfulEntry,
   parseBroadcastFromContentfulEntry,
-  parseLegacyBroadcastFromContentfulEntry,
 };

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -65,8 +65,8 @@ function getById(broadcastId, resetCache = false) {
  */
 function parseBroadcastFromContentfulEntry(contentfulEntry) {
   const data = helpers.contentfulEntry.getSummaryFromContentfulEntry(contentfulEntry);
-  // A nice to have TODO is migrating all legacy broadcast entries into the respective new type, so
-  // we can remove check and the function it calls entirely.
+  // A nice to have TODO would be migrating all legacy broadcast entries into their new respective
+  // type to avoid this check, but it likely is not possible to change type of an existing entry.
   if (helpers.contentfulEntry.isLegacyBroadcast(contentfulEntry)) {
     return Promise.resolve(Object.assign(data, module.exports
       .parseLegacyBroadcastFromContentfulEntry(contentfulEntry)));
@@ -74,7 +74,8 @@ function parseBroadcastFromContentfulEntry(contentfulEntry) {
 
   const message = helpers.contentfulEntry
     .getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, data.type);
-  const templates = helpers.contentfulEntry.getMessageTemplatesFromContentfulEntry(contentfulEntry);
+  logger.debug('getMessageTemplateFromContentfulEntryAndTemplateName', { message });
+  const templates = helpers.contentfulEntry.getTopicTemplatesFromContentfulEntry(contentfulEntry);
   return Promise.resolve(Object.assign(data, { message, templates }));
 }
 

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -64,19 +64,17 @@ function getById(broadcastId, resetCache = false) {
  * @return {Promise}
  */
 function parseBroadcastFromContentfulEntry(contentfulEntry) {
-  const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
+  const data = helpers.contentfulEntry.getSummaryFromContentfulEntry(contentfulEntry);
   // A nice to have TODO is migrating all legacy broadcast entries into the respective new type, so
   // we can remove check and the function it calls entirely.
-  const contentTypeConfigs = helpers.contentfulEntry.getContentTypeConfigs();
-  if (contentType === contentTypeConfigs.legacyBroadcast.type) {
-    return module.exports.parseLegacyBroadcastFromContentfulEntry(contentfulEntry);
+  if (helpers.contentfulEntry.isLegacyBroadcast(contentfulEntry)) {
+    return Promise.resolve(Object.assign(data, module.exports
+      .parseLegacyBroadcastFromContentfulEntry(contentfulEntry)));
   }
 
-  const data = helpers.contentfulEntry.getSummaryFromContentfulEntry(contentfulEntry);
-  const message = module.exports
-    .parseBroadcastMessageFromContentfulEntryAndTemplateName(contentfulEntry, contentType);
+  const message = helpers.contentfulEntry
+    .getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, data.type);
   const templates = helpers.contentfulEntry.getMessageTemplatesFromContentfulEntry(contentfulEntry);
-
   return Promise.resolve(Object.assign(data, { message, templates }));
 }
 
@@ -85,13 +83,14 @@ function parseBroadcastFromContentfulEntry(contentfulEntry) {
  * deprecated by new content types per broadcast type.
  *
  * @param {Object} contentfulEntry
- * @return {Promise}
+ * @return {Object}
  */
 function parseLegacyBroadcastFromContentfulEntry(contentfulEntry) {
-  const data = helpers.contentfulEntry.getSummaryFromContentfulEntry(contentfulEntry);
-  data.message = {
-    text: contentfulEntry.fields.message,
-    attachments: contentful.getAttachmentsFromContentfulEntry(contentfulEntry),
+  const data = {
+    message: {
+      text: contentfulEntry.fields.message,
+      attachments: contentful.getAttachmentsFromContentfulEntry(contentfulEntry),
+    },
   };
   // This content type was used to send all types of broadcasts and has since been deprecated.
   const hardcodedTopic = contentfulEntry.fields.topic;
@@ -110,22 +109,7 @@ function parseLegacyBroadcastFromContentfulEntry(contentfulEntry) {
     data.topic = null;
     data.message.template = contentfulEntry.fields.template || 'askSignup';
   }
-  return Promise.resolve(data);
-}
-
-/**
- * @param {Object} contentfulEntry
- * @return {Object}
- */
-function parseBroadcastMessageFromContentfulEntryAndTemplateName(contentfulEntry, templateName) {
-  const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
-  const broadcastMessageEntry = contentfulEntry.fields[contentType];
-
-  if (!broadcastMessageEntry) {
-    return null;
-  }
-  return helpers.contentfulEntry
-    .getMessageTemplateFromContentfulEntryAndTemplateName(broadcastMessageEntry, templateName);
+  return data;
 }
 
 module.exports = {
@@ -134,6 +118,5 @@ module.exports = {
   getById,
   getContentTypes,
   parseBroadcastFromContentfulEntry,
-  parseBroadcastMessageFromContentfulEntryAndTemplateName,
   parseLegacyBroadcastFromContentfulEntry,
 };

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -57,7 +57,7 @@ function getSummaryFromContentfulEntry(contentfulEntry) {
     createdAt: contentfulEntry.sys.createdAt,
     updatedAt: contentfulEntry.sys.updatedAt,
   };
-  logger.debug('parseNameInfoFromContentfulEntry', { result });
+  logger.debug('getSummaryFromContentfulEntry', { result });
   return result;
 }
 
@@ -124,7 +124,7 @@ function isBroadcastable(contentfulEntry) {
  * @return {Boolean}
  */
 function isDefaultTopicTrigger(contentfulEntry) {
-  return contentful.isContentType(contentfulEntry, 'defaultTopicTrigger');
+  return contentful.isContentType(contentfulEntry, config.contentTypes.defaultTopicTrigger.type);
 }
 
 /**

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -131,6 +131,14 @@ function isDefaultTopicTrigger(contentfulEntry) {
  * @param {Object} contentfulEntry
  * @return {Boolean}
  */
+function isLegacyBroadcast(contentfulEntry) {
+  return contentful.isContentType(contentfulEntry, config.contentTypes.legacyBroadcast.type);
+}
+
+/**
+ * @param {Object} contentfulEntry
+ * @return {Boolean}
+ */
 function isMessage(contentfulEntry) {
   return contentful.isContentType(contentfulEntry, config.contentTypes.message.type);
 }
@@ -144,6 +152,7 @@ module.exports = {
   isAutoReply,
   isBroadcastable,
   isDefaultTopicTrigger,
+  isLegacyBroadcast,
   isMessage,
   parseContentfulEntry,
 };

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -82,23 +82,31 @@ function getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, t
  * @param {String}
  * @return {Object}
  */
-function getMessageTemplatesFromContentfulEntry(contentfulEntry) {
+function getTopicTemplatesFromContentfulEntry(contentfulEntry) {
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
-  const fieldNames = config.contentTypes[contentType].templates;
+  const templateFieldNames = config.contentTypes[contentType].templates;
   const result = {};
 
-  if (!contentfulEntry || !fieldNames) {
+  if (!contentfulEntry || !templateFieldNames) {
     return result;
   }
 
-  fieldNames.forEach((fieldName) => {
-    const messageEntry = contentfulEntry.fields[fieldName];
-    if (!messageEntry) {
-      return;
+  templateFieldNames.forEach((fieldName) => {
+    const text = contentfulEntry.fields[fieldName];
+    const topic = {};
+    // The saidYes template should change conversation topic to the saidYesTopic field.
+    if (fieldName === 'saidYes') {
+      const topicRef = contentfulEntry.fields.saidYesTopic;
+      if (topicRef) {
+        topic.id = contentful.getContentfulIdFromContentfulEntry(topicRef);
+      }
     }
-    result[fieldName] = module.exports
-      .getMessageTemplateFromContentfulEntryAndTemplateName(messageEntry, fieldName);
+    result[fieldName] = {
+      text,
+      topic,
+    };
   });
+
   return result;
 }
 
@@ -147,8 +155,8 @@ module.exports = {
   getById,
   getContentTypeConfigs,
   getMessageTemplateFromContentfulEntryAndTemplateName,
-  getMessageTemplatesFromContentfulEntry,
   getSummaryFromContentfulEntry,
+  getTopicTemplatesFromContentfulEntry,
   isAutoReply,
   isBroadcastable,
   isDefaultTopicTrigger,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -163,8 +163,9 @@ function parseTemplateFromContentfulEntryAndTemplateName(contentfulEntry, templa
  */
 function parseTemplatesFromContentfulEntryAndCampaign(contentfulEntry, campaign) {
   if (helpers.contentfulEntry.isAutoReply(contentfulEntry)) {
-    return helpers.contentfulEntry.getMessageTemplatesFromContentfulEntry(contentfulEntry);
+    return helpers.contentfulEntry.getTopicTemplatesFromContentfulEntry(contentfulEntry);
   }
+
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
   const data = {};
   const templateNames = Object.keys(config.templatesByContentType[contentType]);

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -10,7 +10,7 @@ const sinon = require('sinon');
 const contentful = require('../../../lib/contentful');
 const helpers = require('../../../lib/helpers');
 const stubs = require('../../utils/stubs');
-const askYesNoEntryFactory = require('../../utils/factories/contentful/askYesNo');
+const autoReplyBroadcastFactory = require('../../utils/factories/contentful/autoReplyBroadcast');
 const broadcastEntryFactory = require('../../utils/factories/contentful/broadcast');
 const broadcastFactory = require('../../utils/factories/broadcast');
 
@@ -19,10 +19,8 @@ const attachments = [stubs.getAttachment()];
 const broadcastId = stubs.getContentfulId();
 const broadcastEntry = broadcastEntryFactory.getValidCampaignBroadcast();
 const broadcast = broadcastFactory.getValidCampaignBroadcast();
-const broadcastName = stubs.getBroadcastName();
 const broadcastType = 'askYesNo';
 const campaignId = stubs.getCampaignId();
-const legacyBroadcastType = 'broadcast';
 
 // Module to test
 const broadcastHelper = require('../../../lib/helpers/broadcast');
@@ -31,15 +29,6 @@ chai.should();
 chai.use(sinonChai);
 
 const sandbox = sinon.sandbox.create();
-
-test.beforeEach(() => {
-  sandbox.stub(contentful, 'getContentfulIdFromContentfulEntry')
-    .returns(broadcastId);
-  sandbox.stub(contentful, 'getNameTextFromContentfulEntry')
-    .returns(broadcastName);
-  sandbox.stub(contentful, 'getCampaignIdFromContentfulEntry')
-    .returns(campaignId);
-});
 
 test.afterEach(() => {
   sandbox.restore();
@@ -96,7 +85,6 @@ test('fetchById returns contentful.fetchByContentfulId parsed as broadcast objec
   result.should.deep.equal(broadcast);
 });
 
-
 // getById
 test('getById returns broadcasts cache if set', async () => {
   sandbox.stub(helpers.cache.broadcasts, 'get')
@@ -134,41 +122,26 @@ test('getById returns fetchById if resetCache arg is true', async () => {
   result.should.deep.equal(broadcast);
 });
 
-// parseBroadcastMessageFromContentfulEntryAndTemplateName
-test('parseBroadcastMessageFromContentfulEntryAndTemplateName returns null if contentfulEntry does not have broadcast set', (t) => {
-  const result = broadcastHelper
-    .parseBroadcastMessageFromContentfulEntryAndTemplateName(broadcastEntry);
-  t.is(result, null);
-});
-
-test('parseBroadcastMessageFromContentfulEntryAndTemplateName returns getMessageTemplateFromContentfulEntryAndTemplateName', () => {
-  const askYesNo = askYesNoEntryFactory.getValidAskYesNo();
-  const templateName = stubs.getRandomWord();
-  const messageTemplate = { text: stubs.getRandomMessageText(), template: templateName };
+// parseBroadcastFromContentfulEntry
+test('parseBroadcastFromContentfulEntry sets message to getMessageTemplateFromContentfulEntryAndTemplateName', async () => {
+  const autoReplyBroadcastEntry = autoReplyBroadcastFactory.getValidAutoReplyBroadcast();
+  const stubContentType = stubs.getRandomWord();
+  sandbox.stub(helpers.contentfulEntry, 'getSummaryFromContentfulEntry')
+    .returns({ type: stubContentType });
+  const stubTemplate = { text: stubs.getRandomMessageText(), template: stubContentType };
   sandbox.stub(helpers.contentfulEntry, 'getMessageTemplateFromContentfulEntryAndTemplateName')
-    .returns(messageTemplate);
-  sandbox.stub(contentful, 'getContentTypeFromContentfulEntry')
-    .returns(broadcastType);
+    .returns(stubTemplate);
 
-  const result = broadcastHelper
-    .parseBroadcastMessageFromContentfulEntryAndTemplateName(askYesNo, templateName);
-  result.should.equal(messageTemplate);
+  const result = await broadcastHelper.parseBroadcastFromContentfulEntry(autoReplyBroadcastEntry);
+  result.message.text.should.equal(stubTemplate.text);
+  result.message.template.should.equal(stubContentType);
 });
 
 // parseLegacyBroadcastFromContentfulEntry
-test('parseLegacyBroadcastFromContentfulEntry returns an object with null topic if campaign broadcast', async (t) => {
+test('parseLegacyBroadcastFromContentfulEntry returns an object with null topic if campaign broadcast', (t) => {
   sandbox.stub(contentful, 'getAttachmentsFromContentfulEntry')
     .returns(attachments);
-  sandbox.stub(contentful, 'getContentTypeFromContentfulEntry')
-    .returns(legacyBroadcastType);
-
-  const result = await broadcastHelper.parseLegacyBroadcastFromContentfulEntry(broadcastEntry);
-  contentful.getContentfulIdFromContentfulEntry.should.have.been.calledWith(broadcastEntry);
-  result.id.should.equal(broadcastId);
-  contentful.getContentTypeFromContentfulEntry.should.have.been.calledWith(broadcastEntry);
-  result.type.should.equal(legacyBroadcastType);
-  contentful.getNameTextFromContentfulEntry.should.have.been.calledWith(broadcastEntry);
-  result.name.should.equal(broadcastName);
+  const result = broadcastHelper.parseLegacyBroadcastFromContentfulEntry(broadcastEntry);
   t.is(result.topic, null);
   result.campaignId.should.equal(campaignId);
   result.message.text.should.equal(broadcastEntry.fields.message);
@@ -177,20 +150,10 @@ test('parseLegacyBroadcastFromContentfulEntry returns an object with null topic 
   result.message.attachments.should.equal(attachments);
 });
 
-test('parseLegacyBroadcastFromContentfulEntry returns an object with null campaignId if hardcoded topic broadcast', async (t) => {
+test('parseLegacyBroadcastFromContentfulEntry returns an object with null campaignId if hardcoded topic broadcast', (t) => {
   const hardcodedTopicBroadcastEntry = broadcastEntryFactory.getValidTopicBroadcast();
-  sandbox.stub(contentful, 'getContentTypeFromContentfulEntry')
-    .returns(legacyBroadcastType);
-
-  const result = await broadcastHelper
+  const result = broadcastHelper
     .parseLegacyBroadcastFromContentfulEntry(hardcodedTopicBroadcastEntry);
-  contentful.getContentfulIdFromContentfulEntry
-    .should.have.been.calledWith(hardcodedTopicBroadcastEntry);
-  result.id.should.equal(broadcastId);
-  result.type.should.equal(legacyBroadcastType);
-  contentful.getNameTextFromContentfulEntry
-    .should.have.been.calledWith(hardcodedTopicBroadcastEntry);
-  result.name.should.equal(broadcastName);
   t.is(result.campaignId, null);
   result.topic.should.equal(hardcodedTopicBroadcastEntry.fields.topic);
   result.message.text.should.equal(hardcodedTopicBroadcastEntry.fields.message);

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -123,7 +123,7 @@ test('getById returns fetchById if resetCache arg is true', async () => {
 });
 
 // parseBroadcastFromContentfulEntry
-test('parseBroadcastFromContentfulEntry sets message to getMessageTemplateFromContentfulEntryAndTemplateName', async () => {
+test('parseBroadcastFromContentfulEntry returns object with message from getMessageTemplateFromContentfulEntryAndTemplateName', async () => {
   const autoReplyBroadcastEntry = autoReplyBroadcastFactory.getValidAutoReplyBroadcast();
   const stubContentType = stubs.getRandomWord();
   sandbox.stub(helpers.contentfulEntry, 'getSummaryFromContentfulEntry')
@@ -137,11 +137,11 @@ test('parseBroadcastFromContentfulEntry sets message to getMessageTemplateFromCo
   result.message.template.should.equal(stubContentType);
 });
 
-// parseLegacyBroadcastFromContentfulEntry
-test('parseLegacyBroadcastFromContentfulEntry returns an object with null topic if campaign broadcast', (t) => {
+// getLegacyBroadcastDataFromContentfulEntry
+test('getLegacyBroadcastDataFromContentfulEntry returns an object with null topic if campaign broadcast', (t) => {
   sandbox.stub(contentful, 'getAttachmentsFromContentfulEntry')
     .returns(attachments);
-  const result = broadcastHelper.parseLegacyBroadcastFromContentfulEntry(broadcastEntry);
+  const result = broadcastHelper.getLegacyBroadcastDataFromContentfulEntry(broadcastEntry);
   t.is(result.topic, null);
   result.campaignId.should.equal(campaignId);
   result.message.text.should.equal(broadcastEntry.fields.message);
@@ -150,10 +150,10 @@ test('parseLegacyBroadcastFromContentfulEntry returns an object with null topic 
   result.message.attachments.should.equal(attachments);
 });
 
-test('parseLegacyBroadcastFromContentfulEntry returns an object with null campaignId if hardcoded topic broadcast', (t) => {
+test('getLegacyBroadcastDataFromContentfulEntry returns an object with null campaignId if hardcoded topic broadcast', (t) => {
   const hardcodedTopicBroadcastEntry = broadcastEntryFactory.getValidTopicBroadcast();
   const result = broadcastHelper
-    .parseLegacyBroadcastFromContentfulEntry(hardcodedTopicBroadcastEntry);
+    .getLegacyBroadcastDataFromContentfulEntry(hardcodedTopicBroadcastEntry);
   t.is(result.campaignId, null);
   result.topic.should.equal(hardcodedTopicBroadcastEntry.fields.topic);
   result.message.text.should.equal(hardcodedTopicBroadcastEntry.fields.message);

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -34,17 +34,6 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
-// getMessageTemplatesFromContentfulEntry
-test('getMessageTemplatesFromContentfulEntry returns an object with templates values if content type config has templates', () => {
-  const result = contentfulEntryHelper.getMessageTemplatesFromContentfulEntry(autoReplyEntry);
-  result.autoReply.text.should.equal(autoReplyEntry.fields.autoReply.fields.text);
-});
-
-test('getMessageTemplatesFromContentfulEntry returns an empty object if content type config does not have templates', () => {
-  const result = contentfulEntryHelper
-    .getMessageTemplatesFromContentfulEntry(autoReplyBroadcastEntry);
-  result.should.deep.equal({});
-});
 
 // getSummaryFromContentfulEntry
 test('getSummaryFromContentfulEntry returns an object with name and type properties', () => {
@@ -62,6 +51,18 @@ test('getSummaryFromContentfulEntry returns an object with name and type propert
   result.name.should.equal(stubNameText);
   result.createdAt.should.equal(stubEntryDate);
   result.updatedAt.should.equal(stubEntryDate);
+});
+
+// getTopicTemplatesFromContentfulEntry
+test('getTopicTemplatesFromContentfulEntry returns an object with templates values if content type config has templates', () => {
+  const result = contentfulEntryHelper.getTopicTemplatesFromContentfulEntry(autoReplyEntry);
+  result.autoReply.text.should.equal(autoReplyEntry.fields.autoReply);
+});
+
+test('getTopicTemplatesFromContentfulEntry returns an empty object if content type config does not have templates', () => {
+  const result = contentfulEntryHelper
+    .getTopicTemplatesFromContentfulEntry(autoReplyBroadcastEntry);
+  result.should.deep.equal({});
 });
 
 // isAutoReply

--- a/test/utils/factories/contentful/askYesNo.js
+++ b/test/utils/factories/contentful/askYesNo.js
@@ -1,22 +1,22 @@
 'use strict';
 
 const stubs = require('../../stubs');
-const messageFactory = require('./message');
 const textPostConfigFactory = require('./textPostConfig');
 
 function getValidAskYesNo(date = Date.now()) {
-  const data = {
+  return {
     sys: stubs.contentful.getSysWithTypeAndDate('askYesNo', date),
     fields: {
       name: stubs.getBroadcastName(),
-      askYesNo: messageFactory.getValidMessage(),
-      saidYes: textPostConfigFactory.getValidTextPostConfig(),
-      saidNo: messageFactory.getValidMessage(),
-      invalidAskYesNoResponse: messageFactory.getValidMessage(),
-      saidNoAutoReply: messageFactory.getValidMessage(),
+      text: stubs.getRandomMessageText(),
+      attachments: stubs.contentful.getAttachments(),
+      topic: textPostConfigFactory.getValidTextPostConfig(),
+      saidYes: stubs.getRandomMessageText(),
+      saidNo: stubs.getRandomMessageText(),
+      invalidAskYesNoResponse: stubs.getRandomMessageText(),
+      autoReply: stubs.getRandomMessageText(),
     },
   };
-  return data;
 }
 
 module.exports = {

--- a/test/utils/factories/contentful/askYesNo.js
+++ b/test/utils/factories/contentful/askYesNo.js
@@ -10,7 +10,7 @@ function getValidAskYesNo(date = Date.now()) {
       name: stubs.getBroadcastName(),
       text: stubs.getRandomMessageText(),
       attachments: stubs.contentful.getAttachments(),
-      topic: textPostConfigFactory.getValidTextPostConfig(),
+      saidYesTopic: textPostConfigFactory.getValidTextPostConfig(),
       saidYes: stubs.getRandomMessageText(),
       saidNo: stubs.getRandomMessageText(),
       invalidAskYesNoResponse: stubs.getRandomMessageText(),

--- a/test/utils/factories/contentful/autoReply.js
+++ b/test/utils/factories/contentful/autoReply.js
@@ -7,7 +7,7 @@ function getValidAutoReply(date = Date.now()) {
   const data = {
     sys: stubs.contentful.getSysWithTypeAndDate('autoReply', date),
     fields: {
-      name: stubs.getBroadcastName(),
+      name: stubs.getRandomName(),
       autoReply: messageFactory.getValidMessage(),
       // TODO: Add a campaign reference field, returning a campaign factory's valid campaign.
     },

--- a/test/utils/factories/contentful/autoReplyBroadcast.js
+++ b/test/utils/factories/contentful/autoReplyBroadcast.js
@@ -1,21 +1,14 @@
 'use strict';
 
 const stubs = require('../../stubs');
-const messageFactory = require('./message');
 const autoReplyFactory = require('./autoReply');
 
-function getValidAutoReplyBroadcast() {
+function getValidAutoReplyBroadcast(date = Date.now()) {
   const data = {
-    sys: {
-      id: stubs.getContentfulId(),
-      contentType: {
-        sys: {
-          id: 'autoReplyBroadcast',
-        },
-      },
-    },
+    sys: stubs.contentful.getSysWithTypeAndDate('autoReplyBroadcast', date),
     fields: {
-      broadcast: messageFactory.getValidMessage(),
+      text: stubs.getRandomMessageText(),
+      attachments: stubs.contentful.getAttachments(),
       topic: autoReplyFactory.getValidAutoReply(),
     },
   };

--- a/test/utils/factories/contentful/broadcast.js
+++ b/test/utils/factories/contentful/broadcast.js
@@ -18,16 +18,7 @@ module.exports.getValidCampaignBroadcast = function getValidCampaignBroadcast(da
           campaignId: stubs.getCampaignId(),
         },
       },
-      attachments: [
-        {
-          sys: {
-            id: stubs.getContentfulId(),
-          },
-          fields: {
-            file: stubs.getAttachment(),
-          },
-        },
-      ],
+      attachments: stubs.contentful.getAttachments(),
     },
   };
 };

--- a/test/utils/factories/contentful/broadcast.js
+++ b/test/utils/factories/contentful/broadcast.js
@@ -4,16 +4,7 @@ const stubs = require('../../stubs');
 
 module.exports.getValidCampaignBroadcast = function getValidCampaignBroadcast(date = Date.now()) {
   return {
-    sys: {
-      id: stubs.getBroadcastId(),
-      contentType: {
-        sys: {
-          id: 'broadcast',
-        },
-      },
-      createdAt: date,
-      updatedAt: date,
-    },
+    sys: stubs.contentful.getSysWithTypeAndDate('broadcast', date),
     fields: {
       name: stubs.getBroadcastName(),
       topic: null,

--- a/test/utils/factories/contentful/message.js
+++ b/test/utils/factories/contentful/message.js
@@ -7,16 +7,7 @@ function getValidMessage() {
     sys: stubs.contentful.getSysWithTypeAndDate('message'),
     fields: {
       text: stubs.getRandomMessageText(),
-      attachments: [
-        {
-          sys: {
-            id: stubs.getContentfulId(),
-          },
-          fields: {
-            file: stubs.getAttachment(),
-          },
-        },
-      ],
+      attachments: stubs.contentful.getAttachments(),
     },
   };
   return data;

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -26,6 +26,19 @@ function getAttachment() {
   };
 }
 
+function getAttachments() {
+  return [
+    {
+      sys: {
+        id: module.exports.getContentfulId(),
+      },
+      fields: {
+        file: module.exports.getAttachment(),
+      },
+    },
+  ];
+}
+
 /**
  * @return {String}
  */
@@ -44,6 +57,10 @@ function getFetchByContentTypesResultWithArray(data) {
     },
     data,
   };
+}
+
+function getRandomName() {
+  return `${chance.animal()} ${chance.word()}`;
 }
 
 /**
@@ -139,6 +156,7 @@ module.exports = {
   getRandomMessageText: function getRandomMessageText() {
     return chance.sentence();
   },
+  getRandomName,
   getRandomWord,
   getTemplateName: function getTemplateName() {
     return 'memberSupport';
@@ -273,6 +291,7 @@ module.exports = {
     return msg;
   },
   contentful: {
+    getAttachments,
     getFetchByContentTypesResultWithArray,
     getAllTemplatesForCampaignId: function getAllTemplatesForCampaignId() {
       return module.exports.getJSONstub('all-campaign-fields');


### PR DESCRIPTION
#### What's this PR do?
This PR adds a `topic` property to the properties in the `templates` object of a `GET /topics/:id` response... and also adds a `topic` property to the `message` object in a `GET /broadcasts/:id`. If said `topic` object contains an `id` property, it means that when a user receives the given template/message, their conversation topic should be updated. In a future PR, [gambit-conversations](https://github.com/dosomething/gambit-conversations) will inspect this topic property and change the `conversation.topic` accordingly if a relevant broadcast/reply is received/sent.

This can be seen in two instances for our new types:

* for an `autoReplyBroadcast`, if the `message.topic` property contains an id -- the conversation topic should be updated upon receiving the broadcast. The `autoReplyBroadcast` content type contains a `topic` reference property limited to `autoReply` entries.

* for an `askYesNo` broadcast, if user responds with a yes, upon receiving a `saidYes` reply -- the conversation topic should be updated to the `saidYesTopic` reference value. The `saidYesTopic` reference field is limited to `autoReply`, `externalPostConfig`, `photoPostConfig`, and `textPostConfig` content types.

    * Note: once an `autoReply` topic is built out (with a campaign reference), it will deprecate the `externalPostConfig` type 

Also standardizes the field names to add for when a content type may be as an outbound broadcast message: it needs to contain a single-value text named `text` and an multi-value media field named `atttachments`.

#### How should this be reviewed?
Verify expected topic properties per test entries in our new types:

* `askYesNo` - e.g. `GET /broadcasts/2X4r3fZrTGA2mGemowgiEI` -- should have a topic.id set in the `templates.saidYes` property

* `autoReplyBroadcast` - e.g. `GET /broadcasts/ =6zj3wladnGyWuMWAUYyg8c` -- should have a `topic.id` set in the `message` property

#### Any background context you want to provide?
I initially thought it'd be convenient for all of our various template fields like `saidNo` on an `askYesNo` to reference a `message` entry, so we could add attachments to any given template. In practice, this started to look like a nightmare as I began to add a few different new broadcast entires (e.g. `askYesNo`, `askAutoReply` -- where for most of these, there isn't a big need to re-use any of the `saidNo` templates. This also feels consistent with our existing `externalPostConfig`, `photoPostConfig` and `textPostConfig` entries -- as most of the templates we send within a topic will never contain attachments (which would potentially cost more 💰to send in the first place). I've updated the contentful factories accordingly to mirror the current field types per broadcast content type.

#### Relevant tickets
https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
