### PR TITLE
Adds config.templates to a GET /campaigns/:id response [pr]

### DIFF
--- a/config/lib/helpers/cache.js
+++ b/config/lib/helpers/cache.js
@@ -5,6 +5,10 @@ module.exports = {
     name: 'broadcasts',
     ttl: parseInt(process.env.GAMBIT_BROADCASTS_CACHE_TTL, 10) || 3600,
   },
+  campaignConfigs: {
+    name: 'campaignConfigs',
+    ttl: parseInt(process.env.GAMBIT_CAMPAIGN_CONFIGS_CACHE_TTL, 10) || 3600,
+  },
   campaigns: {
     name: 'campaigns',
     ttl: parseInt(process.env.GAMBIT_CAMPAIGNS_CACHE_TTL, 10) || 3600,

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -8,7 +8,7 @@ Endpoint                                       | Functionality
 `GET /v1/broadcasts` | [Retrieve broadcasts](endpoints/broadcasts.md#retrieve-broadcasts)
 `GET /v1/broadcasts/:id` | [Retrieve a broadcast](endpoints/broadcasts.md#retrieve-broadcast)
 `GET /v1/campaigns` | [Retrieve all campaigns with active topics](endpoints/campaigns.md#retrieve-all-campaigns)
-`GET /v1/campaigns/:id` | [Retrieve a campaign](endpoints/campaigns.md#retrieve-a-campaigns)
+`GET /v1/campaigns/:id` | [Retrieve a campaign](endpoints/campaigns.md#retrieve-campaign)
 `GET /v1/contentfulEntries/:id` | Retrieve a parsed Contentful entry
 `GET /v1/defaultTopicTriggers` | [Retrieve all additional default topic triggers](endpoints/defaultTopicTriggers.md)
 `GET /v1/topics` | [Retrieve topics](endpoints/topics.md#retrieve-topics)

--- a/documentation/endpoints/campaignActivity.md
+++ b/documentation/endpoints/campaignActivity.md
@@ -31,15 +31,15 @@ Name | Type | Description
 <details><summary>**Example Request**</summary><p>
 
 ```
-curl -X "POST" "http://localhost:5000/v1/campaignActivity" \
-     -H "x-gambit-api-key: totallysecret" \
-     -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
-     --data-urlencode "userId=59cd4c1910707d778633e30f" \
+curl -X "POST" "http://localhost:5000/v1/campaignActivity"
+     -H "x-gambit-api-key: totallysecret"
+     -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8"
+     --data-urlencode "userId=59cd4c1910707d778633e30f"
      --data-urlencode "text=I love rock and roll"
      --data-urlencode "postType=text"
      --data-urlencode "platform=alexa"
      --data-urlencode "campaignRunId=8873"
-     --data-urlencode "campaignId=6620" \
+     --data-urlencode "campaignId=6620"
 ```
 
 </p></details>

--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -1,6 +1,7 @@
 # Campaigns
 
-The `campaigns` resource lists active topics for [campaigns](https://github.com/DoSomething/phoenix-next/blob/master/docs/api-reference/v2/campaigns.md#retrieve-a-campaign).  Users can participate in a campaign via chatbot if the campaign has at least one active topic, meaning the topic has at least one published defaultTopicTrigger referencing it.
+The `campaigns` resource queries the Phoenix API for campaigns, and our Contentful space for chatbot
+configurations.
 
 
 Fields:
@@ -12,7 +13,11 @@ Name | Type | Description
 `tagline` | String | The campaign tagline, available as a `{{tagline}}` tag within a topic template
 `status` | String | Either `'active'` or `'closed'`. Users may not participate in chatbot topics for closed campaigns.
 `currentCampaignRun` | Object | Contains a numeric `id` property to be passed when creating a post for the campaign
-`topics` | Array | List of active [topics](/topics.md) available for the campaign.
+`config` | Object | The chatbot configuration for this campaign
+`config.id` | String | The id of the chatbot configuration
+`config.templates` | Object | Message templates defined for the campaign
+`config.templates.webSignup` | Object | Message template to user if they signed up for this campaign on the web
+`topics` | Array | To be deprecated -- List of active [topics](/topics.md) available for the campaign.
 
 
 ## Retrieve all campaigns
@@ -45,6 +50,26 @@ curl http://localhost:5000/v1/campaigns \
       "status": "active",
       "currentCampaignRun": {
         "id": 8076
+      },
+      "config": {
+        "id": "68Oy1FcaR2EiaMieicaoom",
+        "templates": {
+          "webSignup": {
+            "text": "Hi this is Freddie from DoSomething! Thanks for signing up for mirror messages. When youve posted some notes and ready to send a photo, text START",
+            "attachments": [],
+            "template": "webSignup",
+            "topic": {
+              "id": "6W1kHJ1XYASOK8w8Q42eum",
+              "name": "Mirror Messages - Post a note",
+              "type": "photoPostConfig",
+              "createdAt": "2018-06-27T17:13:46.755Z",
+              "updatedAt": "2018-08-08T14:45:12.186Z",
+              "postType": "text",
+              "campaign": {...},
+              "templates": {...}
+            }
+          }
+        }
       },
       "topics": [
         {
@@ -82,11 +107,19 @@ curl http://localhost:5000/v1/campaigns \
 
 </p></details>
 
-## Retrieve a campaign
+## Retrieve campaign
 
 ```
 GET /v1/campaigns/:id
 ```
+
+Returns a campaign and its config if set.
+
+### Query parameters
+
+Name | Type | Description
+-----|------|------------
+`cache` | string | If set to `false`, fetches campaign from Phoenix and campaignConfig from Contentful and resets each cache.
 
 <details><summary>**Example Request**</summary><p>
 
@@ -109,120 +142,27 @@ curl http://localhost:5000/v1/campaigns/7 \
     "currentCampaignRun": {
       "id": 8076
     },
-    "topics": [
-      {
-        "id": "6swLaA7HKE8AGI6iQuWk4y",
-        "type": "photoPostConfig",
-        "postType": "photo",
-        "templates": {
-          "startPhotoPost": {
-            "raw": "Over 111,000 people have joined the movement to bring positivity to their schools. All it takes is posting encouraging notes in places that can trigger low self-esteem. Take 5 mins to post a note today. \n\nThen, text {{cmd_reportback}} to share a photo of the messages you posted (and you'll be entered to win a $2000 scholarship)!",
-            "override": true,
-            "rendered": "Over 111,000 people have joined the movement to bring positivity to their schools. All it takes is posting encouraging notes in places that can trigger low self-esteem. Take 5 mins to post a note today. \n\nThen, text START to share a photo of the messages you posted (and you'll be entered to win a $2000 scholarship)!"
-          },
-          "webStartPhotoPost": {
-            "raw": "Hey - this is Freddie from DoSomething. Thanks for joining a movement to spread positivity in school. You can do something simple to make a big impact for a stranger.\n\nLet's do this: post encouraging notes in places that can trigger low self-esteem, like school bathrooms.\n\nThen, text  {{cmd_reportback}}  to share a photo of the messages you posted (and you'll be entered to win a $2000 scholarship)!",
-            "override": true,
-            "rendered": "Hey - this is Freddie from DoSomething. Thanks for joining a movement to spread positivity in school. You can do something simple to make a big impact for a stranger.\n\nLet's do this: post encouraging notes in places that can trigger low self-esteem, like school bathrooms.\n\nThen, text  START  to share a photo of the messages you posted (and you'll be entered to win a $2000 scholarship)!"
-          },
-          "startPhotoPostAutoReply": {
-            "raw": "Sorry, I didn't get that.\n\nText {{cmd_reportback}} when you're ready to submit a post for {{title}}.",
-            "override": false,
-            "rendered": "Sorry, I didn't get that.\n\nText START when you're ready to submit a post for Mirror Messages."
-          },
-          "completedPhotoPost": {
-            "raw": "Great! We've got you down for {{quantity}} messages posted.\n\nTo submit another post for Mirror Messages, text {{cmd_reportback}}.",
-            "override": true,
-            "rendered": "Great! We've got you down for {{quantity}} messages posted.\n\nTo submit another post for Mirror Messages, text START."
-          },
-          "completedPhotoPostAutoReply": {
-            "raw": "Sorry I didn't get that.  If you've posted more messages, text {{cmd_reportback}}.\n\nText Q if you have a question, or text MENU to find a different action to take.",
-            "override": true,
-            "rendered": "Sorry I didn't get that.  If you've posted more messages, text START.\n\nText Q if you have a question, or text MENU to find a different action to take."
-          },
-          "askQuantity": {
-            "raw": "Sweet! First, what's the total number of messages you posted?\n\nBe sure to text in a number not a word (i.e. “4”, not “four”)",
-            "override": true,
-            "rendered": "Sweet! First, what's the total number of messages you posted?\n\nBe sure to text in a number not a word (i.e. “4”, not “four”)"
-          },
-          "invalidQuantity": {
-            "raw": "Sorry, that isn't a valid number. What's the total number of messages you posted? Be sure to text in a number not a word (i.e. “4”, not “four”)",
-            "override": true,
-            "rendered": "Sorry, that isn't a valid number. What's the total number of messages you posted? Be sure to text in a number not a word (i.e. “4”, not “four”)"
-          },
-          "askPhoto": {
-            "raw": "Send us your best pic of yourself and the messages you posted.",
-            "override": true,
-            "rendered": "Send us your best pic of yourself and the messages you posted."
-          },
-          "invalidPhoto": {
-            "raw": "Sorry, I didn't get that.\n\nSend us your best pic of yourself and the messages you posted. \n\nIf you have a question, text Q.",
-            "override": true,
-            "rendered": "Sorry, I didn't get that.\n\nSend us your best pic of yourself and the messages you posted. \n\nIf you have a question, text Q."
-          },
-          "askCaption": {
-            "raw": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.",
-            "override": false,
-            "rendered": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please."
-          },
-          "invalidCaption": {
-            "raw": "Sorry, I didn't get that.\n\nText back a caption for your photo -- keep it short & sweet, under 60 characters please. (but more than 3!)",
-            "override": false,
-            "rendered": "Sorry, I didn't get that.\n\nText back a caption for your photo -- keep it short & sweet, under 60 characters please. (but more than 3!)"
-          },
-          "askWhyParticipated": {
-            "raw": "Last question: Why was participating in {{title}} important to you? (No need to write an essay, one sentence is good).",
-            "override": false,
-            "rendered": "Last question: Why was participating in Mirror Messages important to you? (No need to write an essay, one sentence is good)."
-          },
-          "invalidWhyParticipated": {
-            "raw": "Sorry, I didn't get that.\n\nLast question: Why was participating in {{title}} important to you? (No need to write an essay, one sentence is good).",
-            "override": false,
-            "rendered": "Sorry, I didn't get that.\n\nLast question: Why was participating in Mirror Messages important to you? (No need to write an essay, one sentence is good)."
-          },
-          "memberSupport": {
-            "raw": "Text back your question and I'll try to get back to you within 24 hrs.",
-            "override": false,
-            "rendered": "Text back your question and I'll try to get back to you within 24 hrs."
-          },
-          "campaignClosed": {
-            "raw": "Sorry, {{title}} is no longer available.\n\nText {{cmd_member_support}} for help.",
-            "override": false,
-            "rendered": "Sorry, Mirror Messages is no longer available.\n\nText Q for help."
-          },
-          "askSignup": {
-            "raw": "{{tagline}}\n\nWant to join {{title}}?\n\nYes or No",
-            "override": false,
-            "rendered": "Boost a stranger's self-esteem with just a sticky note!\n\nWant to join Mirror Messages?\n\nYes or No"
-          },
-          "declinedSignup": {
-            "raw": "Ok! Text MENU if you'd like to find a different action to take.",
-            "override": false,
-            "rendered": "Ok! Text MENU if you'd like to find a different action to take."
-          },
-          "invalidAskSignupResponse": {
-            "raw": "Sorry, I didn't get that. Did you want to join {{title}}?\n\nYes or No",
-            "override": false,
-            "rendered": "Sorry, I didn't get that. Did you want to join Mirror Messages?\n\nYes or No"
-          },
-          "askContinue": {
-            "raw": "Ready to get back to {{title}}?\n\nYes or No",
-            "override": false,
-            "rendered": "Ready to get back to Mirror Messages?\n\nYes or No"
-          },
-          "declinedContinue": {
-            "raw": "Right on, we'll check in with you about {{title}} later.\n\nText MENU if you'd like to find a different action to take.",
-            "override": false,
-            "rendered": "Right on, we'll check in with you about Mirror Messages later.\n\nText MENU if you'd like to find a different action to take."
-          },
-          "invalidAskContinueResponse": {
-            "raw": "Sorry, I didn't get that. Did you want to join {{title}}?\n\nYes or No",
-            "override": false,
-            "rendered": "Sorry, I didn't get that. Did you want to join Mirror Messages?\n\nYes or No"
+    "config": {
+      "id": "68Oy1FcaR2EiaMieicaoom",
+      "templates": {
+        "webSignup": {
+          "text": "Hi this is Freddie from DoSomething! Thanks for signing up for mirror messages. When youve posted some notes and ready to send a photo, text START",
+          "attachments": [],
+          "template": "webSignup",
+          "topic": {
+            "id": "6W1kHJ1XYASOK8w8Q42eum",
+            "name": "Mirror Messages - Post a note",
+            "type": "photoPostConfig",
+            "createdAt": "2018-06-27T17:13:46.755Z",
+            "updatedAt": "2018-08-08T14:45:12.186Z",
+            "postType": "text",
+            "campaign": {...},
+            "templates": {...}
           }
         }
       }
-    ],
+    },
+    "topics": [...],
   }
 }
 ```

--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -31,9 +31,10 @@ Returns a list of campaigns that active topics.
 <details><summary>**Example Request**</summary><p>
 
 ```
-curl http://localhost:5000/v1/campaigns \
-  -H "Accept: application/json" \
-  -H "Content-Type: application/json" \
+curl http://localhost:5000/v1/campaigns
+  -H "x-gambit-api-key: totallysecret"
+  -H "Accept: application/json"
+  -H "Content-Type: application/json"
 ```
 
 </p></details>
@@ -124,9 +125,10 @@ Name | Type | Description
 <details><summary>**Example Request**</summary><p>
 
 ```
-curl http://localhost:5000/v1/campaigns/7 \
-     -H "Accept: application/json" \
-     -H "Content-Type: application/json" \
+curl http://localhost:5000/v1/campaigns/7
+  -H "x-gambit-api-key: totallysecret"
+  -H "Accept: application/json"
+  -H "Content-Type: application/json"
 ```
 
 </p></details>

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -128,6 +128,14 @@ function fetchByContentTypes(contentTypes, queryParams = {}) {
     });
 }
 
+function fetchEntries(queryParams) {
+  const query = module.exports.getQueryBuilder()
+    .custom(queryParams)
+    .build();
+  return module.exports.getClient().getEntries(query);
+}
+
+
 /**
  * Parses Contentful getEntries response as object with meta and data properties.
  *
@@ -216,6 +224,7 @@ module.exports = {
   createNewClient,
   fetchByContentfulId,
   fetchByContentTypes,
+  fetchEntries,
   getAttachmentsFromContentfulEntry,
   getCampaignIdFromContentfulEntry,
   getClient,

--- a/lib/helpers/cache.js
+++ b/lib/helpers/cache.js
@@ -14,6 +14,10 @@ const campaignsCache = new Cacheman(config.campaigns.name, {
   ttl: config.campaigns.ttl,
   engine: redisEngine,
 });
+const campaignConfigsCache = new Cacheman(config.campaignConfigs.name, {
+  ttl: config.campaignConfigs.ttl,
+  engine: redisEngine,
+});
 const defaultTopicTriggersCache = new Cacheman(config.defaultTopicTriggers.name, {
   ttl: config.defaultTopicTriggers.ttl,
   engine: redisEngine,
@@ -34,6 +38,14 @@ module.exports = {
     },
     set: function set(id, data) {
       return broadcastsCache.set(id, data).then(res => parseSetCacheResponse(res));
+    },
+  },
+  campaignConfigs: {
+    get: function get(id) {
+      return campaignConfigsCache.get(`${id}`);
+    },
+    set: function set(id, data) {
+      return campaignConfigsCache.set(`${id}`, data).then(res => parseSetCacheResponse(res));
     },
   },
   campaigns: {

--- a/lib/helpers/cache.js
+++ b/lib/helpers/cache.js
@@ -38,10 +38,10 @@ module.exports = {
   },
   campaigns: {
     get: function get(id) {
-      return campaignsCache.get(id);
+      return campaignsCache.get(`${id}`);
     },
     set: function set(id, data) {
-      return campaignsCache.set(id, data).then(res => parseSetCacheResponse(res));
+      return campaignsCache.set(`${id}`, data).then(res => parseSetCacheResponse(res));
     },
   },
   defaultTopicTriggers: {

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -3,7 +3,6 @@
 const dateFns = require('date-fns');
 const logger = require('winston');
 const Promise = require('bluebird');
-const helpers = require('../helpers');
 const cacheHelper = require('./cache');
 const phoenix = require('../phoenix');
 const config = require('../../config/lib/helpers/campaign');
@@ -14,9 +13,9 @@ const phoenixConfig = require('../../config/lib/phoenix');
  * @return {Promise}
  */
 function fetchById(campaignId) {
- return phoenix.fetchCampaignById(campaignId)
-   .then(res => module.exports.parseCampaign(res.data))
-   .then(campaign => cacheHelper.campaigns.set(campaignId, campaign));
+  return phoenix.fetchCampaignById(campaignId)
+    .then(res => module.exports.parseCampaign(res.data))
+    .then(campaign => cacheHelper.campaigns.set(campaignId, campaign));
 }
 
 /**

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -18,27 +18,36 @@ async function fetchById(campaignId) {
   const campaign = module.exports.parseCampaign(phoenixResult.data);
   const campaignConfig = await helpers.contentfulEntry
     .fetchCampaignConfigByCampaignId(campaignId);
-  return Object.assign(campaign, { config: campaignConfig });
+  const data = Object.assign(campaign, { config: campaignConfig });
+  return cacheHelper.campaigns.set(campaignId, data);
+}
+
+/**
+ * @param {String} campaignId
+ * @param {Boolean} resetCache
+ * @return {Promise}
+ */
+async function getById(campaignId, resetCache = false) {
+  if (resetCache === true) {
+    logger.debug('Campaign cache reset', { campaignId });
+    return module.exports.fetchById(campaignId);
+  }
+  const data = await cacheHelper.campaigns.get(campaignId);
+  if (data) {
+    logger.debug('Campaign cache hit', { campaignId });
+    return data;
+  }
+  logger.debug('Campaign cache miss', { campaignId });
+  return module.exports.fetchById(campaignId);
 }
 
 module.exports = {
   fetchById,
+  getById,
   getByIds: function fetchByIds(campaignIds) {
     const promises = [];
     campaignIds.forEach(campaignId => promises.push(this.getById(campaignId)));
     return Promise.all(promises);
-  },
-  getById: function getById(campaignId) {
-    return cacheHelper.campaigns.get(`${campaignId}`)
-      .then((data) => {
-        if (data) {
-          logger.debug(`Campaigns cache hit:${campaignId}`);
-          return data;
-        }
-        logger.debug(`Campaigns cache miss:${campaignId}`);
-        return this.fetchById(campaignId)
-          .then(campaign => cacheHelper.campaigns.set(`${campaignId}`, campaign));
-      });
   },
   /**
    * @param {Object} campaign

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -13,13 +13,10 @@ const phoenixConfig = require('../../config/lib/phoenix');
  * @param {String} campaignId
  * @return {Promise}
  */
-async function fetchById(campaignId) {
-  const phoenixResult = await phoenix.fetchCampaignById(campaignId);
-  const campaign = module.exports.parseCampaign(phoenixResult.data);
-  const campaignConfig = await helpers.contentfulEntry
-    .fetchCampaignConfigByCampaignId(campaignId);
-  const data = Object.assign(campaign, { config: campaignConfig });
-  return cacheHelper.campaigns.set(campaignId, data);
+function fetchById(campaignId) {
+ return phoenix.fetchCampaignById(campaignId)
+   .then(res => module.exports.parseCampaign(res.data))
+   .then(campaign => cacheHelper.campaigns.set(campaignId, campaign));
 }
 
 /**

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -3,6 +3,7 @@
 const dateFns = require('date-fns');
 const logger = require('winston');
 const Promise = require('bluebird');
+const helpers = require('../helpers');
 const cacheHelper = require('./cache');
 const phoenix = require('../phoenix');
 const config = require('../../config/lib/helpers/campaign');
@@ -12,9 +13,12 @@ const phoenixConfig = require('../../config/lib/phoenix');
  * @param {String} campaignId
  * @return {Promise}
  */
-function fetchById(campaignId) {
-  return phoenix.fetchCampaignById(campaignId)
-    .then(res => module.exports.parseCampaign(res.data));
+async function fetchById(campaignId) {
+  const phoenixResult = await phoenix.fetchCampaignById(campaignId);
+  const campaign = module.exports.parseCampaign(phoenixResult.data);
+  const campaignConfig = await helpers.contentfulEntry
+    .fetchCampaignConfigByCampaignId(campaignId);
+  return Object.assign(campaign, { config: campaignConfig });
 }
 
 module.exports = {

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -3,23 +3,38 @@
 const dateFns = require('date-fns');
 const logger = require('winston');
 const Promise = require('bluebird');
-const cacheHelper = require('./cache');
+const helpers = require('../helpers');
+const contentful = require('../contentful');
 const phoenix = require('../phoenix');
 const config = require('../../config/lib/helpers/campaign');
 const phoenixConfig = require('../../config/lib/phoenix');
 
 /**
- * @param {String} campaignId
+ * @param {Number} campaignId
  * @return {Promise}
  */
 function fetchById(campaignId) {
   return phoenix.fetchCampaignById(campaignId)
     .then(res => module.exports.parseCampaign(res.data))
-    .then(campaign => cacheHelper.campaigns.set(campaignId, campaign));
+    .then(campaign => helpers.cache.campaigns.set(campaignId, campaign));
 }
 
 /**
- * @param {String} campaignId
+ * @param {Number} campaignId
+ * @return {Promise}
+ */
+function fetchCampaignConfigByCampaignId(campaignId) {
+  const query = {
+    content_type: 'campaign',
+    'fields.campaignId': campaignId,
+  };
+  return contentful.fetchEntries(query)
+    .then(res => module.exports.parseCampaignConfig(res.items[0]))
+    .then(campaignConfig => helpers.cache.campaignConfigs.set(campaignId, campaignConfig));
+}
+
+/**
+ * @param {Number} campaignId
  * @param {Boolean} resetCache
  * @return {Promise}
  */
@@ -28,23 +43,71 @@ async function getById(campaignId, resetCache = false) {
     logger.debug('Campaign cache reset', { campaignId });
     return module.exports.fetchById(campaignId);
   }
-  const data = await cacheHelper.campaigns.get(campaignId);
+
+  const data = await helpers.cache.campaigns.get(campaignId);
   if (data) {
     logger.debug('Campaign cache hit', { campaignId });
     return data;
   }
+
   logger.debug('Campaign cache miss', { campaignId });
   return module.exports.fetchById(campaignId);
 }
 
+/**
+ * @param {Number} campaignId
+ * @param {Boolean} resetCache
+ * @return {Promise}
+ */
+async function getCampaignConfigByCampaignId(campaignId, resetCache = false) {
+  if (resetCache === true) {
+    logger.debug('Campaign config cache reset', { campaignId });
+    return module.exports.fetchCampaignConfigByCampaignId(campaignId);
+  }
+
+  const data = await helpers.cache.campaignConfigs.get(campaignId);
+  if (data) {
+    logger.debug('Campaign config cache hit', { campaignId });
+    return data;
+  }
+
+  logger.debug('Campaign config cache miss', { campaignId });
+  return module.exports.fetchCampaignConfigByCampaignId(campaignId);
+}
+
+/**
+ * @param {Object} contentfulEntry
+ * @return {Promise}
+ */
+async function parseCampaignConfig(contentfulEntry) {
+  const data = {
+    id: contentful.getContentfulIdFromContentfulEntry(contentfulEntry),
+    templates: {
+      webSignup: {},
+    },
+  };
+
+  const webSignupEntry = contentfulEntry.fields.webSignup;
+  if (!webSignupEntry) {
+    return data;
+  }
+
+  data.templates.webSignup = await helpers.contentfulEntry
+    .getMessageTemplateFromContentfulEntryAndTemplateName(webSignupEntry, 'webSignup');
+
+  return data;
+}
+
 module.exports = {
   fetchById,
+  fetchCampaignConfigByCampaignId,
   getById,
   getByIds: function fetchByIds(campaignIds) {
     const promises = [];
     campaignIds.forEach(campaignId => promises.push(this.getById(campaignId)));
     return Promise.all(promises);
   },
+  getCampaignConfigByCampaignId,
   /**
    * @param {Object} campaign
    * @return {Boolean}
@@ -104,6 +167,7 @@ module.exports = {
 
     return result;
   },
+  parseCampaignConfig,
   /**
    * @param {object} data
    * @return {Object}

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -38,9 +38,18 @@ async function fetchCampaignConfigByCampaignId(campaignId) {
  * @return {Object}
  */
 function parseCampaignConfig(contentfulEntry) {
-  return {
+  const data = {
     id: contentful.getContentfulIdFromContentfulEntry(contentfulEntry),
+    templates: {
+      webSignup: {},
+    },
   };
+  const webSignupEntry = contentfulEntry.fields.webSignup;
+  if (!webSignupEntry) {
+    return data;
+  }
+  data.templates.webSignup.text = contentful.getTextFromMessage(webSignupEntry);
+  return data;
 }
 
 /**

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -22,41 +22,6 @@ function getById(contentfulId) {
 }
 
 /**
- * @param {String} campaignId
- * @return {Promise}
- */
-async function fetchCampaignConfigByCampaignId(campaignId) {
-  const result = await contentful.fetchEntries({
-    content_type: 'campaign',
-    'fields.campaignId': campaignId,
-  });
-  return module.exports.parseCampaignConfig(result.items[0]);
-}
-
-/**
- * @param {Object} contentfulEntry
- * @return {Promise}
- */
-async function parseCampaignConfig(contentfulEntry) {
-  const data = {
-    id: contentful.getContentfulIdFromContentfulEntry(contentfulEntry),
-    templates: {
-      webSignup: {},
-    },
-  };
-
-  const webSignupEntry = contentfulEntry.fields.webSignup;
-  if (!webSignupEntry) {
-    return data;
-  }
-
-  data.templates.webSignup = await module.exports
-    .getMessageTemplateFromContentfulEntryAndTemplateName(webSignupEntry, 'webSignup');
-
-  return data;
-}
-
-/**
  * @param {Object} contentfulEntry
  * @param {Promise}
  */
@@ -191,7 +156,6 @@ function isMessage(contentfulEntry) {
 }
 
 module.exports = {
-  fetchCampaignConfigByCampaignId,
   getById,
   getContentTypeConfigs,
   getMessageTemplateFromContentfulEntryAndTemplateName,
@@ -202,6 +166,5 @@ module.exports = {
   isDefaultTopicTrigger,
   isLegacyBroadcast,
   isMessage,
-  parseCampaignConfig,
   parseContentfulEntry,
 };

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -30,7 +30,7 @@ async function fetchCampaignConfigByCampaignId(campaignId) {
     content_type: 'campaign',
     'fields.campaignId': campaignId,
   });
-  return await module.exports.parseCampaignConfig(result.items[0]);
+  return module.exports.parseCampaignConfig(result.items[0]);
 }
 
 /**

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -22,6 +22,28 @@ function getById(contentfulId) {
 }
 
 /**
+ * @param {String} campaignId
+ * @return {Promise}
+ */
+async function fetchCampaignConfigByCampaignId(campaignId) {
+  const result = await contentful.fetchEntries({
+    content_type: 'campaign',
+    'fields.campaignId': campaignId,
+  });
+  return module.exports.parseCampaignConfig(result.items[0]);
+}
+
+/**
+ * @param {Object} contentfulEntry
+ * @return {Object}
+ */
+function parseCampaignConfig(contentfulEntry) {
+  return {
+    id: contentful.getContentfulIdFromContentfulEntry(contentfulEntry),
+  };
+}
+
+/**
  * @param {Object} contentfulEntry
  * @param {Promise}
  */
@@ -156,6 +178,7 @@ function isMessage(contentfulEntry) {
 }
 
 module.exports = {
+  fetchCampaignConfigByCampaignId,
   getById,
   getContentTypeConfigs,
   getMessageTemplateFromContentfulEntryAndTemplateName,
@@ -166,5 +189,6 @@ module.exports = {
   isDefaultTopicTrigger,
   isLegacyBroadcast,
   isMessage,
+  parseCampaignConfig,
   parseContentfulEntry,
 };

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -30,25 +30,29 @@ async function fetchCampaignConfigByCampaignId(campaignId) {
     content_type: 'campaign',
     'fields.campaignId': campaignId,
   });
-  return module.exports.parseCampaignConfig(result.items[0]);
+  return await module.exports.parseCampaignConfig(result.items[0]);
 }
 
 /**
  * @param {Object} contentfulEntry
- * @return {Object}
+ * @return {Promise}
  */
-function parseCampaignConfig(contentfulEntry) {
+async function parseCampaignConfig(contentfulEntry) {
   const data = {
     id: contentful.getContentfulIdFromContentfulEntry(contentfulEntry),
     templates: {
       webSignup: {},
     },
   };
+
   const webSignupEntry = contentfulEntry.fields.webSignup;
   if (!webSignupEntry) {
     return data;
   }
-  data.templates.webSignup.text = contentful.getTextFromMessage(webSignupEntry);
+
+  data.templates.webSignup = await module.exports
+    .getMessageTemplateFromContentfulEntryAndTemplateName(webSignupEntry, 'webSignup');
+
   return data;
 }
 

--- a/lib/middleware/campaigns/single/campaign-get.js
+++ b/lib/middleware/campaigns/single/campaign-get.js
@@ -10,7 +10,7 @@ module.exports = function getCampaign() {
     return helpers.campaign.getById(req.campaignId, resetCache)
       .then((campaign) => {
         req.campaign = campaign;
-        return helpers.contentfulEntry.fetchCampaignConfigByCampaignId(req.campaignId, resetCache);
+        return helpers.campaign.getCampaignConfigByCampaignId(req.campaignId, resetCache);
       })
       .then((campaignConfig) => {
         req.campaign.config = campaignConfig;

--- a/lib/middleware/campaigns/single/campaign-get.js
+++ b/lib/middleware/campaigns/single/campaign-get.js
@@ -10,7 +10,10 @@ module.exports = function getCampaign() {
     return helpers.campaign.getById(req.campaignId, resetCache)
       .then((campaign) => {
         req.campaign = campaign;
-
+        return helpers.contentfulEntry.fetchCampaignConfigByCampaignId(req.campaignId, resetCache);
+      })
+      .then((campaignConfig) => {
+        req.campaign.config = campaignConfig;
         return next();
       })
       .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/campaigns/single/campaign-get.js
+++ b/lib/middleware/campaigns/single/campaign-get.js
@@ -5,8 +5,9 @@ const helpers = require('../../../helpers');
 module.exports = function getCampaign() {
   return (req, res, next) => {
     req.campaignId = Number(req.params.campaignId);
+    const resetCache = helpers.request.isCacheReset(req);
 
-    return helpers.campaign.getById(req.campaignId)
+    return helpers.campaign.getById(req.campaignId, resetCache)
       .then((campaign) => {
         req.campaign = campaign;
 

--- a/lib/middleware/campaigns/single/topics-get.js
+++ b/lib/middleware/campaigns/single/topics-get.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const logger = require('winston');
 const helpers = require('../../../helpers');
 
 module.exports = function getTopics() {
@@ -8,7 +7,6 @@ module.exports = function getTopics() {
     .then((defaultTopicTriggers) => {
       // Find all defaultTopicTriggers that change to a topic for this campaign.
       const changeTopicTriggersForThisCampaign = defaultTopicTriggers.filter((trigger) => {
-        logger.debug('getTopics', { trigger });
         const isCampaignTopicTrigger = trigger && trigger.topic && trigger.topic.campaign;
         return isCampaignTopicTrigger && trigger.topic.campaign.id === req.campaignId;
       });

--- a/lib/middleware/campaigns/single/topics-get.js
+++ b/lib/middleware/campaigns/single/topics-get.js
@@ -2,6 +2,9 @@
 
 const helpers = require('../../../helpers');
 
+// NOTE: This will be deprecated for the sake of leaving it up to Gambit Admin to make multiple
+// queries (or integrating these endpoints into GraphQL) for the sake of grouping topics by campaign
+
 module.exports = function getTopics() {
   return (req, res, next) => helpers.defaultTopicTrigger.getAll()
     .then((defaultTopicTriggers) => {

--- a/test/lib/lib-helpers/campaign.test.js
+++ b/test/lib/lib-helpers/campaign.test.js
@@ -13,6 +13,7 @@ const underscore = require('underscore');
 const dateFns = require('date-fns');
 
 const helpers = require('../../../lib/helpers');
+const contentfulEntryHelper = require('../../../lib/helpers/contentfulEntry');
 const phoenix = require('../../../lib/phoenix');
 const stubs = require('../../utils/stubs');
 
@@ -47,11 +48,14 @@ test('fetchById calls phoenix.fetchCampaignById and parseCampaign', async () => 
     .returns(Promise.resolve(stubs.phoenix.getCampaign()));
   sandbox.stub(campaignHelper, 'parseCampaign')
     .returns(campaign);
+  const stubCampaignConfig = { id: stubs.getContentfulId() };
+  sandbox.stub(contentfulEntryHelper, 'fetchCampaignConfigByCampaignId')
+    .returns(Promise.resolve(stubCampaignConfig));
 
   const result = await campaignHelper.fetchById(campaignId);
   phoenix.fetchCampaignById.should.have.been.calledWith(campaignId);
   campaignHelper.parseCampaign.should.have.been.calledWith(campaign);
-  result.should.deep.equal(campaign);
+  result.should.deep.equal(Object.assign(campaign, { config: stubCampaignConfig }));
 });
 
 // getById

--- a/test/lib/lib-helpers/campaign.test.js
+++ b/test/lib/lib-helpers/campaign.test.js
@@ -51,11 +51,14 @@ test('fetchById calls phoenix.fetchCampaignById and parseCampaign', async () => 
   const stubCampaignConfig = { id: stubs.getContentfulId() };
   sandbox.stub(contentfulEntryHelper, 'fetchCampaignConfigByCampaignId')
     .returns(Promise.resolve(stubCampaignConfig));
+  sandbox.stub(helpers.cache.campaigns, 'set')
+    .returns(Promise.resolve(campaign));
 
   const result = await campaignHelper.fetchById(campaignId);
   phoenix.fetchCampaignById.should.have.been.calledWith(campaignId);
   campaignHelper.parseCampaign.should.have.been.calledWith(campaign);
   result.should.deep.equal(Object.assign(campaign, { config: stubCampaignConfig }));
+  helpers.cache.campaigns.set.should.have.been.calledWith(campaignId, campaign);
 });
 
 // getById
@@ -76,13 +79,10 @@ test('getById returns fetchById and sets cache if cache not set', async () => {
     .returns(Promise.resolve(null));
   sandbox.stub(campaignHelper, 'fetchById')
     .returns(Promise.resolve(campaign));
-  sandbox.stub(helpers.cache.campaigns, 'set')
-    .returns(Promise.resolve(campaign));
 
   const result = await campaignHelper.getById(campaignId);
   helpers.cache.campaigns.get.should.have.been.calledWith(campaignId);
   campaignHelper.fetchById.should.have.been.calledWith(campaignId);
-  helpers.cache.campaigns.set.should.have.been.calledWith(`${campaignId}`, campaign);
   result.should.deep.equal(campaign);
 });
 


### PR DESCRIPTION
#### What's this PR do?

Modifies the `campaign-get` middleware in a `GET /campaigns/:id` response to query Contentful for the `campaign` entry that has a `campaignId` field value matching our campaign id passed in the query parameter, parse it, and set it as a `config` property on the campaign.

* Renders the newly added `webSignup` field as a `config.templates.webSignup` property - returning the text to send a user, and the topic to set the conversation to

* Adds a `campaignConfigs` cache to cache `campaign` Contentful entries

* Adds a `cache` query parameter to the `GET /campaigns/:id` endpoint to allow manually clearing Redis cache for the campaign and campaignConfig

This still needs more unit tests (e.g. `parseCampaignConfig`) but wanted to open at this point to help keep this reviewable)

#### How should this be reviewed?
Verify `GET /v1/campaigns/2299` contains a `config` set as expected. This is the only campaign I've added a `webSignup` value for, but will be backfilling all current campaigns that are sending web signup messages.

#### Any background context you want to provide?
Once this is in place, [Signup message requests in gambit-conversations](https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/messages.md#signup) will be updated to inspect the `config.templates.webSignup` property instead of the first item it finds in the `topics` array.

We also aim to deprecate the MENU command per https://www.pivotaltracker.com/story/show/159796050 -- which means we'll no longer need the `GET /campaigns` resource to include a list of topics by campaign for anything business critical (Gambit Admin can be updated to either make multiple requests, or start on GraphQL integration). This means we can remove a lot of the complexity around caching a long list of all topics for the sake of returning topics by campaign in these endpoints.

#### Relevant tickets
Similar to https://www.pivotaltracker.com/story/show/157369418 in the sense that admins no longer require the web signup topic to match a keyword topic, broadcast topic, etc.

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
