### PR TITLE
Adds photoPostBroadcast and textPostBroadcast types

### DIFF
--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -12,8 +12,10 @@
  * fields to use if the field values are blank.
  *
  * A broadcastable content type currently requires a text field named "text" and attachments field
- * named "attachments" to define content for the outbound broadcast.
- *
+ * named "attachments" to define content for the outbound broadcast. If a topic reference field
+ * exists, it will include the topic in the outbound message, indicating that the conversation topic
+ * should be updated upon receiving the broadcast (otherwise, the broadcast itself can be used as a
+ * topic if it has templates -- e.g. askYesNo)
  */
 module.exports = {
   contentTypes: {
@@ -47,9 +49,17 @@ module.exports = {
     message: {
       type: 'message',
     },
+    photoPostBroadcast: {
+      type: 'photoPostBroadcast',
+      broadcastable: true,
+    },
     photoPostConfig: {
       type: 'photoPostConfig',
       postType: 'photo',
+    },
+    textPostBroadcast: {
+      type: 'textPostBroadcast',
+      broadcastable: true,
     },
     textPostConfig: {
       type: 'textPostConfig',

--- a/config/lib/middleware/campaignActivity/required-params.js
+++ b/config/lib/middleware/campaignActivity/required-params.js
@@ -7,7 +7,6 @@ configVars.requiredParams = [
   'campaignId',
   'campaignRunId',
   'platform',
-  'postType',
   'userId',
 ];
 module.exports = configVars;

--- a/documentation/endpoints/campaignActivity.md
+++ b/documentation/endpoints/campaignActivity.md
@@ -21,7 +21,7 @@ Name | Type | Description
 `userId` | `string` | **Required.** 
 `campaignId` | `string` | **Required.** Campaign that the User has signed up for.
 `campaignRunId` | `string` | **Required.** Campaign Run that the User has signed up for.
-`postType` | `string` | **Required.** Type of Post to submit for the Campaign.
+`postType` | `string` |  Optional -- type of campaign post to submit (when set to `text`) or begin (when set to `photo`) 
 `platform` | `string` | **Required.** Platform that message was sent from.
 `text` | `string` | Message text.
 `mediaUrl` | `string` | Message media URL.


### PR DESCRIPTION
#### What's this PR do?

* Adds two new types I've manually created in Contentful to deprecate using the legacy broadcast type configured with `askText` or `startPhotoPost` template values.

    * The `photoPostBroadcast` topic reference field is limited to `photoPostConfig` entries; the `textPostBroadcast` topic reference field is limited to `textPostConfig` entries.

* Updates the `POST /campaignActivity` required params to make `postType` optional - as our `autoReply` topic won't be sending a `postType` but may be sending a request for a signup. 

#### How should this be reviewed?
Verify the API responses look broadcastable (a message.text is provided, the message.template matches the content type name). I've created test entries for each type:

`5t2fmKd2iQgaCCy8Kgg0CI` -a photoPostBroadcast
`1pGaGNh8fCyIeqAukYkUwM` - a textPostBroadcast



```
// http://localhost:5000/v1/broadcasts/5t2fmKd2iQgaCCy8Kgg0CI?apiKey=totallysecret&test=123
{
  "data": {
    "id": "5t2fmKd2iQgaCCy8Kgg0CI",
    "name": "Test photoPostBroadcast #1",
    "type": "photoPostBroadcast",
    "createdAt": "2018-08-09T21:14:49.304Z",
    "updatedAt": "2018-08-09T21:15:41.308Z",
    "message": {
      "text": "Have you posted a flyer yet? Text START to share your photo.",
      "attachments": [
        
      ],
      "template": "photoPostBroadcast",
      "topic": {
        "id": "4xXe9sQqmIeiWauSUu6kAY",
        "name": "Pump It Up - Submit Flyer",
        "type": "photoPostConfig",
        "createdAt": "2018-08-01T14:41:30.242Z",
        "updatedAt": "2018-08-07T15:44:59.609Z"
      }
    },
    "templates": {
      
    }
  }
}
```

#### Relevant tickets
https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [x] Tested on staging.
