### PR TITLE
Return full objects instead of summaries for nested topics in GET topics/broadcasts responses [pr]

### DIFF
--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -30,7 +30,6 @@ module.exports = {
         'saidYes',
         'saidNo',
         'invalidAskYesNoResponse',
-        'autoReply',
       ],
     },
     autoReply: {

--- a/documentation/endpoints/broadcasts.md
+++ b/documentation/endpoints/broadcasts.md
@@ -81,29 +81,55 @@ curl http://localhost:5000/v1/broadcasts?skip=20
         "template": "askYesNo",
         "topic": {}
       },
-      "templates": {
-        "saidYes": {
-          "text": "Great! Text START to submit a photo.",
-           "topic": {
-            "id": "4xXe9sQqmIeiWauSUu6kAY",
-            "name": "Pump It Up - Submit Flyer",
-            "type": "photoPostConfig",
-            "createdAt": "2018-08-01T14:41:30.242Z",
-            "updatedAt": "2018-08-07T15:44:59.609Z"
+    "templates": {
+      "saidYes": {
+        "text": "Great! Text START to submit a photo.",
+        "topic": {
+          "id": "4xXe9sQqmIeiWauSUu6kAY",
+          "name": "Pump It Up - Submit Flyer",
+          "type": "photoPostConfig",
+          "createdAt": "2018-08-01T14:41:30.242Z",
+          "updatedAt": "2018-08-13T13:31:32.583Z",
+          "postType": "photo",
+          "campaign": {
+            "id": 8142,
+            "title": "Pump It Up",
+            "tagline": "Print & post our tire flyers to keep friends safe on the road.",
+            "status": "active",
+            "currentCampaignRun": {
+              "id": 8161
+            },
+            "endDate": {
+              "date": "2018-09-30 23:59:00.000000",
+              "timezone_type": 1,
+              "timezone": "-04:00"
+            }
+          },
+          "templates": {
+            ...
           }
         },
         "saidNo": {
           "text": "Ok, we'll check in with you later.",
-          "topic": {}
+          "topic": {
+            "id": "61RPZx8atiGyeoeaqsckOE",
+            "name": "Generic autoReply",
+            "type": "autoReply",
+            "createdAt": "2018-08-07T17:43:06.893Z",
+            "updatedAt": "2018-08-13T18:08:16.056Z",
+            "campaign": {},
+            "templates": {
+              "autoReply": {
+                "text": "Sorry, I didn't understand that. Text Q if you have a question.",
+                "topic": {}
+              }
+            }
+          }
         },
         "invalidAskYesNoResponse": {
           "text": "Sorry, I didn't get that - did you want to join for Pump It Up? Yes or No",
           "topic": {}
         },
-        "autoReply": {
-          "text": "Sorry, I didn't understand that. Text Q if you have a question.",
-          "topic": {}
-        }
       },
     },
     ...

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -63,20 +63,21 @@ function getById(broadcastId, resetCache = false) {
  * @param {Object} contentfulEntry
  * @return {Promise}
  */
-function parseBroadcastFromContentfulEntry(contentfulEntry) {
+async function parseBroadcastFromContentfulEntry(contentfulEntry) {
   const data = helpers.contentfulEntry.getSummaryFromContentfulEntry(contentfulEntry);
   // A nice to have TODO would be migrating all legacy broadcast entries into their new respective
   // type to avoid this check, but it likely is not possible to change type of an existing entry.
   if (helpers.contentfulEntry.isLegacyBroadcast(contentfulEntry)) {
-    return Promise.resolve(Object.assign(data, module.exports
-      .getLegacyBroadcastDataFromContentfulEntry(contentfulEntry)));
+    return Object.assign(data, module.exports
+      .getLegacyBroadcastDataFromContentfulEntry(contentfulEntry));
   }
   // Parse the outbound broadcast message to send.
-  const message = helpers.contentfulEntry
+  const message = await helpers.contentfulEntry
     .getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, data.type);
   // Parse topic templates if they exist.
-  const templates = helpers.contentfulEntry.getTopicTemplatesFromContentfulEntry(contentfulEntry);
-  return Promise.resolve(Object.assign(data, { message, templates }));
+  const templates = await helpers.contentfulEntry
+    .getTopicTemplatesFromContentfulEntry(contentfulEntry);
+  return Object.assign(data, { message, templates });
 }
 
 /**

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -71,12 +71,15 @@ async function parseBroadcastFromContentfulEntry(contentfulEntry) {
     return Object.assign(data, module.exports
       .getLegacyBroadcastDataFromContentfulEntry(contentfulEntry));
   }
-  // Parse the outbound broadcast message to send.
-  const message = await helpers.contentfulEntry
-    .getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, data.type);
-  // Parse topic templates if they exist.
-  const templates = await helpers.contentfulEntry
-    .getTopicTemplatesFromContentfulEntry(contentfulEntry);
+
+  const [message, templates] = await Promise.all([
+    // Parse the outbound broadcast message to send.
+    helpers.contentfulEntry
+      .getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, data.type),
+    // Parse topic templates if they exist.
+    helpers.contentfulEntry.getTopicTemplatesFromContentfulEntry(contentfulEntry),
+  ]);
+
   return Object.assign(data, { message, templates });
 }
 

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -77,7 +77,7 @@ async function parseBroadcastFromContentfulEntry(contentfulEntry) {
     helpers.contentfulEntry
       .getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, data.type),
     // Parse topic templates if they exist.
-    helpers.contentfulEntry.getTopicTemplatesFromContentfulEntry(contentfulEntry),
+    helpers.contentfulEntry.getTopicTemplates(contentfulEntry),
   ]);
 
   return Object.assign(data, { message, templates });

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -64,11 +64,12 @@ function getSummaryFromContentfulEntry(contentfulEntry) {
 /**
  * @param {Object} contentfulEntry
  * @param {String} templateName
- * @return {Object}
+ * @return {Promise}
  */
-function getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, templateName) {
+async function getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, templateName) {
   const topicEntry = contentfulEntry.fields.topic;
-  const topic = topicEntry ? module.exports.getSummaryFromContentfulEntry(topicEntry) : {};
+  const topic = topicEntry ? await helpers.topic
+    .getById(contentful.getContentfulIdFromContentfulEntry(topicEntry)) : {};
   return {
     text: contentful.getTextFromMessage(contentfulEntry),
     attachments: contentful.getAttachmentsFromContentfulEntry(contentfulEntry),
@@ -80,9 +81,9 @@ function getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, t
 /**
  * @param {Object}
  * @param {String}
- * @return {Object}
+ * @return {Promise}
  */
-function getTopicTemplatesFromContentfulEntry(contentfulEntry) {
+async function getTopicTemplatesFromContentfulEntry(contentfulEntry) {
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
   const templateFieldNames = config.contentTypes[contentType].templates;
   const result = {};
@@ -92,17 +93,17 @@ function getTopicTemplatesFromContentfulEntry(contentfulEntry) {
   }
 
   templateFieldNames.forEach((fieldName) => {
-    const text = contentfulEntry.fields[fieldName];
-    // The saidYes template should include the topic saved to the saidYesTopic field.
-    const hasSaidYesTopic = fieldName === 'saidYes' && contentfulEntry.fields.saidYesTopic;
-    const topic = hasSaidYesTopic ? module.exports
-      .getSummaryFromContentfulEntry(contentfulEntry.fields.saidYesTopic) : {};
-
     result[fieldName] = {
-      text,
-      topic,
+      text: contentfulEntry.fields[fieldName],
+      topic: {},
     };
   });
+
+  // The saidYes template should include the topic saved to the saidYesTopic field.
+  if (result.saidYes && contentfulEntry.fields.saidYesTopic) {
+    result.saidYes.topic = await helpers.topic
+      .getById(contentful.getContentfulIdFromContentfulEntry(contentfulEntry.fields.saidYesTopic));
+  }
 
   return result;
 }

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -105,6 +105,12 @@ async function getTopicTemplatesFromContentfulEntry(contentfulEntry) {
       .getById(contentful.getContentfulIdFromContentfulEntry(contentfulEntry.fields.saidYesTopic));
   }
 
+  // The saidNo template should include the topic saved to the saidNoTopic field.
+  if (result.saidNo && contentfulEntry.fields.saidNoTopic) {
+    result.saidNo.topic = await helpers.topic
+      .getById(contentful.getContentfulIdFromContentfulEntry(contentfulEntry.fields.saidNoTopic));
+  }
+
   return result;
 }
 

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -83,7 +83,7 @@ async function getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEn
  * @param {String}
  * @return {Promise}
  */
-async function getTopicTemplatesFromContentfulEntry(contentfulEntry) {
+async function getTopicTemplates(contentfulEntry) {
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
   const templateFieldNames = config.contentTypes[contentType].templates;
   const result = {};
@@ -160,7 +160,7 @@ module.exports = {
   getContentTypeConfigs,
   getMessageTemplateFromContentfulEntryAndTemplateName,
   getSummaryFromContentfulEntry,
-  getTopicTemplatesFromContentfulEntry,
+  getTopicTemplates,
   isAutoReply,
   isBroadcastable,
   isDefaultTopicTrigger,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -150,7 +150,7 @@ function getFieldValueFromContentfulEntryAndTemplateName(contentfulEntry, templa
  * @param {String} templateName
  * @return {Object}
  */
-function parseRawAndOverrideFromContentfulEntryAndTemplateName(contentfulEntry, templateName) {
+function parseRawAndOverride(contentfulEntry, templateName) {
   const data = {};
   const templateText = module.exports
     .getFieldValueFromContentfulEntryAndTemplateName(contentfulEntry, templateName);
@@ -173,13 +173,13 @@ function parseRawAndOverrideFromContentfulEntryAndTemplateName(contentfulEntry, 
  * @param {Object} campaign
  * @return {Object}
  */
-function getTemplatesWithDefaultsFromContentfulEntryAndCampaign(contentfulEntry, campaign) {
+function getTemplates(contentfulEntry, campaign) {
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
   const data = {};
   const templateNames = Object.keys(config.templatesByContentType[contentType]);
   templateNames.forEach((templateName) => {
     data[templateName] = module.exports
-      .parseRawAndOverrideFromContentfulEntryAndTemplateName(contentfulEntry, templateName);
+      .parseRawAndOverride(contentfulEntry, templateName);
     data[templateName].text = helpers
       .replacePhoenixCampaignVars(data[templateName].raw, campaign);
     // TODO: Remove rendered property once Gambit Conversations references text.
@@ -240,7 +240,7 @@ async function parseTopicFromContentfulEntry(contentfulEntry) {
   // names that don't match the template names). A rainy day TODO here would be to migrate the field
   // names to DRY all template/field name mapping.
   data.templates = module.exports
-    .getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign(contentfulEntry, data.campaign);
+    .getTopicTemplates(contentfulEntry, data.campaign);
   return data;
 }
 
@@ -249,15 +249,15 @@ async function parseTopicFromContentfulEntry(contentfulEntry) {
  * @param {Object} campaign
  * @return {Object}
  */
-function getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign(contentfulEntry, campaign) {
+function getTopicTemplates(contentfulEntry, campaign) {
   const topicTemplates = module.exports
-    .getTemplatesWithDefaultsFromContentfulEntryAndCampaign(contentfulEntry, campaign);
+    .getTemplates(contentfulEntry, campaign);
   const campaignConfigEntry = contentfulEntry.fields.campaign;
   if (!campaignConfigEntry) {
     return topicTemplates;
   }
   const campaignConfigTemplates = module.exports
-    .getTemplatesWithDefaultsFromContentfulEntryAndCampaign(campaignConfigEntry, campaign);
+    .getTemplates(campaignConfigEntry, campaign);
   return Object.assign(topicTemplates, campaignConfigTemplates);
 }
 
@@ -272,9 +272,9 @@ module.exports = {
   getFieldValueFromContentfulEntryAndTemplateName,
   getPostTypeFromContentType,
   getTemplateInfoFromContentfulEntryAndTemplateName,
-  getTemplatesWithDefaultsFromContentfulEntryAndCampaign,
-  getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign,
+  getTemplates,
+  getTopicTemplates,
   isTopicForCampaignId,
-  parseRawAndOverrideFromContentfulEntryAndTemplateName,
+  parseRawAndOverride,
   parseTopicFromContentfulEntry,
 };

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -232,7 +232,7 @@ async function parseTopicFromContentfulEntry(contentfulEntry) {
   // Templates for autoReply topics are configured via the contentfulEntry helper.
   if (helpers.contentfulEntry.isAutoReply(contentfulEntry)) {
     data.templates = await helpers.contentfulEntry
-      .getTopicTemplatesFromContentfulEntry(contentfulEntry);
+      .getTopicTemplates(contentfulEntry);
     return data;
   }
 

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -174,14 +174,12 @@ function parseRawAndOverride(contentfulEntry, templateName) {
  * @return {Object}
  */
 function getTemplates(contentfulEntry, campaign) {
-  const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
   const data = {};
+  const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
   const templateNames = Object.keys(config.templatesByContentType[contentType]);
   templateNames.forEach((templateName) => {
-    data[templateName] = module.exports
-      .parseRawAndOverride(contentfulEntry, templateName);
-    data[templateName].text = helpers
-      .replacePhoenixCampaignVars(data[templateName].raw, campaign);
+    data[templateName] = module.exports.parseRawAndOverride(contentfulEntry, templateName);
+    data[templateName].text = helpers.replacePhoenixCampaignVars(data[templateName].raw, campaign);
     // TODO: Remove rendered property once Gambit Conversations references text.
     data[templateName].rendered = data[templateName].text;
   });
@@ -214,15 +212,18 @@ async function parseTopicFromContentfulEntry(contentfulEntry) {
 
   // Get campaign if topic has a campaign set.
   const campaignConfigEntry = contentfulEntry.fields.campaign;
+  const campaignId = campaignConfigEntry ? contentful
+    .getCampaignIdFromContentfulEntry(campaignConfigEntry) : null;
+
   try {
-    data.campaign = campaignConfigEntry ? await helpers.campaign
-      .getById(contentful.getCampaignIdFromContentfulEntry(campaignConfigEntry)) : {};
+    data.campaign = campaignId ? await helpers.campaign.getById(campaignId) : {};
   } catch (error) {
-    // The campaignId is set via freeform text field on the campaign content type.
-    // If a topic's campaign is misconfigured, we still want to return topic data.
-    // Hardcode the status as closed to auto reply with the campaignClosed template.
+    // The campaignId value is set by manual input in Contentful, when adding or editing a campaign
+    // entry. If a topic campaign is misconfigured, we still want to return topic data.
     if (error.status === 404) {
-      data.campaign = { status: 'closed' };
+      // Hardcode status as closed to avoid posting activity for an unknown campaign.
+      // TODO: Get status value from campaign helper config instead of hardcoding here.
+      data.campaign = { id: campaignId, status: 'closed' };
     } else {
       throw error;
     }

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -194,7 +194,7 @@ function getPostTypeFromContentType(contentType) {
  * @param {Object} contentfulEntry
  * @return {Promise}
  */
-function parseTopicFromContentfulEntry(contentfulEntry) {
+async function parseTopicFromContentfulEntry(contentfulEntry) {
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
 
   if (helpers.contentfulEntry.isBroadcastable(contentfulEntry)) {
@@ -203,32 +203,27 @@ function parseTopicFromContentfulEntry(contentfulEntry) {
 
   const data = helpers.contentfulEntry.getSummaryFromContentfulEntry(contentfulEntry);
   data.postType = module.exports.getPostTypeFromContentType(contentType);
+
+  // Get campaign if topic has a campaign set.
   const campaignConfigEntry = contentfulEntry.fields.campaign;
-  let promise = Promise.resolve(null);
-  let campaignId;
-  if (campaignConfigEntry) {
-    campaignId = contentful.getCampaignIdFromContentfulEntry(campaignConfigEntry);
-    promise = helpers.campaign.getById(campaignId);
-  }
-  return promise
-    .then((campaign) => {
-      data.campaign = campaign;
-      data.templates = module.exports
-        .parseTopicTemplatesFromContentfulEntryAndCampaign(contentfulEntry, campaign);
-      return data;
-    })
-    .catch((error) => {
-      if (error.status === 404) {
-        // The campaignId is set via freeform text field on the campaign content type.
-        // If a topic's campaign is misconfigured, we still want to return topic data.
-        // Hardcode the status as closed to auto reply with the campaignClosed template.
-        data.campaign = { id: campaignId, status: 'closed' };
-        data.templates = module.exports
-          .parseTopicTemplatesFromContentfulEntryAndCampaign(contentfulEntry, null);
-        return data;
-      }
+  try {
+    data.campaign = campaignConfigEntry ? await helpers.campaign
+      .getById(contentful.getCampaignIdFromContentfulEntry(campaignConfigEntry)) : {};
+  } catch (error) {
+    // The campaignId is set via freeform text field on the campaign content type.
+    // If a topic's campaign is misconfigured, we still want to return topic data.
+    // Hardcode the status as closed to auto reply with the campaignClosed template.
+    if (error.status === 404) {
+      data.campaign = { status: 'closed' };
+    } else {
       throw error;
-    });
+    }
+  }
+
+  data.templates = module.exports
+    .parseTopicTemplatesFromContentfulEntryAndCampaign(contentfulEntry, data.campaign);
+
+  return data;
 }
 
 /**

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -42,6 +42,10 @@ function fetchById(topicId) {
 }
 
 /**
+ * TODO: We're caching a list of all topics to make it easy to find topics by campaign id. Slowly
+ * starting to move away from using this (and leaving it to something like GraphQL to querying by
+ * nested object properties.
+ *
  * @return {Promise}
  */
 function getAll() {

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -116,33 +116,37 @@ function getTemplateInfoFromContentfulEntryAndTemplateName(contentfulEntry, temp
 }
 
 /**
- * @param {Object} entry
+ * @param {Object} contentfulEntry
  * @param {String} templateName
  * @return {String}
  */
-function getDefaultTextFromContentfulEntryAndTemplateName(entry, templateName) {
+function getDefaultTextFromContentfulEntryAndTemplateName(contentfulEntry, templateName) {
   const templateInfo = module.exports
-    .getTemplateInfoFromContentfulEntryAndTemplateName(entry, templateName);
+    .getTemplateInfoFromContentfulEntryAndTemplateName(contentfulEntry, templateName);
   return templateInfo.defaultText;
 }
 
 /**
- * @param {Object} entry
+ * @param {Object} contentfulEntry
  * @param {String} templateName
  * @return {String}
  */
-function getFieldValueFromContentfulEntryAndTemplateName(entry, templateName) {
+function getFieldValueFromContentfulEntryAndTemplateName(contentfulEntry, templateName) {
   const templateInfo = module.exports
-    .getTemplateInfoFromContentfulEntryAndTemplateName(entry, templateName);
-  return entry.fields[templateInfo.fieldName];
+    .getTemplateInfoFromContentfulEntryAndTemplateName(contentfulEntry, templateName);
+  return contentfulEntry.fields[templateInfo.fieldName];
 }
 
 /**
- * @param {Object} entry
+ * Returns an object with two properties:
+ * - raw - String saved in the field for the given templateName, or default value if not set
+ * - override - Boolean, true when a field value exists
+ *
+ * @param {Object} contentfulEntry
  * @param {String} templateName
  * @return {Object}
  */
-function parseTemplateFromContentfulEntryAndTemplateName(contentfulEntry, templateName) {
+function parseRawAndOverrideFromContentfulEntryAndTemplateName(contentfulEntry, templateName) {
   const data = {};
   const templateText = module.exports
     .getFieldValueFromContentfulEntryAndTemplateName(contentfulEntry, templateName);
@@ -158,20 +162,20 @@ function parseTemplateFromContentfulEntryAndTemplateName(contentfulEntry, templa
 }
 
 /**
- * @param {Object} entry
+ * Returns the contentfulEntry's text field values (or default values) as templates, rendering any
+ * tags with the given campaign, e.g. Thanks for signing up for {{title}}!
+ *
+ * @param {Object} contentfulEntry
+ * @param {Object} campaign
  * @return {Object}
  */
-function parseTemplatesFromContentfulEntryAndCampaign(contentfulEntry, campaign) {
-  if (helpers.contentfulEntry.isAutoReply(contentfulEntry)) {
-    return helpers.contentfulEntry.getTopicTemplatesFromContentfulEntry(contentfulEntry);
-  }
-
+function getTemplatesWithDefaultsFromContentfulEntryAndCampaign(contentfulEntry, campaign) {
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
   const data = {};
   const templateNames = Object.keys(config.templatesByContentType[contentType]);
   templateNames.forEach((templateName) => {
     data[templateName] = module.exports
-      .parseTemplateFromContentfulEntryAndTemplateName(contentfulEntry, templateName);
+      .parseRawAndOverrideFromContentfulEntryAndTemplateName(contentfulEntry, templateName);
     data[templateName].text = helpers
       .replacePhoenixCampaignVars(data[templateName].raw, campaign);
     // TODO: Remove rendered property once Gambit Conversations references text.
@@ -220,9 +224,19 @@ async function parseTopicFromContentfulEntry(contentfulEntry) {
     }
   }
 
-  data.templates = module.exports
-    .parseTopicTemplatesFromContentfulEntryAndCampaign(contentfulEntry, data.campaign);
+  // Templates for autoReply topics are configured via the contentfulEntry helper.
+  if (helpers.contentfulEntry.isAutoReply(contentfulEntry)) {
+    data.templates = await helpers.contentfulEntry
+      .getTopicTemplatesFromContentfulEntry(contentfulEntry);
+    return data;
+  }
 
+  // The older types (textPostConfig, photoPostConfig, externalPostConfig) are configured via this
+  // topic helper's config, where we've hardcoded default values (and also have Contentful field
+  // names that don't match the template names). A rainy day TODO here would be to migrate the field
+  // names to DRY all template/field name mapping.
+  data.templates = module.exports
+    .getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign(contentfulEntry, data.campaign);
   return data;
 }
 
@@ -231,15 +245,15 @@ async function parseTopicFromContentfulEntry(contentfulEntry) {
  * @param {Object} campaign
  * @return {Object}
  */
-function parseTopicTemplatesFromContentfulEntryAndCampaign(contentfulEntry, campaign) {
+function getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign(contentfulEntry, campaign) {
   const topicTemplates = module.exports
-    .parseTemplatesFromContentfulEntryAndCampaign(contentfulEntry, campaign);
+    .getTemplatesWithDefaultsFromContentfulEntryAndCampaign(contentfulEntry, campaign);
   const campaignConfigEntry = contentfulEntry.fields.campaign;
   if (!campaignConfigEntry) {
     return topicTemplates;
   }
   const campaignConfigTemplates = module.exports
-    .parseTemplatesFromContentfulEntryAndCampaign(campaignConfigEntry, campaign);
+    .getTemplatesWithDefaultsFromContentfulEntryAndCampaign(campaignConfigEntry, campaign);
   return Object.assign(topicTemplates, campaignConfigTemplates);
 }
 
@@ -254,9 +268,9 @@ module.exports = {
   getFieldValueFromContentfulEntryAndTemplateName,
   getPostTypeFromContentType,
   getTemplateInfoFromContentfulEntryAndTemplateName,
+  getTemplatesWithDefaultsFromContentfulEntryAndCampaign,
+  getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign,
   isTopicForCampaignId,
-  parseTemplateFromContentfulEntryAndTemplateName,
-  parseTemplatesFromContentfulEntryAndCampaign,
+  parseRawAndOverrideFromContentfulEntryAndTemplateName,
   parseTopicFromContentfulEntry,
-  parseTopicTemplatesFromContentfulEntryAndCampaign,
 };

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -208,7 +208,7 @@ function parseTopicFromContentfulEntry(contentfulEntry) {
   let campaignId;
   if (campaignConfigEntry) {
     campaignId = contentful.getCampaignIdFromContentfulEntry(campaignConfigEntry);
-    promise = helpers.campaign.fetchById(campaignId);
+    promise = helpers.campaign.getById(campaignId);
   }
   return promise
     .then((campaign) => {

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -24,7 +24,6 @@ const defaultTopicTriggerEntry = defaultTopicTriggerFactory.getValidDefaultTopic
 const messageEntry = messageFactory.getValidMessage();
 const fetchTopicResult = { id: stubs.getContentfulId() };
 
-
 // Module to test
 const contentfulEntryHelper = require('../../../lib/helpers/contentfulEntry');
 
@@ -99,12 +98,11 @@ test('getTopicTemplatesFromContentfulEntry returns an empty object if content ty
 });
 
 test('getTopicTemplatesFromContentfulEntry should call topic.getById to set saidYes template topic', async () => {
-  const stubFetchResult = { id: stubs.getContentfulId() };
   sandbox.stub(helpers.topic, 'getById')
-    .returns(stubFetchResult);
+    .returns(fetchTopicResult);
   const result = await contentfulEntryHelper
     .getTopicTemplatesFromContentfulEntry(askYesNoEntry);
-  result.saidYes.topic.should.deep.equal(stubFetchResult);
+  result.saidYes.topic.should.deep.equal(fetchTopicResult);
 });
 
 // isAutoReply

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -85,23 +85,23 @@ test('getSummaryFromContentfulEntry returns an object with name and type propert
   result.updatedAt.should.equal(stubEntryDate);
 });
 
-// getTopicTemplatesFromContentfulEntry
-test('getTopicTemplatesFromContentfulEntry returns an object with templates values if content type config has templates', async () => {
-  const result = await contentfulEntryHelper.getTopicTemplatesFromContentfulEntry(autoReplyEntry);
+// getTopicTemplates
+test('getTopicTemplates returns an object with templates values if content type config has templates', async () => {
+  const result = await contentfulEntryHelper.getTopicTemplates(autoReplyEntry);
   result.autoReply.text.should.equal(autoReplyEntry.fields.autoReply);
 });
 
-test('getTopicTemplatesFromContentfulEntry returns an empty object if content type config does not have templates', async () => {
+test('getTopicTemplates returns an empty object if content type config does not have templates', async () => {
   const result = await contentfulEntryHelper
-    .getTopicTemplatesFromContentfulEntry(autoReplyBroadcastEntry);
+    .getTopicTemplates(autoReplyBroadcastEntry);
   result.should.deep.equal({});
 });
 
-test('getTopicTemplatesFromContentfulEntry should call topic.getById to set saidYes and saidNo topics', async () => {
+test('getTopicTemplates should call topic.getById to set saidYes and saidNo topics', async () => {
   sandbox.stub(helpers.topic, 'getById')
     .returns(fetchTopicResult);
   const result = await contentfulEntryHelper
-    .getTopicTemplatesFromContentfulEntry(askYesNoEntry);
+    .getTopicTemplates(askYesNoEntry);
   result.saidYes.topic.should.deep.equal(fetchTopicResult);
   result.saidNo.topic.should.deep.equal(fetchTopicResult);
 });

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -97,12 +97,13 @@ test('getTopicTemplatesFromContentfulEntry returns an empty object if content ty
   result.should.deep.equal({});
 });
 
-test('getTopicTemplatesFromContentfulEntry should call topic.getById to set saidYes template topic', async () => {
+test('getTopicTemplatesFromContentfulEntry should call topic.getById to set saidYes and saidNo topics', async () => {
   sandbox.stub(helpers.topic, 'getById')
     .returns(fetchTopicResult);
   const result = await contentfulEntryHelper
     .getTopicTemplatesFromContentfulEntry(askYesNoEntry);
   result.saidYes.topic.should.deep.equal(fetchTopicResult);
+  result.saidNo.topic.should.deep.equal(fetchTopicResult);
 });
 
 // isAutoReply

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -54,13 +54,13 @@ test('getSummaryFromContentfulEntry returns an object with name and type propert
 });
 
 // getTopicTemplatesFromContentfulEntry
-test('getTopicTemplatesFromContentfulEntry returns an object with templates values if content type config has templates', () => {
-  const result = contentfulEntryHelper.getTopicTemplatesFromContentfulEntry(autoReplyEntry);
+test('getTopicTemplatesFromContentfulEntry returns an object with templates values if content type config has templates', async () => {
+  const result = await contentfulEntryHelper.getTopicTemplatesFromContentfulEntry(autoReplyEntry);
   result.autoReply.text.should.equal(autoReplyEntry.fields.autoReply);
 });
 
-test('getTopicTemplatesFromContentfulEntry returns an empty object if content type config does not have templates', () => {
-  const result = contentfulEntryHelper
+test('getTopicTemplatesFromContentfulEntry returns an empty object if content type config does not have templates', async () => {
+  const result = await contentfulEntryHelper
     .getTopicTemplatesFromContentfulEntry(autoReplyBroadcastEntry);
   result.should.deep.equal({});
 });

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -8,6 +8,7 @@ const sinonChai = require('sinon-chai');
 const sinon = require('sinon');
 
 const contentful = require('../../../lib/contentful');
+const helpers = require('../../../lib/helpers');
 const stubs = require('../../utils/stubs');
 const askYesNoEntryFactory = require('../../utils/factories/contentful/askYesNo');
 const autoReplyFactory = require('../../utils/factories/contentful/autoReply');
@@ -21,6 +22,8 @@ const autoReplyEntry = autoReplyFactory.getValidAutoReply();
 const autoReplyBroadcastEntry = autoReplyBroadcastFactory.getValidAutoReplyBroadcast();
 const defaultTopicTriggerEntry = defaultTopicTriggerFactory.getValidDefaultTopicTrigger();
 const messageEntry = messageFactory.getValidMessage();
+const fetchTopicResult = { id: stubs.getContentfulId() };
+
 
 // Module to test
 const contentfulEntryHelper = require('../../../lib/helpers/contentfulEntry');
@@ -34,6 +37,36 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
+// getMessageTemplateFromContentfulEntryAndTemplateName
+test('getMessageTemplateFromContentfulEntryAndTemplateName should call topic.getById to set topic if topic reference field saved', async () => {
+  const messageTemplate = stubs.getRandomWord();
+  const messageText = stubs.getRandomMessageText();
+  const messageAttachments = [{ name: 'Tyrion' }, { name: 'Cersei' }];
+  sandbox.stub(contentful, 'getTextFromMessage')
+    .returns(messageText);
+  sandbox.stub(contentful, 'getAttachmentsFromContentfulEntry')
+    .returns(messageAttachments);
+  sandbox.stub(helpers.topic, 'getById')
+    .returns(fetchTopicResult);
+
+  const result = await contentfulEntryHelper
+    .getMessageTemplateFromContentfulEntryAndTemplateName(autoReplyBroadcastEntry, messageTemplate);
+  helpers.topic.getById.should.have.been.calledWith(autoReplyBroadcastEntry.fields.topic.sys.id);
+  result.text.should.equal(messageText);
+  result.attachments.should.deep.equal(messageAttachments);
+  result.topic.should.deep.equal(fetchTopicResult);
+  result.template.should.equal(messageTemplate);
+});
+
+test('getMessageTemplateFromContentfulEntryAndTemplateName should not call topic.getById if topic reference field undefined', async () => {
+  sandbox.stub(helpers.topic, 'getById')
+    .returns(fetchTopicResult);
+
+  const result = await contentfulEntryHelper
+    .getMessageTemplateFromContentfulEntryAndTemplateName(askYesNoEntry, stubs.getRandomWord());
+  helpers.topic.getById.should.not.have.been.called;
+  result.topic.should.deep.equal({});
+});
 
 // getSummaryFromContentfulEntry
 test('getSummaryFromContentfulEntry returns an object with name and type properties', () => {
@@ -63,6 +96,15 @@ test('getTopicTemplatesFromContentfulEntry returns an empty object if content ty
   const result = await contentfulEntryHelper
     .getTopicTemplatesFromContentfulEntry(autoReplyBroadcastEntry);
   result.should.deep.equal({});
+});
+
+test('getTopicTemplatesFromContentfulEntry should call topic.getById to set saidYes template topic', async () => {
+  const stubFetchResult = { id: stubs.getContentfulId() };
+  sandbox.stub(helpers.topic, 'getById')
+    .returns(stubFetchResult);
+  const result = await contentfulEntryHelper
+    .getTopicTemplatesFromContentfulEntry(askYesNoEntry);
+  result.saidYes.topic.should.deep.equal(stubFetchResult);
 });
 
 // isAutoReply

--- a/test/lib/lib-helpers/topic.test.js
+++ b/test/lib/lib-helpers/topic.test.js
@@ -186,29 +186,29 @@ test('getTemplateInfoFromContentfulEntryAndTemplateName returns an object', () =
   result.should.equal(config.templatesByContentType[campaignConfigContentType][templateName]);
 });
 
-// parseTemplateFromContentfulEntryAndTemplateName
-test('parseTemplateFromContentfulEntryAndTemplateName returns default text when no field value exists', () => {
+// parseRawAndOverrideFromContentfulEntryAndTemplateName
+test('parseRawAndOverrideFromContentfulEntryAndTemplateName returns default text when no field value exists', () => {
   sandbox.stub(topicHelper, 'getDefaultTextFromContentfulEntryAndTemplateName')
     .returns(templateText);
   sandbox.stub(topicHelper, 'getFieldValueFromContentfulEntryAndTemplateName')
     .returns(null);
 
   const result = topicHelper
-    .parseTemplateFromContentfulEntryAndTemplateName(campaignConfig, templateName);
+    .parseRawAndOverrideFromContentfulEntryAndTemplateName(campaignConfig, templateName);
   topicHelper.getDefaultTextFromContentfulEntryAndTemplateName.should.have.been.called;
   topicHelper.getFieldValueFromContentfulEntryAndTemplateName.should.have.been.called;
   result.override.should.equal(false);
   result.raw.should.equal(templateText);
 });
 
-test('parseTemplateFromContentfulEntryAndTemplateName returns template text when topic value exists', () => {
+test('parseRawAndOverrideFromContentfulEntryAndTemplateName returns template text when topic value exists', () => {
   sandbox.stub(topicHelper, 'getDefaultTextFromContentfulEntryAndTemplateName')
     .returns(stubs.getRandomString());
   sandbox.stub(topicHelper, 'getFieldValueFromContentfulEntryAndTemplateName')
     .returns(templateText);
 
   const result = topicHelper
-    .parseTemplateFromContentfulEntryAndTemplateName(campaignConfig, templateName);
+    .parseRawAndOverrideFromContentfulEntryAndTemplateName(campaignConfig, templateName);
   topicHelper.getDefaultTextFromContentfulEntryAndTemplateName.should.not.have.been.called;
   topicHelper.getFieldValueFromContentfulEntryAndTemplateName.should.have.been.called;
   result.override.should.equal(true);
@@ -254,7 +254,7 @@ test('parseTopicFromContentfulEntry gets campaign by id if campaign field is set
     .returns(stubPostType);
   sandbox.stub(helpers.campaign, 'getById')
     .returns(Promise.resolve(stubCampaign));
-  sandbox.stub(helpers.topic, 'parseTopicTemplatesFromContentfulEntryAndCampaign')
+  sandbox.stub(helpers.topic, 'getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign')
     .returns(stubTemplates);
 
   const result = await topicHelper.parseTopicFromContentfulEntry(textPostConfig);
@@ -265,7 +265,7 @@ test('parseTopicFromContentfulEntry gets campaign by id if campaign field is set
   helpers.campaign.getById
     .should.have.been.calledWith(textPostConfig.fields.campaign.fields.campaignId);
   result.campaign.should.deep.equal(stubCampaign);
-  helpers.topic.parseTopicTemplatesFromContentfulEntryAndCampaign
+  helpers.topic.getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign
     .should.have.been.calledWith(textPostConfig, stubCampaign);
   result.templates.should.deep.equal(stubTemplates);
 });
@@ -274,7 +274,7 @@ test('parseTopicFromContentfulEntry does not get campaign by id if campaign fiel
   const textPostConfig = autoReplyFactory.getValidAutoReplyWithoutCampaign();
   sandbox.stub(helpers.campaign, 'getById')
     .returns(Promise.resolve({ data: { title: stubs.getRandomName() } }));
-  sandbox.stub(helpers.topic, 'parseTopicTemplatesFromContentfulEntryAndCampaign')
+  sandbox.stub(helpers.topic, 'getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign')
     .returns({});
 
   const result = await topicHelper.parseTopicFromContentfulEntry(textPostConfig);

--- a/test/lib/lib-helpers/topic.test.js
+++ b/test/lib/lib-helpers/topic.test.js
@@ -12,6 +12,7 @@ const helpers = require('../../../lib/helpers');
 const stubs = require('../../utils/stubs');
 const config = require('../../../config/lib/helpers/topic');
 const askYesNoFactory = require('../../utils/factories/contentful/askYesNo');
+const autoReplyFactory = require('../../utils/factories/contentful/autoReply');
 const textPostConfigFactory = require('../../utils/factories/contentful/textPostConfig');
 const broadcastFactory = require('../../utils/factories/broadcast');
 
@@ -241,7 +242,7 @@ test('parseTopicFromContentfulEntry returns parseBroadcastFromContentfulEntry if
   result.should.deep.equal(broadcast);
 });
 
-test('parseTopicFromContentfulEntry calls campaignHelper getById if campaign field is set', async () => {
+test('parseTopicFromContentfulEntry gets campaign by id if campaign field is set', async () => {
   const textPostConfig = textPostConfigFactory.getValidTextPostConfig();
   const stubCampaign = { title: stubs.getRandomName() };
   const stubPostType = topicContentType;
@@ -267,4 +268,16 @@ test('parseTopicFromContentfulEntry calls campaignHelper getById if campaign fie
   helpers.topic.parseTopicTemplatesFromContentfulEntryAndCampaign
     .should.have.been.calledWith(textPostConfig, stubCampaign);
   result.templates.should.deep.equal(stubTemplates);
+});
+
+test('parseTopicFromContentfulEntry does not get campaign by id if campaign field undefined', async () => {
+  const textPostConfig = autoReplyFactory.getValidAutoReplyWithoutCampaign();
+  sandbox.stub(helpers.campaign, 'getById')
+    .returns(Promise.resolve({ data: { title: stubs.getRandomName() } }));
+  sandbox.stub(helpers.topic, 'parseTopicTemplatesFromContentfulEntryAndCampaign')
+    .returns({});
+
+  const result = await topicHelper.parseTopicFromContentfulEntry(textPostConfig);
+  helpers.campaign.getById.should.not.have.been.called;
+  result.campaign.should.deep.equal({});
 });

--- a/test/lib/lib-helpers/topic.test.js
+++ b/test/lib/lib-helpers/topic.test.js
@@ -186,7 +186,7 @@ test('getTemplateInfoFromContentfulEntryAndTemplateName returns an object', () =
 });
 
 // getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign
-test('getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign returns an object', () => {
+test('getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign returns an object of templates', () => {
   const stubTemplate = { autoReply: { text: stubs.getRandomWord() } };
   sandbox.stub(topicHelper, 'getTemplatesWithDefaultsFromContentfulEntryAndCampaign')
     .returns(stubTemplate);

--- a/test/lib/lib-helpers/topic.test.js
+++ b/test/lib/lib-helpers/topic.test.js
@@ -185,41 +185,41 @@ test('getTemplateInfoFromContentfulEntryAndTemplateName returns an object', () =
   result.should.equal(config.templatesByContentType[campaignConfigContentType][templateName]);
 });
 
-// getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign
-test('getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign returns an object of templates', () => {
+// getTopicTemplates
+test('getTopicTemplates returns an object of templates', () => {
   const stubTemplate = { autoReply: { text: stubs.getRandomWord() } };
-  sandbox.stub(topicHelper, 'getTemplatesWithDefaultsFromContentfulEntryAndCampaign')
+  sandbox.stub(topicHelper, 'getTemplates')
     .returns(stubTemplate);
   const autoReply = autoReplyFactory.getValidAutoReplyWithoutCampaign();
 
   const result = topicHelper
-    .getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign(autoReply, templateName);
+    .getTopicTemplates(autoReply, templateName);
   result.should.deep.equal(stubTemplate);
 });
 
-// parseRawAndOverrideFromContentfulEntryAndTemplateName
-test('parseRawAndOverrideFromContentfulEntryAndTemplateName returns default text when no field value exists', () => {
+// parseRawAndOverride
+test('parseRawAndOverride returns default text when no field value exists', () => {
   sandbox.stub(topicHelper, 'getDefaultTextFromContentfulEntryAndTemplateName')
     .returns(templateText);
   sandbox.stub(topicHelper, 'getFieldValueFromContentfulEntryAndTemplateName')
     .returns(null);
 
   const result = topicHelper
-    .parseRawAndOverrideFromContentfulEntryAndTemplateName(campaignConfig, templateName);
+    .parseRawAndOverride(campaignConfig, templateName);
   topicHelper.getDefaultTextFromContentfulEntryAndTemplateName.should.have.been.called;
   topicHelper.getFieldValueFromContentfulEntryAndTemplateName.should.have.been.called;
   result.override.should.equal(false);
   result.raw.should.equal(templateText);
 });
 
-test('parseRawAndOverrideFromContentfulEntryAndTemplateName returns template text when topic value exists', () => {
+test('parseRawAndOverride returns template text when topic value exists', () => {
   sandbox.stub(topicHelper, 'getDefaultTextFromContentfulEntryAndTemplateName')
     .returns(stubs.getRandomString());
   sandbox.stub(topicHelper, 'getFieldValueFromContentfulEntryAndTemplateName')
     .returns(templateText);
 
   const result = topicHelper
-    .parseRawAndOverrideFromContentfulEntryAndTemplateName(campaignConfig, templateName);
+    .parseRawAndOverride(campaignConfig, templateName);
   topicHelper.getDefaultTextFromContentfulEntryAndTemplateName.should.not.have.been.called;
   topicHelper.getFieldValueFromContentfulEntryAndTemplateName.should.have.been.called;
   result.override.should.equal(true);
@@ -265,7 +265,7 @@ test('parseTopicFromContentfulEntry gets campaign by id if campaign field is set
     .returns(stubPostType);
   sandbox.stub(helpers.campaign, 'getById')
     .returns(Promise.resolve(stubCampaign));
-  sandbox.stub(helpers.topic, 'getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign')
+  sandbox.stub(helpers.topic, 'getTopicTemplates')
     .returns(stubTemplates);
 
   const result = await topicHelper.parseTopicFromContentfulEntry(textPostConfig);
@@ -276,7 +276,7 @@ test('parseTopicFromContentfulEntry gets campaign by id if campaign field is set
   helpers.campaign.getById
     .should.have.been.calledWith(textPostConfig.fields.campaign.fields.campaignId);
   result.campaign.should.deep.equal(stubCampaign);
-  helpers.topic.getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign
+  helpers.topic.getTopicTemplates
     .should.have.been.calledWith(textPostConfig, stubCampaign);
   result.templates.should.deep.equal(stubTemplates);
 });
@@ -285,7 +285,7 @@ test('parseTopicFromContentfulEntry does not get campaign by id if campaign fiel
   const textPostConfig = autoReplyFactory.getValidAutoReplyWithoutCampaign();
   sandbox.stub(helpers.campaign, 'getById')
     .returns(Promise.resolve({ data: { title: stubs.getRandomName() } }));
-  sandbox.stub(helpers.topic, 'getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign')
+  sandbox.stub(helpers.topic, 'getTopicTemplates')
     .returns({});
 
   const result = await topicHelper.parseTopicFromContentfulEntry(textPostConfig);

--- a/test/lib/lib-helpers/topic.test.js
+++ b/test/lib/lib-helpers/topic.test.js
@@ -65,7 +65,6 @@ test('fetch throws if contentful.fetchByContentTypes fails', async (t) => {
   sandbox.stub(topicHelper, 'parseTopicFromContentfulEntry')
     .returns(Promise.resolve(topic));
 
-
   const result = await t.throws(topicHelper.fetch());
   result.should.deep.equal(error);
 });
@@ -169,7 +168,7 @@ test('getById returns fetchById if resetCache arg is true', async () => {
   result.should.deep.equal(topic);
 });
 
-// getDefaultTextForBotConfigTemplateName
+// getDefaultTextFromContentfulEntryAndTemplateName
 test('getDefaultTextFromContentfulEntryAndTemplateName returns default for templateName', () => {
   const result = topicHelper
     .getDefaultTextFromContentfulEntryAndTemplateName(campaignConfig, templateName);
@@ -184,6 +183,18 @@ test('getTemplateInfoFromContentfulEntryAndTemplateName returns an object', () =
     .getTemplateInfoFromContentfulEntryAndTemplateName(campaignConfig, templateName);
   contentful.getContentTypeFromContentfulEntry.should.have.been.called;
   result.should.equal(config.templatesByContentType[campaignConfigContentType][templateName]);
+});
+
+// getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign
+test('getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign returns an object', () => {
+  const stubTemplate = { autoReply: { text: stubs.getRandomWord() } };
+  sandbox.stub(topicHelper, 'getTemplatesWithDefaultsFromContentfulEntryAndCampaign')
+    .returns(stubTemplate);
+  const autoReply = autoReplyFactory.getValidAutoReplyWithoutCampaign();
+
+  const result = topicHelper
+    .getTopicTemplatesWithDefaultsFromContentfulEntryAndCampaign(autoReply, templateName);
+  result.should.deep.equal(stubTemplate);
 });
 
 // parseRawAndOverrideFromContentfulEntryAndTemplateName

--- a/test/utils/factories/broadcast.js
+++ b/test/utils/factories/broadcast.js
@@ -2,7 +2,7 @@
 
 const stubs = require('../stubs');
 
-function getValidCampaignBroadcast(date = Date.now()) {
+function getValidBroadcast(date = Date.now()) {
   return {
     id: stubs.getBroadcastId(),
     name: stubs.getBroadcastName(),
@@ -11,10 +11,16 @@ function getValidCampaignBroadcast(date = Date.now()) {
     message: {
       text: stubs.getRandomMessageText(),
       attachments: [],
-      template: 'askSignup',
+      template: 'textPostBroadcast',
     },
-    campaignId: stubs.getCampaignId(),
   };
+}
+
+function getValidCampaignBroadcast(date = Date.now()) {
+  const broadcast = getValidBroadcast(date);
+  broadcast.message.template = 'askSignup';
+  broadcast.campaignId.stubs.getCampaignId();
+  return broadcast;
 }
 
 function getValidTopicBroadcast(date = Date.now()) {
@@ -26,6 +32,7 @@ function getValidTopicBroadcast(date = Date.now()) {
 }
 
 module.exports = {
+  getValidBroadcast,
   getValidCampaignBroadcast,
   getValidTopicBroadcast,
 };

--- a/test/utils/factories/broadcast.js
+++ b/test/utils/factories/broadcast.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const stubs = require('../stubs');
+const topicFactory = require('./topic');
 
 function getValidBroadcast(date = Date.now()) {
   return {
@@ -12,6 +13,7 @@ function getValidBroadcast(date = Date.now()) {
       text: stubs.getRandomMessageText(),
       attachments: [],
       template: 'textPostBroadcast',
+      topic: topicFactory.getValidTopic(),
     },
   };
 }
@@ -19,7 +21,7 @@ function getValidBroadcast(date = Date.now()) {
 function getValidCampaignBroadcast(date = Date.now()) {
   const broadcast = getValidBroadcast(date);
   broadcast.message.template = 'askSignup';
-  broadcast.campaignId.stubs.getCampaignId();
+  broadcast.campaignId = stubs.getCampaignId();
   return broadcast;
 }
 

--- a/test/utils/factories/contentful/askYesNo.js
+++ b/test/utils/factories/contentful/askYesNo.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const stubs = require('../../stubs');
+const autoReplyFactory = require('./autoReply');
 const textPostConfigFactory = require('./textPostConfig');
 
 function getValidAskYesNo(date = Date.now()) {
@@ -10,11 +11,11 @@ function getValidAskYesNo(date = Date.now()) {
       name: stubs.getBroadcastName(),
       text: stubs.getRandomMessageText(),
       attachments: stubs.contentful.getAttachments(),
-      saidYesTopic: textPostConfigFactory.getValidTextPostConfig(),
       saidYes: stubs.getRandomMessageText(),
+      saidYesTopic: textPostConfigFactory.getValidTextPostConfig(),
       saidNo: stubs.getRandomMessageText(),
+      saidNoTopic: autoReplyFactory.getValidAutoReplyWithoutCampaign(),
       invalidAskYesNoResponse: stubs.getRandomMessageText(),
-      autoReply: stubs.getRandomMessageText(),
     },
   };
 }

--- a/test/utils/factories/contentful/autoReply.js
+++ b/test/utils/factories/contentful/autoReply.js
@@ -1,20 +1,29 @@
 'use strict';
 
 const stubs = require('../../stubs');
-const messageFactory = require('./message');
+const campaignFactory = require('./campaign');
 
 function getValidAutoReply(date = Date.now()) {
   const data = {
     sys: stubs.contentful.getSysWithTypeAndDate('autoReply', date),
     fields: {
       name: stubs.getRandomName(),
-      autoReply: messageFactory.getValidMessage(),
-      // TODO: Add a campaign reference field, returning a campaign factory's valid campaign.
+      autoReply: stubs.getRandomMessageText(),
+      campaign: campaignFactory.getValidCampaign(),
     },
   };
   return data;
 }
 
+function getValidAutoReplyWithoutCampaign(date = Date.now()) {
+  const autoReply = getValidAutoReply(date);
+  // If an entry is not saved to a reference field in Contentful, the field is set to null.
+  autoReply.fields.campaign = null;
+
+  return autoReply;
+}
+
 module.exports = {
   getValidAutoReply,
+  getValidAutoReplyWithoutCampaign,
 };

--- a/test/utils/factories/contentful/broadcast.js
+++ b/test/utils/factories/contentful/broadcast.js
@@ -1,6 +1,9 @@
 'use strict';
 
+// TODO: Rename this file and these functions as legacyBroadcast.
+
 const stubs = require('../../stubs');
+const campaignFactory = require('./campaign');
 
 module.exports.getValidCampaignBroadcast = function getValidCampaignBroadcast(date = Date.now()) {
   return {
@@ -10,14 +13,7 @@ module.exports.getValidCampaignBroadcast = function getValidCampaignBroadcast(da
       topic: null,
       message: stubs.getRandomMessageText(),
       template: 'askSignup',
-      campaign: {
-        sys: {
-          id: stubs.getContentfulId(),
-        },
-        fields: {
-          campaignId: stubs.getCampaignId(),
-        },
-      },
+      campaign: campaignFactory.getValidCampaign(),
       attachments: stubs.contentful.getAttachments(),
     },
   };

--- a/test/utils/factories/contentful/campaign.js
+++ b/test/utils/factories/contentful/campaign.js
@@ -7,13 +7,12 @@ const stubs = require('../../stubs');
  * reference to link topics to a Phoenix campaign (via the campaignId text field).
  */
 function getValidCampaign() {
-  const data = {
+  return {
     sys: stubs.contentful.getSysWithTypeAndDate('campaign'),
     fields: {
       campaignId: stubs.getCampaignId(),
     },
   };
-  return data;
 }
 
 module.exports = {

--- a/test/utils/factories/contentful/campaign.js
+++ b/test/utils/factories/contentful/campaign.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const stubs = require('../../stubs');
+
+/**
+ * NOTE: The Gambit Contentful space (confusingly?) has a content type called campaign, used as a
+ * reference to link topics to a Phoenix campaign (via the campaignId text field).
+ */
+function getValidCampaign() {
+  const data = {
+    sys: stubs.contentful.getSysWithTypeAndDate('campaign'),
+    fields: {
+      campaignId: stubs.getCampaignId(),
+    },
+  };
+  return data;
+}
+
+module.exports = {
+  getValidCampaign,
+};

--- a/test/utils/factories/contentful/textPostConfig.js
+++ b/test/utils/factories/contentful/textPostConfig.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const stubs = require('../../stubs');
+const campaignFactory = require('./campaign');
 
 function getValidTextPostConfig() {
   const data = {
@@ -14,6 +15,8 @@ function getValidTextPostConfig() {
     },
     fields: {
       name: stubs.getRandomMessageText(),
+      // A campaign reference is required for a textPostConfig conversation to create text posts.
+      campaign: campaignFactory.getValidCampaign(),
     },
   };
   return data;

--- a/test/utils/factories/topic.js
+++ b/test/utils/factories/topic.js
@@ -11,6 +11,17 @@ function getValidTopic() {
     name: stubs.getRandomMessageText(),
     type: 'textPostConfig',
     postType: 'text',
+    campaign: {
+      id: stubs.getCampaignId(),
+      title: stubs.getRandomName(),
+      status: 'active',
+      currentCampaignRun: {
+        id: stubs.getCampaignRunId(),
+      },
+    },
+    templates: {
+      askText: stubs.getRandomMessageText(),
+    },
   };
 }
 


### PR DESCRIPTION
#### What's this PR do?

Modifies the contentfulEntry helper `getTopicTemplatesFromContentfulEntry` and `getMessageTemplateFromContentfulEntryAndTemplateName` to set the message or template topic by calling `helpers.topic.getById` instead of the `helpers.contentfulEntry.getSummaryFromContentfulId` -- which doesn't include campaign information (which ideally we'd return to avoid making multiple `GET /topics/:id` requests when processing a user's reply to an outbound `askYesNo`-- when looking up the `askYesNo` topic to find replies, if a user says yes, it's convenient to have the campaign id available for posting campaign activity)

#### How should this be reviewed?

* Verify a full topic object is returned in the `message.topic` properties of a `GET /broadcasts` request for a non askYesNo (e.g. `5t2fmKd2iQgaCCy8Kgg0CI`)

```
// 20180815190247
// http://localhost:5000/v1/broadcasts/5t2fmKd2iQgaCCy8Kgg0CI?apiKey=totallysecret&test=123

{
  "data": {
      "id": "5t2fmKd2iQgaCCy8Kgg0CI",
      "name": "Test photoPostBroadcast - Pump it up",
      "type": "photoPostBroadcast",
      "createdAt": "2018-08-09T21:14:49.304Z",
      "updatedAt": "2018-08-13T18:19:04.214Z",
      "message": {
        "text": "Have you posted a flyer yet? Text START to share your photo.",
        "attachments": [
          
        ],
        "template": "photoPostBroadcast",
        "topic": {
          "id": "4xXe9sQqmIeiWauSUu6kAY",
          "name": "Pump It Up - Submit Flyer",
          "type": "photoPostConfig",
          "createdAt": "2018-08-01T14:41:30.242Z",
          "updatedAt": "2018-08-13T13:31:32.583Z",
          "postType": "photo",
          "campaign": {
            "id": 8142,
            "title": "Pump It Up",
            "tagline": "Print & post our tire flyers to keep friends safe on the road.",
            "status": "active",
            "currentCampaignRun": {
              "id": 8161
            },
            "endDate": {
              "date": "2018-09-30 23:59:00.000000",
              "timezone_type": 1,
              "timezone": "-04:00"
            }
          },
          ...
```

* Verify a full topic is returned in the `templates.saidYes.topic` property of a `GET /broadcasts` request for an askYesNo (e.g. `2X4r3fZrTGA2mGemowgiEI`)

```
// http://localhost:5000/v1/broadcasts/2X4r3fZrTGA2mGemowgiEI?apiKey=totallysecret&test=123

{
  "data": {
    "id": "2X4r3fZrTGA2mGemowgiEI",
    "name": "Test askYesNo - Pump it up",
    "type": "askYesNo",
    "createdAt": "2018-08-06T23:34:56.395Z",
    "updatedAt": "2018-08-13T17:45:47.751Z",
    "message": {
      "text": "Join Pump it Up? \n\nYes No",
      "attachments": [
        
      ],
      "template": "askYesNo",
      "topic": {
        
      }
    },
    "templates": {
      "saidYes": {
        "text": "Great! Text START to submit a photo.",
        "topic": {
          "id": "4xXe9sQqmIeiWauSUu6kAY",
          "name": "Pump It Up - Submit Flyer",
          "type": "photoPostConfig",
          "createdAt": "2018-08-01T14:41:30.242Z",
          "updatedAt": "2018-08-13T13:31:32.583Z",
          "postType": "photo",
          "campaign": {
            "id": 8142,
            "title": "Pump It Up",
            "tagline": "Print & post our tire flyers to keep friends safe on the road.",
            "status": "active",
            "currentCampaignRun": {
              "id": 8161
            },
            "endDate": {
              "date": "2018-09-30 23:59:00.000000",
              "timezone_type": 1,
              "timezone": "-04:00"
            }
          },
          "templates": {
          ....
```

#### Relevant tickets
https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
