### PR TITLE
Topic templates cleanup

### DIFF
--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const defaultText = {
-  declined: 'Text MENU if you\'d like to find a different action to take.',
+  declined: 'Text Q if you have a question.',
   invalidInput: 'Sorry, I didn\'t get that.',
   yesNo: '\n\nYes or No',
 };

--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -27,25 +27,9 @@ module.exports = {
    */
   templatesByContentType: {
     campaign: {
-      memberSupport: {
-        fieldName: 'memberSupportMessage',
-        defaultText: 'Text back your question and I\'ll try to get back to you within 24 hrs.',
-      },
       campaignClosed: {
         fieldName: 'campaignClosedMessage',
         defaultText: 'Sorry, {{title}} is no longer available.\n\nText {{cmd_member_support}} for help.',
-      },
-      askSignup: {
-        fieldName: 'askSignupMessage',
-        defaultText: `{{tagline}}\n\nWant to join {{title}}?${defaultText.yesNo}`,
-      },
-      declinedSignup: {
-        fieldName: 'declinedSignupMessage',
-        defaultText: `Ok! ${defaultText.declined}`,
-      },
-      invalidAskSignupResponse: {
-        fieldName: 'invalidSignupResponseMessage',
-        defaultText: `${defaultText.invalidInput} Did you want to join {{title}}?${defaultText.yesNo}`,
       },
       askContinue: {
         fieldName: 'askContinueMessage',

--- a/documentation/endpoints/topics.md
+++ b/documentation/endpoints/topics.md
@@ -91,11 +91,6 @@ curl http://localhost:5000/v1/topics?skip=5
           "override": true,
           "rendered": "Whoops, I didn't understand that. To enter to win the $2000 scholarship, click here and tag a friend: https://www.dosomething.org/us/campaigns/lose-your-v-card/blocks/7UYxNKCmS4OqEOiKSSAE2?user_id={{user.id}}\n\nHave a question for me? Text QUESTION and I will respond within 24 hours."
         },
-        "memberSupport": {
-          "raw": "Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to continue {{title}}, text back {{keyword}}",
-          "override": false,
-          "rendered": "Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to continue Lose Your V-Card, text back VCARD"
-        },
         ...
       },
       "triggers": [

--- a/test/lib/lib-helpers/topic.test.js
+++ b/test/lib/lib-helpers/topic.test.js
@@ -230,7 +230,7 @@ test('parseRawAndOverride returns template text when topic value exists', () => 
 test('getFieldValueFromContentfulEntryAndTemplateName returns the entry field value for templateName', () => {
   const result = topicHelper
     .getFieldValueFromContentfulEntryAndTemplateName(campaignConfig, templateName);
-  result.should.deep.equal(campaignConfig.fields.memberSupportMessage);
+  result.should.deep.equal(campaignConfig.fields.campaignClosedMessage);
 });
 
 // getPostTypeFromContentType

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -159,7 +159,7 @@ module.exports = {
   getRandomName,
   getRandomWord,
   getTemplateName: function getTemplateName() {
-    return 'memberSupport';
+    return 'campaignClosed';
   },
   getUserId: function getUserId() {
     return '597b9ef910707d07c84b00aa';


### PR DESCRIPTION
#### What's this PR do?
Follow up to https://github.com/DoSomething/gambit-conversations/pull/389 (and to be deployed to prod once that PR makes it to conversations-prod): 

* removes the `MENU` command reference found in a `declinedContinue` template

*  removes the `askSignup` templates 

* removes `memberSupport` template removed in https://github.com/DoSomething/gambit-conversations/pull/388

#### How should this be reviewed?
Verify the `declinedContinue` template prompts user to text Q instead of MENU. This template can be triggered by joining a campaign topic (e.g. text PUMP), sending a quick reply ("hello"), then sending a catchAll (e.g. France) to the `askContinue` template:

<img width="313" alt="screen shot 2018-08-22 at 2 36 43 pm" src="https://user-images.githubusercontent.com/1236811/44492306-dbb07280-a618-11e8-8a80-6c62dbd9347d.png">

#### Relevant tickets
https://www.pivotaltracker.com/story/show/159796050

#### Checklist
- [ ] Tested on staging.
