### PR TITLE
Fixes GET /campaigns/:id response when campaign does not have config

### DIFF
--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -80,6 +80,9 @@ async function getCampaignConfigByCampaignId(campaignId, resetCache = false) {
  * @return {Promise}
  */
 async function parseCampaignConfig(contentfulEntry) {
+  if (!contentfulEntry) {
+    return {};
+  }
   const data = {
     id: contentful.getContentfulIdFromContentfulEntry(contentfulEntry),
     templates: {

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -83,6 +83,7 @@ async function parseCampaignConfig(contentfulEntry) {
   if (!contentfulEntry) {
     return {};
   }
+
   const data = {
     id: contentful.getContentfulIdFromContentfulEntry(contentfulEntry),
     templates: {

--- a/test/lib/lib-helpers/campaign.test.js
+++ b/test/lib/lib-helpers/campaign.test.js
@@ -204,6 +204,15 @@ test('parseCampaignConfig should return empty object if contentfulEntry undefine
   result.should.deep.equal({});
 });
 
+test('parseCampaignConfig should return object with id and templates properties', async () => {
+  const stubTemplate = { text: stubs.getRandomMessageText() };
+  sandbox.stub(helpers.contentfulEntry, 'getMessageTemplateFromContentfulEntryAndTemplateName')
+    .returns(Promise.resolve(stubTemplate));
+  const result = await campaignHelper.parseCampaignConfig(campaignConfigEntry);
+  result.id.should.equal(campaignConfigEntry.sys.id);
+  result.templates.webSignup.should.deep.equal(stubTemplate);
+});
+
 // parseAshesCampaign
 test('parseAshesCampaign returns an object with parsed properties from arg', () => {
   const ashesCampaign = stubs.phoenix.getAshesCampaign().data;

--- a/test/lib/lib-helpers/campaign.test.js
+++ b/test/lib/lib-helpers/campaign.test.js
@@ -198,6 +198,12 @@ test('parseCampaign should return parseAshesCampaign if phoenixConfig.useAshes',
   result.should.equal(mockResult);
 });
 
+// parseCampaignConfig
+test('parseCampaignConfig should return empty object if contentfulEntry undefined', async () => {
+  const result = await campaignHelper.parseCampaignConfig();
+  result.should.deep.equal({});
+});
+
 // parseAshesCampaign
 test('parseAshesCampaign returns an object with parsed properties from arg', () => {
   const ashesCampaign = stubs.phoenix.getAshesCampaign().data;

--- a/test/utils/factories/contentful/campaign.js
+++ b/test/utils/factories/contentful/campaign.js
@@ -11,6 +11,16 @@ function getValidCampaign() {
     sys: stubs.contentful.getSysWithTypeAndDate('campaign'),
     fields: {
       campaignId: stubs.getCampaignId(),
+      webSignup: {
+        sys: stubs.contentful.getSysWithTypeAndDate('webSignup'),
+        fields: {
+          text: stubs.getRandomMessageText(),
+          attachments: stubs.contentful.getAttachments(),
+          topic: {
+            sys: stubs.contentful.getSysWithTypeAndDate('textPostConfig'),
+          },
+        },
+      },
     },
   };
 }


### PR DESCRIPTION
#### What's this PR do?
Modifies `parseCampaignConfig` to return an empty response if the given campaignId does not have a corresponding `campaign` Gambini entry, preventing returning a 500 error returned from a `GET /campaigns/:id` for the campaignId.

#### How should this be reviewed?
a `GET /campaigns/4` request should return an empty object for the `config` property.

#### Any background context you want to provide?
Bug from #1076 -- I rolled back production 5.13.0 to avoid errors for signup message requests for campaigns without configs (refs https://dosomething.slack.com/archives/C1V0M6RPE/p1534796348000100)

#### Relevant tickets
Fixes bug in #1076 

#### Checklist
- [x] Tested on staging.
