### PR TITLE
Adds askSubscriptionStatus as a broadcastable content type

### DIFF
--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -17,6 +17,10 @@
  */
 module.exports = {
   contentTypes: {
+    askSubscriptionStatus: {
+      type: 'askSubscriptionStatus',
+      broadcastable: true,
+    },
     askYesNo: {
       type: 'askYesNo',
       broadcastable: true,

--- a/documentation/endpoints/broadcasts.md
+++ b/documentation/endpoints/broadcasts.md
@@ -13,8 +13,8 @@ Name | Type | Description
 `message.text` | String |
 `message.attachments` | Array |
 `message.template` | String |
-`message.topic` | Object | If an id property exists, its saved to the [conversation topic](https://github.com/DoSomething/gambit-campaigns/blob/master/documentation/endpoints/topics.md) when broadcast is sent
-`templates` | Object | Defines replies for when this broadcast is saved as a [conversation topic](https://github.com/DoSomething/gambit-campaigns/blob/master/documentation/endpoints/topics.md) -- used in `askYesNo`, which will update the conversation topic again if user answers yes
+`message.topic` | Object | Optional. If is set, the id saved to the [conversation topic](https://github.com/DoSomething/gambit-campaigns/blob/master/documentation/endpoints/topics.md) when user receives the message. Otherwise the topic is set to this broadcast id.
+`templates` | Object | Provides replies for when this broadcast is saved for a [conversation topic](https://github.com/DoSomething/gambit-campaigns/blob/master/documentation/endpoints/topics.md) -- used in `askYesNo`, which will update the conversation topic again if user answers yes
 
 Legacy fields (only used for type `broadcast`)
 
@@ -84,8 +84,12 @@ curl http://localhost:5000/v1/broadcasts?skip=20
       "templates": {
         "saidYes": {
           "text": "Great! Text START to submit a photo.",
-          "topic": {
-            "id": "4xXe9sQqmIeiWauSUu6kAY"
+           "topic": {
+            "id": "4xXe9sQqmIeiWauSUu6kAY",
+            "name": "Pump It Up - Submit Flyer",
+            "type": "photoPostConfig",
+            "createdAt": "2018-08-01T14:41:30.242Z",
+            "updatedAt": "2018-08-07T15:44:59.609Z"
           }
         },
         "saidNo": {

--- a/documentation/endpoints/topics.md
+++ b/documentation/endpoints/topics.md
@@ -118,7 +118,11 @@ curl http://localhost:5000/v1/topics?skip=5
         "saidYes": {
           "text": "Great! Text START to submit a photo.",
           "topic": {
-            "id": "4xXe9sQqmIeiWauSUu6kAY"
+            "id": "4xXe9sQqmIeiWauSUu6kAY",
+            "name": "Pump It Up - Submit Flyer",
+            "type": "photoPostConfig",
+            "createdAt": "2018-08-01T14:41:30.242Z",
+            "updatedAt": "2018-08-07T15:44:59.609Z"
           }
         },
         "saidNo": {

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -67,8 +67,8 @@ function getSummaryFromContentfulEntry(contentfulEntry) {
  * @return {Object}
  */
 function getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, templateName) {
-  const topicRef = contentfulEntry.fields.topic;
-  const topic = topicRef ? { id: contentful.getContentfulIdFromContentfulEntry(topicRef) } : {};
+  const topicEntry = contentfulEntry.fields.topic;
+  const topic = topicEntry ? module.exports.getSummaryFromContentfulEntry(topicEntry) : {};
   return {
     text: contentful.getTextFromMessage(contentfulEntry),
     attachments: contentful.getAttachmentsFromContentfulEntry(contentfulEntry),
@@ -93,14 +93,11 @@ function getTopicTemplatesFromContentfulEntry(contentfulEntry) {
 
   templateFieldNames.forEach((fieldName) => {
     const text = contentfulEntry.fields[fieldName];
-    const topic = {};
-    // The saidYes template should change conversation topic to the saidYesTopic field.
-    if (fieldName === 'saidYes') {
-      const topicRef = contentfulEntry.fields.saidYesTopic;
-      if (topicRef) {
-        topic.id = contentful.getContentfulIdFromContentfulEntry(topicRef);
-      }
-    }
+    // The saidYes template should include the topic saved to the saidYesTopic field.
+    const hasSaidYesTopic = fieldName === 'saidYes' && contentfulEntry.fields.saidYesTopic;
+    const topic = hasSaidYesTopic ? module.exports
+      .getSummaryFromContentfulEntry(contentfulEntry.fields.saidYesTopic) : {};
+
     result[fieldName] = {
       text,
       topic,


### PR DESCRIPTION
#### What's this PR do?

* I've manually created an `askSubscriptionStatus` content type in Contentful, simply with the `text` and `attachments` fields. On the Conversations side, if a broadcast request is sent for an `askSubscriptionStatus` type, we'll hardcode setting the conversation to `askSubscriptionStatus`. 

    * Ideally, we'd add `saidActive`, `saidLess`, `needsMoreInfo` templates to avoid hardcoding replies in Rivescript, but we're aiming to send these broadcasts again soon -- and I'm aiming to get us off the legacy `broadcast` type. When we set the `topic` field there we're only using it for `survey_response` broadcasts (which our new `AutoReplyBroadcast` in #1072 will deprecate) and `ask_subscription_status` broadcasts (which this type aims to deprecate)


* Returns a topic summary instead of id per https://github.com/DoSomething/gambit-campaigns/pull/1072/files/8dc28ee16a5e373597f7f750d65dc917c095deb7#r209002872

#### How should this be reviewed?
Verify the response of an `askSubscriptionStatus` id (e.g.  4qLXWRSqY0ommayY2iWCwU) looks broadcastable (e.g. has a message.text property) in a GET v1/broadcasts/:id response:

```
// http://localhost:5000/v1/broadcasts/4qLXWRSqY0ommayY2iWCwU?apiKey=totallysecret&cache=false

{
  "data": {
    "id": "4qLXWRSqY0ommayY2iWCwU",
    "name": "Test askSubscriptionStatus",
    "type": "askSubscriptionStatus",
    "createdAt": "2018-08-09T17:24:44.553Z",
    "updatedAt": "2018-08-09T17:25:16.527Z",
    "message": {
      "text": "Aaron Testing A) Weekly B) Monthly C) More info",
      "attachments": [
        
      ],
      "template": "askSubscriptionStatus",
      "topic": {
        
      }
    },
    "templates": {
      
    }
  }
}
```

#### Any background context you want to provide?

We could manually return `ask_subscription_status` as the `topic.id`, but then we'd be keeping it up to date in 2 places, which didn't seem right. I keep pondering over moving all the hardcoded Rivescript into this repo, so when Conversations starts it fetches all Rivescript from the API (this app would be responsible for parsing all of the defaultTopicTrigger (or other topic related) data into Rivescript to provide the replies for all Conversations `messages?origin=member` requests.

#### Relevant tickets
https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [x] Tested on staging.
