### PR TITLE
Adds GET /contentfulEntries index endpoint

### DIFF
--- a/app/routes/contentfulEntries/index.js
+++ b/app/routes/contentfulEntries/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const express = require('express');
+
+const getContentfulEntriesMiddleware = require('../../../lib/middleware/contentfulEntries/index/contentfulEntries-get');
+
+const router = express.Router();
+
+router.use(getContentfulEntriesMiddleware());
+
+module.exports = router;

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -6,8 +6,9 @@ const broadcastsSingleRoute = require('./broadcasts/single');
 const campaignsIndexRoute = require('./campaigns/index');
 const campaignsSingleRoute = require('./campaigns/single');
 const campaignActivityRoute = require('./campaignActivity');
-const defaultTopicTriggersRoute = require('./defaultTopicTriggers');
+const contentfulEntriesIndexRoute = require('./contentfulEntries/index');
 const contentfulEntriesSingleRoute = require('./contentfulEntries/single');
+const defaultTopicTriggersRoute = require('./defaultTopicTriggers');
 const topicsIndexRoute = require('./topics/index');
 const topicsSingleRoute = require('./topics/single');
 const statusRoute = require('./status');
@@ -37,7 +38,10 @@ module.exports = function init(app) {
   regGlobalMiddleware(app);
   app.get('/', statusRoute);
 
-  // Returns data for a contentful entry.
+  // Returns list of Contentful entries.
+  app.use('/v1/contentfulEntries/', contentfulEntriesIndexRoute);
+
+  // Returns data for a Contentful entry.
   app.use('/v1/contentfulEntries/:contentfulId', contentfulEntriesSingleRoute);
 
   // Provides data for a chatbot broadcast.

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -38,11 +38,11 @@ module.exports = function init(app) {
   regGlobalMiddleware(app);
   app.get('/', statusRoute);
 
-  // Returns list of Contentful entries.
-  app.use('/v1/contentfulEntries/', contentfulEntriesIndexRoute);
-
   // Returns data for a Contentful entry.
   app.use('/v1/contentfulEntries/:contentfulId', contentfulEntriesSingleRoute);
+
+  // Returns list of Contentful entries.
+  app.use('/v1/contentfulEntries/', contentfulEntriesIndexRoute);
 
   // Provides data for a chatbot broadcast.
   app.use('/v1/broadcasts/:broadcastId', broadcastsSingleRoute);

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -9,8 +9,8 @@ Endpoint                                       | Functionality
 `GET /v1/broadcasts/:id` | [Retrieve a broadcast](endpoints/broadcasts.md#retrieve-broadcast)
 `GET /v1/campaigns` | [Retrieve all campaigns with active topics](endpoints/campaigns.md#retrieve-all-campaigns)
 `GET /v1/campaigns/:id` | [Retrieve a campaign](endpoints/campaigns.md#retrieve-campaign)
-`GET /v1/contentfulEntries/` | Retrieve Contentful entries
-`GET /v1/contentfulEntries/:id` | Retrieve a Contentful entry
+`GET /v1/contentfulEntries/` | [Retrieve Contentful entries](endpoints/contentfulEntries.md#retrieve-contentful-entries)
+`GET /v1/contentfulEntries/:id` | [Retrieve a Contentful entry](endpoints/contentfulEntries.md#retrieve-contentful-entry)
 `GET /v1/defaultTopicTriggers` | [Retrieve all additional default topic triggers](endpoints/defaultTopicTriggers.md)
 `GET /v1/topics` | [Retrieve topics](endpoints/topics.md#retrieve-topics)
 `GET /v1/topics/:id` | [Retrieve a topic](endpoints/topics.md#retrieve-topic)

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -9,7 +9,8 @@ Endpoint                                       | Functionality
 `GET /v1/broadcasts/:id` | [Retrieve a broadcast](endpoints/broadcasts.md#retrieve-broadcast)
 `GET /v1/campaigns` | [Retrieve all campaigns with active topics](endpoints/campaigns.md#retrieve-all-campaigns)
 `GET /v1/campaigns/:id` | [Retrieve a campaign](endpoints/campaigns.md#retrieve-campaign)
-`GET /v1/contentfulEntries/:id` | Retrieve a parsed Contentful entry
+`GET /v1/contentfulEntries/` | Retrieve Contentful entries
+`GET /v1/contentfulEntries/:id` | Retrieve a Contentful entry
 `GET /v1/defaultTopicTriggers` | [Retrieve all additional default topic triggers](endpoints/defaultTopicTriggers.md)
 `GET /v1/topics` | [Retrieve topics](endpoints/topics.md#retrieve-topics)
 `GET /v1/topics/:id` | [Retrieve a topic](endpoints/topics.md#retrieve-topic)

--- a/documentation/endpoints/contentfulEntries.md
+++ b/documentation/endpoints/contentfulEntries.md
@@ -6,8 +6,8 @@ Fields:
 
 Name | Type | Description
 -----|------|------------
-`raw` | Object | The response from a Contentful API query for an entry. This data can be used to pass query string parameters to proxy to the Contentful API. 
-`parsed` | Object | The parsed raw property, if entry type is used in a `GET /broadcasts`, `GET /defaultTopicTriggers`, or `GET /topics` request. This property is set to `null` otherwise (e.g.  `campaign`, `webSignup` types).
+`raw` | Object | Formatted response of a Contentful Entries API request for a Contentful entry. 
+`parsed` | Object | Contains corresponding response of a `GET /broadcasts`, `GET /defaultTopicTriggers`, or`GET /topics` request for the Contentful entry. Set to `null` when content type is not returned as a resource (e.g.  the `campaign`, `message`, or `webSignup` types).
 
 
 ## Retrieve Contentful entries

--- a/documentation/endpoints/contentfulEntries.md
+++ b/documentation/endpoints/contentfulEntries.md
@@ -1,0 +1,246 @@
+# Contentful entries
+
+Contentful entries used for chatbot content.
+
+Fields:
+
+Name | Type | Description
+-----|------|------------
+`raw` | Object | The response from a Contentful API query for an entry. This data can be used to pass query string parameters to proxy to the Contentful API. 
+`parsed` | Object | The parsed raw property, if entry type is used in a `GET /broadcasts`, `GET /defaultTopicTriggers`, or `GET /topics` request. This property is set to `null` otherwise (e.g.  `campaign`, `webSignup` types).
+
+
+## Retrieve Contentful entries
+
+```
+GET /v1/contentfulEntries
+```
+
+Returns Contentful entries.
+
+### Query parameters
+
+Proxies the Contentful API.
+
+@see https://www.contentful.com/developers/docs/references/content-delivery-api for querying by fields.
+
+Name | Type | Description
+-----|------|------------
+`content_type` | String | Required -- the type of entry to query for. When querying by fields, Contentful requires a single `content_type` value. 
+
+<details><summary>**Example Request**</summary><p>
+
+```
+curl http://localhost:5000/v1/contentfulEntries?&content_type=campaign&fields.webSignup[exists]=true
+  -H "x-gambit-api-key: totallysecret"
+  -H "Accept: application/json"
+  -H "Content-Type: application/json"
+```
+
+</p></details>
+
+<details><summary>**Example Response**</summary><p>
+
+```
+{
+  "data": [
+    {
+      "raw": {
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "owik07lyerdj"
+            }
+          },
+          "type": "Entry",
+          "id": "68Oy1FcaR2EiaMieicaoom",
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "campaign"
+            }
+          },
+          ...
+          "locale": "en-US"
+        },
+        "fields": {
+          "campaignId": "2299",
+          "webSignup": {
+            "sys": {
+              "space": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Space",
+                  "id": "owik07lyerdj"
+                }
+              },
+              "type": "Entry",
+              "id": "1IFUHnCS0QmYMiscKC2qMO",
+              "contentType": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "ContentType",
+                  "id": "webSignup"
+                }
+              },
+              ...
+            },
+            "fields": {
+              "text": "Thanks for signing up for Two Books Blue Books!",
+              "topic": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "2Wzzquygx2wwMWe8kQAMgc"
+                }
+              }
+            }
+          },
+        }
+      },
+      "parsed": null
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "total": 1,
+      "skip": 0,
+      "limit": 100
+    }
+  }
+}
+
+```
+</p></details>
+
+
+## Retrieve Contentful entry
+
+```
+GET /v1/contentfulEntries/:id
+```
+
+Returns a Contentful entry.
+
+<details><summary>**Example Request**</summary><p>
+
+```
+curl http://localhost:5000/v1/contentfulEntries/5IZR2IQlJSw6UOaiwQgkWm
+  -H "x-gambit-api-key: totallysecret"
+  -H "Accept: application/json"
+  -H "Content-Type: application/json"
+```
+
+</p></details>
+
+<details><summary>**Example Response**</summary><p>
+  
+```
+// 20180831170241
+// http://localhost:5000/v1/contentfulEntries/5IZR2IQlJSw6UOaiwQgkWm?apiKey=totallysecret&content_type=campaign&fields.webSignup[exists]=true
+
+{
+  "data": {
+    "raw": {
+      "sys": {
+        "type": "Entry",
+        "id": "5IZR2IQlJSw6UOaiwQgkWm",
+        ...
+      },
+      "fields": {
+        "name": "PollLocationFinder2018_Sept4_MA",
+        "text": "Hi it's Freddie again! It's finally here! Today is Primary Election Day in Massachusetts. Are you (or your friends and family) going to vote today? Yes or No?",
+        "saidYes": "That's amazing! Your voice matters and we want to celebrate you for voting today. Take a photo of you and your I voted sticker (or make a sign that says I'm A Voter). Text START to share your photo with us.\n\nNeed to know where your polling place is? Find yours here: https://www.dosomething.org/us/campaigns/i-found-my-v-spot-2018/blocks/5slmqL2Xkcm0C60iyMwoa8?source=sms&utm_source=dosomething&utm_medium=sms&utm_campaign=sms_polllocator0904&user_id={{user.id}}&broadcastid=5IZR2IQlJSw6UOaiwQgkWm",
+        "saidYesTopic": {
+          "sys": {
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "owik07lyerdj"
+              }
+            },
+            "type": "Entry",
+            "id": "1yuEra7KjSwMwyO66UO2wE",
+            ...
+          },
+          "fields": {
+            "name": "Poll Location Finder - I Voted Sticker",
+            "campaign": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "3ZegOE2FVuW4oKq2GuKi04"
+              }
+            },
+            ...
+          }
+        },
+        "saidNo": "Even if you're not voting today, there's still an important election in November. Your voice matters, and it only takes 2 mins to register. Become a voter: https://vote.dosomething.org/?r=user:{{user.id}},campaignID:8017,campaignRunID:8022,source:sms,source_details:broadcastID_5IZR2IQlJSw6UOaiwQgkWm\n\nNot eligible to vote? You can still make an impact. Run an online voter reg drive to get your friends and family to the polls: https://www.dosomething.org/us/campaigns/online-registration-drive/blocks/4wXK2RiFo4KyKgOWssS0Og?source=sms&utm_source=dosomething&utm_medium=sms&utm_campaign=sms_voterreg0904&user_id={{user.id}}&broadcastid=5IZR2IQlJSw6UOaiwQgkWm",
+        "saidNoTopic": {
+          "sys": {
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "owik07lyerdj"
+              }
+            },
+            "type": "Entry",
+            "id": "61RPZx8atiGyeoeaqsckOE",
+            ...
+          },
+          "fields": {
+            "name": "Generic autoReply",
+            "autoReply": "Sorry, I didn't understand that. Text Q if you have a question."
+          }
+        },
+        "invalidAskYesNoResponse": "Sorry, I didn't get that - are you going to the polls today? Yes or No"
+      }
+    },
+    "parsed": {
+      "id": "5IZR2IQlJSw6UOaiwQgkWm",
+      "name": "PollLocationFinder2018_Sept4_MA",
+      "type": "askYesNo",
+      "createdAt": "2018-08-31T14:57:56.844Z",
+      "updatedAt": "2018-08-31T15:00:49.219Z",
+      "message": {
+        "text": "Hi it's Freddie again! It's finally here! Today is Primary Election Day in Massachusetts. Are you (or your friends and family) going to vote today? Yes or No?",
+        "attachments": [],
+        "template": "askYesNo",
+        "topic": {}
+      },
+      "templates": {
+        "saidYes": {
+          "text": "That's amazing! Your voice matters and we want to celebrate you for voting today. Take a photo of you and your I voted sticker (or make a sign that says I'm A Voter). Text START to share your photo with us.\n\nNeed to know where your polling place is? Find yours here: https://www.dosomething.org/us/campaigns/i-found-my-v-spot-2018/blocks/5slmqL2Xkcm0C60iyMwoa8?source=sms&utm_source=dosomething&utm_medium=sms&utm_campaign=sms_polllocator0904&user_id={{user.id}}&broadcastid=5IZR2IQlJSw6UOaiwQgkWm",
+          "topic": {
+            "id": "1yuEra7KjSwMwyO66UO2wE",
+            "name": "Poll Location Finder - I Voted Sticker",
+            "type": "photoPostConfig",
+            "createdAt": "2018-08-27T22:06:33.787Z",
+            "updatedAt": "2018-08-28T00:59:24.089Z",
+            "postType": "photo",
+            "campaign": {
+              "id": 7314,
+              "title": "I Found My V-Spot",
+              "tagline": "Find your polling place and send us photos of you voting.",
+              "status": "active",
+              "currentCampaignRun": {
+                "id": 8188
+              },
+              "endDate": null
+            },
+            "templates": {...},
+          },
+        },
+        "saidNo": {...}
+      }
+    }
+  }
+}
+```
+
+</p></details>

--- a/documentation/endpoints/contentfulEntries.md
+++ b/documentation/endpoints/contentfulEntries.md
@@ -139,9 +139,6 @@ curl http://localhost:5000/v1/contentfulEntries/5IZR2IQlJSw6UOaiwQgkWm
 <details><summary>**Example Response**</summary><p>
   
 ```
-// 20180831170241
-// http://localhost:5000/v1/contentfulEntries/5IZR2IQlJSw6UOaiwQgkWm?apiKey=totallysecret&content_type=campaign&fields.webSignup[exists]=true
-
 {
   "data": {
     "raw": {

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -128,6 +128,10 @@ function fetchByContentTypes(contentTypes, queryParams = {}) {
     });
 }
 
+/**
+ * @param {Object} query
+ * @return {Promise}
+ */
 function fetchEntries(queryParams) {
   const query = module.exports.getQueryBuilder()
     .custom(queryParams)
@@ -138,7 +142,6 @@ function fetchEntries(queryParams) {
       throw module.exports.contentfulError(error);
     });
 }
-
 
 /**
  * Parses Contentful getEntries response as object with meta and data properties.

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -132,7 +132,11 @@ function fetchEntries(queryParams) {
   const query = module.exports.getQueryBuilder()
     .custom(queryParams)
     .build();
-  return module.exports.getClient().getEntries(query);
+  return module.exports.getClient().getEntries(query)
+    .then(res => module.exports.parseGetEntriesResponse(res))
+    .catch((error) => {
+      throw module.exports.contentfulError(error);
+    });
 }
 
 

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -129,7 +129,7 @@ function fetchByContentTypes(contentTypes, queryParams = {}) {
 }
 
 /**
- * @param {Object} query
+ * @param {Object} queryParams
  * @return {Promise}
  */
 function fetchEntries(queryParams) {

--- a/lib/contentfulQueryBuilder.js
+++ b/lib/contentfulQueryBuilder.js
@@ -30,10 +30,14 @@ class QueryBuilder {
     return this;
   }
   custom(queryObject = {}) {
-    const keys = Object.keys(queryObject);
-    keys.forEach((queryKey) => {
-      this.query[queryKey] = queryObject[queryKey];
-    });
+    if (queryObject) {
+      Object.keys(queryObject).forEach((queryKey) => {
+        this.query[queryKey] = queryObject[queryKey];
+      });
+    }
+    if (!queryObject.order) {
+      this.orderByDescCreatedAt();
+    }
     return this;
   }
   limit(pageSize) {

--- a/lib/contentfulQueryBuilder.js
+++ b/lib/contentfulQueryBuilder.js
@@ -29,12 +29,10 @@ class QueryBuilder {
     this.query['fields.campaignId'] = id;
     return this;
   }
-  custom(queryObject = {}) {
-    if (queryObject) {
-      Object.keys(queryObject).forEach((queryKey) => {
-        this.query[queryKey] = queryObject[queryKey];
-      });
-    }
+  custom(queryObject) {
+    Object.keys(queryObject).forEach((queryKey) => {
+      this.query[queryKey] = queryObject[queryKey];
+    });
     if (!queryObject.order) {
       this.orderByDescCreatedAt();
     }

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -28,7 +28,7 @@ function fetchCampaignConfigByCampaignId(campaignId) {
     'fields.campaignId': campaignId,
   };
   return contentful.fetchEntries(query)
-    .then(res => module.exports.parseCampaignConfig(res.items[0]))
+    .then(res => module.exports.parseCampaignConfig(res.data[0]))
     .then(campaignConfig => helpers.cache.campaignConfigs.set(campaignId, campaignConfig));
 }
 

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const logger = require('winston');
+const Promise = require('bluebird');
 const contentful = require('../contentful');
 const helpers = require('../helpers');
 const config = require('../../config/lib/helpers/contentfulEntry');
@@ -12,11 +13,20 @@ function getContentTypeConfigs() {
   return config.contentTypes;
 }
 
+async function fetch(query = {}, parsed = 'true') {
+  const result = await contentful.fetchEntries(query);
+  if (parsed === 'false') {
+    return result;
+  }
+  result.data = await Promise.map(result.data, module.exports.parseContentfulEntry);
+  return result;
+}
+
 /**
  * @param {String} contentfulId
  * @param {Promise}
  */
-function getById(contentfulId) {
+function fetchById(contentfulId) {
   return contentful.fetchByContentfulId(contentfulId)
     .then(module.exports.parseContentfulEntry);
 }
@@ -156,7 +166,8 @@ function isMessage(contentfulEntry) {
 }
 
 module.exports = {
-  getById,
+  fetch,
+  fetchById,
   getContentTypeConfigs,
   getMessageTemplateFromContentfulEntryAndTemplateName,
   getSummaryFromContentfulEntry,

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -13,13 +13,17 @@ function getContentTypeConfigs() {
   return config.contentTypes;
 }
 
-async function fetch(query = {}, parsed = 'true') {
+/**
+ * @param {Object} query
+ * @return {Promise}
+ */
+async function fetch(query = {}) {
   const result = await contentful.fetchEntries(query);
-  if (parsed === 'false') {
-    return result;
-  }
-  result.data = await Promise.map(result.data, module.exports.parseContentfulEntry);
-  return result;
+
+  return {
+    meta: result.meta,
+    data: await Promise.map(result.data, module.exports.parseContentfulEntry),
+  };
 }
 
 /**
@@ -35,24 +39,25 @@ function fetchById(contentfulId) {
  * @param {Object} contentfulEntry
  * @param {Promise}
  */
-function parseContentfulEntry(contentfulEntry) {
-  // TODO: It might be nice to move all of these type of functions into this helper, to restrict
+async function parseContentfulEntry(contentfulEntry) {
+  const data = {
+    raw: contentfulEntry,
+    parsed: null,
+  };
+  // TODO: It'd be nice to move all of these type of functions into this helper, to restrict
   // lib/contentful to simply querying Contentful API.
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
 
   if (helpers.broadcast.getContentTypes().includes(contentType)) {
-    return helpers.broadcast.parseBroadcastFromContentfulEntry(contentfulEntry);
+    data.parsed = await helpers.broadcast.parseBroadcastFromContentfulEntry(contentfulEntry);
+  } else if (helpers.topic.getContentTypes().includes(contentType)) {
+    data.parsed = await helpers.topic.parseTopicFromContentfulEntry(contentfulEntry);
+  } else if (helpers.defaultTopicTrigger.getContentTypes().includes(contentType)) {
+    data.parsed = await helpers.defaultTopicTrigger
+      .parseDefaultTopicTriggerFromContentfulEntry(contentfulEntry);
   }
 
-  if (helpers.topic.getContentTypes().includes(contentType)) {
-    return helpers.topic.parseTopicFromContentfulEntry(contentfulEntry);
-  }
-
-  if (helpers.defaultTopicTrigger.getContentTypes().includes(contentType)) {
-    return helpers.defaultTopicTrigger.parseDefaultTopicTriggerFromContentfulEntry(contentfulEntry);
-  }
-
-  return Promise.resolve(contentfulEntry);
+  return data;
 }
 
 /**

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -22,7 +22,7 @@ async function fetch(query = {}) {
 
   return {
     meta: result.meta,
-    data: await Promise.map(result.data, module.exports.parseContentfulEntry),
+    data: await Promise.map(result.data, module.exports.formatForApi),
   };
 }
 
@@ -32,7 +32,36 @@ async function fetch(query = {}) {
  */
 function fetchById(contentfulId) {
   return contentful.fetchByContentfulId(contentfulId)
-    .then(module.exports.parseContentfulEntry);
+    .then(module.exports.formatForApi);
+}
+
+/**
+ * @param {Object} contentfulEntry
+ * @param {Promise}
+ */
+async function formatForApi(contentfulEntry) {
+  return {
+    raw: {
+      sys: module.exports.formatSys(contentfulEntry),
+      // TODO: Loop through fields and call formatSys for any references for readable API responses.
+      // @see https://github.com/DoSomething/gambit-campaigns/pull/1081/files#r214998873
+      fields: contentfulEntry.fields,
+    },
+    parsed: await module.exports.parseContentfulEntry(contentfulEntry),
+  };
+}
+
+/**
+ * @param {Object} contentfulEntry
+ * @return {Object}
+ */
+function formatSys(contentfulEntry) {
+  return {
+    id: contentfulEntry.sys.id,
+    contentType: contentfulEntry.sys.contentType,
+    createdAt: contentfulEntry.sys.createdAt,
+    updatedAt: contentfulEntry.sys.updatedAt,
+  };
 }
 
 /**
@@ -40,24 +69,21 @@ function fetchById(contentfulId) {
  * @param {Promise}
  */
 async function parseContentfulEntry(contentfulEntry) {
-  const data = {
-    raw: contentfulEntry,
-    parsed: null,
-  };
   // TODO: It'd be nice to move all of these type of functions into this helper, to restrict
   // lib/contentful to simply querying Contentful API.
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
 
   if (helpers.broadcast.getContentTypes().includes(contentType)) {
-    data.parsed = await helpers.broadcast.parseBroadcastFromContentfulEntry(contentfulEntry);
-  } else if (helpers.topic.getContentTypes().includes(contentType)) {
-    data.parsed = await helpers.topic.parseTopicFromContentfulEntry(contentfulEntry);
-  } else if (helpers.defaultTopicTrigger.getContentTypes().includes(contentType)) {
-    data.parsed = await helpers.defaultTopicTrigger
-      .parseDefaultTopicTriggerFromContentfulEntry(contentfulEntry);
+    return helpers.broadcast.parseBroadcastFromContentfulEntry(contentfulEntry);
+  }
+  if (helpers.topic.getContentTypes().includes(contentType)) {
+    return helpers.topic.parseTopicFromContentfulEntry(contentfulEntry);
+  }
+  if (helpers.defaultTopicTrigger.getContentTypes().includes(contentType)) {
+    return helpers.defaultTopicTrigger.parseDefaultTopicTriggerFromContentfulEntry(contentfulEntry);
   }
 
-  return data;
+  return null;
 }
 
 /**
@@ -173,6 +199,8 @@ function isMessage(contentfulEntry) {
 module.exports = {
   fetch,
   fetchById,
+  formatForApi,
+  formatSys,
   getContentTypeConfigs,
   getMessageTemplateFromContentfulEntryAndTemplateName,
   getSummaryFromContentfulEntry,

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -68,7 +68,7 @@ function formatSys(contentfulEntry) {
  * @param {Object} contentfulEntry
  * @param {Promise}
  */
-async function parseContentfulEntry(contentfulEntry) {
+function parseContentfulEntry(contentfulEntry) {
   // TODO: It'd be nice to move all of these type of functions into this helper, to restrict
   // lib/contentful to simply querying Contentful API.
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
@@ -83,7 +83,7 @@ async function parseContentfulEntry(contentfulEntry) {
     return helpers.defaultTopicTrigger.parseDefaultTopicTriggerFromContentfulEntry(contentfulEntry);
   }
 
-  return null;
+  return Promise.resolve(null);
 }
 
 /**

--- a/lib/middleware/contentfulEntries/index/contentfulEntries-get.js
+++ b/lib/middleware/contentfulEntries/index/contentfulEntries-get.js
@@ -7,12 +7,10 @@ module.exports = function getContentfulEntries() {
     if (!req.query.content_type) {
       return helpers.sendResponse(res, 422, 'content_type query parameter required,');
     }
-    const shouldParse = req.query.parsed;
     // Contentful throws an error when an unknown query parameter is passed, like our apiKey param.
     delete req.query.apiKey;
-    delete req.query.parsed;
 
-    return helpers.contentfulEntry.fetch(req.query, shouldParse)
+    return helpers.contentfulEntry.fetch(req.query)
       .then(fetchResult => helpers.response.sendIndexData(res, fetchResult.data, fetchResult.meta))
       .catch(err => helpers.sendErrorResponse(res, err));
   };

--- a/lib/middleware/contentfulEntries/index/contentfulEntries-get.js
+++ b/lib/middleware/contentfulEntries/index/contentfulEntries-get.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const contentful = require('../../../contentful');
+const helpers = require('../../../helpers');
+
+module.exports = function getContentfulEntries() {
+  return (req, res) => {
+    const query = req.query;
+    // Contentful throws an error when an unknown query parameter is passed, like our apiKey param.
+    delete query.apiKey;
+
+    return contentful.fetchEntries(req.query)
+      .then(fetchResult => helpers.response.sendIndexData(res, fetchResult.data, fetchResult.meta))
+      .catch(err => helpers.sendErrorResponse(res, err));
+  };
+};

--- a/lib/middleware/contentfulEntries/index/contentfulEntries-get.js
+++ b/lib/middleware/contentfulEntries/index/contentfulEntries-get.js
@@ -4,6 +4,9 @@ const helpers = require('../../../helpers');
 
 module.exports = function getContentfulEntries() {
   return (req, res) => {
+    if (!req.query.content_type) {
+      return helpers.sendResponse(res, 422, 'content_type query parameter required,');
+    }
     const shouldParse = req.query.parsed;
     // Contentful throws an error when an unknown query parameter is passed, like our apiKey param.
     delete req.query.apiKey;

--- a/lib/middleware/contentfulEntries/index/contentfulEntries-get.js
+++ b/lib/middleware/contentfulEntries/index/contentfulEntries-get.js
@@ -10,6 +10,9 @@ module.exports = function getContentfulEntries() {
       return helpers.sendErrorResponse(res, new UnprocessibleEntityError(errorMessage));
     }
     // Contentful throws an error when an unknown query parameter is passed, like our apiKey param.
+    // TODO: Instead of sending our req.query and guessing which params are Contentful specific vs
+    // our own parameters, expect a stringified contentfulQuery param.
+    // @see https://github.com/DoSomething/gambit-campaigns/pull/1081/files/ca4a6bb034a8758a056b7323cde2d37325f308d4#discussion_r214556063
     delete req.query.apiKey;
 
     return helpers.contentfulEntry.fetch(req.query)

--- a/lib/middleware/contentfulEntries/index/contentfulEntries-get.js
+++ b/lib/middleware/contentfulEntries/index/contentfulEntries-get.js
@@ -1,15 +1,15 @@
 'use strict';
 
-const contentful = require('../../../contentful');
 const helpers = require('../../../helpers');
 
 module.exports = function getContentfulEntries() {
   return (req, res) => {
-    const query = req.query;
+    const shouldParse = req.query.parsed;
     // Contentful throws an error when an unknown query parameter is passed, like our apiKey param.
-    delete query.apiKey;
+    delete req.query.apiKey;
+    delete req.query.parsed;
 
-    return contentful.fetchEntries(req.query)
+    return helpers.contentfulEntry.fetch(req.query, shouldParse)
       .then(fetchResult => helpers.response.sendIndexData(res, fetchResult.data, fetchResult.meta))
       .catch(err => helpers.sendErrorResponse(res, err));
   };

--- a/lib/middleware/contentfulEntries/index/contentfulEntries-get.js
+++ b/lib/middleware/contentfulEntries/index/contentfulEntries-get.js
@@ -1,11 +1,13 @@
 'use strict';
 
 const helpers = require('../../../helpers');
+const UnprocessibleEntityError = require('../../../../app/exceptions/UnprocessibleEntityError');
 
 module.exports = function getContentfulEntries() {
   return (req, res) => {
     if (!req.query.content_type) {
-      return helpers.sendResponse(res, 422, 'content_type query parameter required,');
+      const errorMessage = 'content_type query parameter required.';
+      return helpers.sendErrorResponse(res, new UnprocessibleEntityError(errorMessage));
     }
     // Contentful throws an error when an unknown query parameter is passed, like our apiKey param.
     delete req.query.apiKey;

--- a/lib/middleware/contentfulEntries/single/contentfulEntry-get.js
+++ b/lib/middleware/contentfulEntries/single/contentfulEntry-get.js
@@ -3,7 +3,7 @@
 const helpers = require('../../../helpers');
 
 module.exports = function getContentfulEntry() {
-  return (req, res) => helpers.contentfulEntry.getById(req.params.contentfulId)
+  return (req, res) => helpers.contentfulEntry.fetchById(req.params.contentfulId)
     .then(data => helpers.response.sendData(res, data))
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -188,7 +188,7 @@ test('fetchEntries should call contentfulError when it fails', async (t) => {
   });
 
   // test
-  await t.throws(contentful.fetchEntries());
+  await t.throws(contentful.fetchEntries({}));
   contentful.contentfulError.should.have.been.called;
 });
 

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -160,6 +160,39 @@ test('fetchByContentTypes should call contentfulError when it fails', async (t) 
   contentful.contentfulError.should.have.been.called;
 });
 
+// fetchEntries
+test('fetchEntries should call getEntries with given query object', async () => {
+  const queryParams = { 'fields.campaignId': stubs.getCampaignId() };
+  const data = ['abc', 'def'];
+  contentful.__set__('client', {
+    getEntries: sinon.stub().returns(getEntriesStub),
+  });
+  sandbox.stub(contentful, 'parseGetEntriesResponse')
+    .returns(data);
+
+  const query = contentful.getQueryBuilder()
+    .custom(queryParams)
+    .orderByDescCreatedAt()
+    .build();
+
+  // test
+  const result = await contentful.fetchEntries(queryParams);
+  contentful.getClient().getEntries.getCall(0).args[0].should.be.eql(query);
+  result.should.deep.equal(data);
+});
+
+test('fetchEntries should call contentfulError when it fails', async (t) => {
+  sandbox.spy(contentful, 'contentfulError');
+  contentful.__set__('client', {
+    getEntries: sinon.stub().returns(failStub),
+  });
+
+  // test
+  await t.throws(contentful.fetchEntries());
+  contentful.contentfulError.should.have.been.called;
+});
+
+
 // getContentfulIdFromContentfulEntry
 test('getContentfulIdFromContentfulEntry returns contentful entry id of given entry', () => {
   const result = contentful.getContentfulIdFromContentfulEntry(campaignConfigStub);

--- a/test/lib/lib-helpers/campaign.test.js
+++ b/test/lib/lib-helpers/campaign.test.js
@@ -63,7 +63,7 @@ test('fetchById calls phoenix.fetchCampaignById, parseCampaign, and sets cache',
 // fetchCampaignConfigByCampaignId
 test('fetchCampaignConfigByCampaignId calls contentful.fetchEntries, parseCampaignConfig, and sets cache', async () => {
   sandbox.stub(contentful, 'fetchEntries')
-    .returns(Promise.resolve({ items: [campaignConfigEntry] }));
+    .returns(Promise.resolve({ data: [campaignConfigEntry] }));
   sandbox.stub(campaignHelper, 'parseCampaignConfig')
     .returns(parsedCampaignConfig);
   sandbox.stub(helpers.cache.campaignConfigs, 'set')

--- a/test/lib/middleware/contentfulEntries/index/contentfulEntries-get.test.js
+++ b/test/lib/middleware/contentfulEntries/index/contentfulEntries-get.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// libs
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../lib/helpers');
+const stubs = require('../../../../utils/stubs');
+const askYesNoFactory = require('../../../../utils/factories/contentful/askYesNo');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const getContentfulEntries = require('../../../../../lib/middleware/contentfulEntries/index/contentfulEntries-get');
+
+const sandbox = sinon.sandbox.create();
+
+const contentfulEntries = [askYesNoFactory.getValidAskYesNo(), askYesNoFactory.getValidAskYesNo()];
+const fetchResult = stubs.contentful.getFetchByContentTypesResultWithArray(contentfulEntries);
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  sandbox.stub(helpers.response, 'sendIndexData')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('getContentfulEntries should send errorResponse if content_type query param not set', async (t) => {
+  const next = sinon.stub();
+  const middleware = getContentfulEntries();
+  sandbox.stub(helpers.contentfulEntry, 'fetch')
+    .returns(Promise.resolve(fetchResult));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.contentfulEntry.fetch.should.not.have.been.called;
+  helpers.response.sendIndexData.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+});
+
+test('getContentfulEntries should call helpers.contentfulEntry.fetch result without apiKey query param', async (t) => {
+  const next = sinon.stub();
+  const middleware = getContentfulEntries();
+  sandbox.stub(helpers.contentfulEntry, 'fetch')
+    .returns(Promise.resolve(fetchResult));
+  const contentType = 'askYesNo';
+  t.context.req.query = {
+    content_type: contentType,
+    apiKey: 'whatever',
+  };
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.contentfulEntry.fetch.should.have.been.calledWith({ content_type: contentType });
+  helpers.response.sendIndexData
+    .should.have.been.calledWith(t.context.res, fetchResult.data, fetchResult.meta);
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('getContentfulEntries should send errorResponse if helpers.contentfulEntry.fetch fails', async (t) => {
+  const next = sinon.stub();
+  const middleware = getContentfulEntries();
+  const error = new Error('o noes');
+  sandbox.stub(helpers.contentfulEntry, 'fetch')
+    .returns(Promise.reject(error));
+  t.context.req.query = {
+    content_type: 'askYesNo',
+  };
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.contentfulEntry.fetch.should.have.been.called;
+  helpers.response.sendIndexData.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
+});

--- a/test/lib/middleware/contentfulEntries/single/contentfulEntry-get.test.js
+++ b/test/lib/middleware/contentfulEntries/single/contentfulEntry-get.test.js
@@ -12,15 +12,15 @@ const underscore = require('underscore');
 const stubs = require('../../../../utils/stubs');
 const helpers = require('../../../../../lib/helpers');
 
-const broadcastFactory = require('../../../../utils/factories/broadcast');
+const askYesNoFactory = require('../../../../utils/factories/contentful/askYesNo');
 
-const broadcast = broadcastFactory.getValidCampaignBroadcast();
+const askYesNoEntry = askYesNoFactory.getValidAskYesNo();
 
 chai.should();
 chai.use(sinonChai);
 
 // module to be tested
-const getBroadcast = require('../../../../../lib/middleware/broadcasts/single/broadcast-get');
+const getContentfulEntry = require('../../../../../lib/middleware/contentfulEntries/single/contentfulEntry-get');
 
 const sandbox = sinon.sandbox.create();
 
@@ -29,7 +29,7 @@ test.beforeEach((t) => {
     .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
   t.context.req.params = {
-    broadcastId: stubs.getBroadcastId(),
+    contentfulId: stubs.getContentfulId(),
   };
   t.context.res = httpMocks.createResponse();
   sandbox.spy(t.context.res, 'send');
@@ -40,29 +40,31 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('getBroadcast should send data with getById result', async (t) => {
+test('getContentfulEntry should send data with fetchById result', async (t) => {
   const next = sinon.stub();
-  const middleware = getBroadcast();
-  sandbox.stub(helpers.broadcast, 'getById')
-    .returns(Promise.resolve(broadcast));
+  const middleware = getContentfulEntry();
+  sandbox.stub(helpers.contentfulEntry, 'fetchById')
+    .returns(Promise.resolve(askYesNoEntry));
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  helpers.broadcast.getById.should.have.been.calledWith(t.context.req.params.broadcastId);
-  t.context.res.send.should.have.been.calledWith({ data: broadcast });
+  helpers.contentfulEntry.fetchById
+    .should.have.been.calledWith(t.context.req.params.contentfulId);
+  t.context.res.send.should.have.been.calledWith({ data: askYesNoEntry });
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('getBroadcast should sendErrorResponse if getById fails', async (t) => {
+test('getContentfulEntry should sendErrorResponse if fetchById fails', async (t) => {
   const next = sinon.stub();
-  const middleware = getBroadcast();
+  const middleware = getContentfulEntry();
   const mockError = { message: 'Epic fail' };
-  sandbox.stub(helpers.broadcast, 'getById')
+  sandbox.stub(helpers.contentfulEntry, 'fetchById')
     .returns(Promise.reject(mockError));
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  helpers.broadcast.getById.should.have.been.calledWith(t.context.req.params.broadcastId);
+  helpers.contentfulEntry.fetchById
+    .should.have.been.calledWith(t.context.req.params.contentfulId);
   t.context.res.send.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, mockError);
 });


### PR DESCRIPTION
#### What's this PR do?

Adds a `GET /contentfulEntries` endpoint that serves as a proxy to our Contentful API, enabling queries such as finding all `campaign` entries with a `webSignup` reference set, or all `textPostConfig` entries that reference a given `campaign` entry id. 

Each item in the `data` response is an object with a `raw` property set to the Contentful entry, and a `parsed` property if the entry is parsed and returned as a broadcast, topic, or defaultTopicTrigger in the respective endpoints.

#### How should this be reviewed?
Verify `GET /contentfulEntries` works as expected

#### Any background context you want to provide?
Once Conversations inspects the `templates.webSignup` in a `GET /campaigns` response to source the signup confirmation message, we'll want Gambit Admin/Slack to query this endpoint to provide a list of all campaigns that currently have webSignup templates available.

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.