### PR TITLE
Adds cache query param to GET /defaultTopicTriggers

### DIFF
--- a/documentation/endpoints/defaultTopicTriggers.md
+++ b/documentation/endpoints/defaultTopicTriggers.md
@@ -22,6 +22,15 @@ GET /v1/defaultTopicTriggers
 
 Returns defaultTopicTrigger entries.
 
+Note: This endpoint currently returns a cached list of defaultTopicTrigger entries if exists. We will no longer need to cache the list once the Conversations API uses Redis to cache parsed Rivescript.
+@see https://github.com/DoSomething/gambit-conversations/pull/398
+
+### Query parameters
+
+Name | Type | Description
+-----|------|------------
+`cache` | string | If set to `false`, fetches default topic triggers from Contentful instead of checking cache.
+
 
 <details><summary>**Example Request**</summary><p>
 

--- a/lib/helpers/defaultTopicTrigger.js
+++ b/lib/helpers/defaultTopicTrigger.js
@@ -23,6 +23,7 @@ function fetch(query = {}) {
   return contentful.fetchByContentTypes(module.exports.getContentTypes(), query)
     .then(contentfulRes => Promise.map(contentfulRes.data, module.exports
       .parseDefaultTopicTriggerFromContentfulEntry))
+    // TODO: We need to modify the meta data too, as we're removing data items here.
     .then(defaultTopicTriggers => module.exports
       .removeInvalidDefaultTopicTriggers(defaultTopicTriggers));
 }

--- a/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.js
+++ b/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.js
@@ -3,7 +3,15 @@
 const helpers = require('../../../helpers');
 
 module.exports = function getDefaultTopicTriggers() {
-  return (req, res) => helpers.defaultTopicTrigger.getAll()
-    .then(defaultTopicTriggers => helpers.response.sendIndexData(res, defaultTopicTriggers))
-    .catch(err => helpers.sendErrorResponse(res, err));
+  return (req, res) => {
+    let promise;
+    if (req.query && req.query.cache === 'false') {
+      promise = helpers.defaultTopicTrigger.fetch(req.query);
+    } else {
+      promise = helpers.defaultTopicTrigger.getAll();
+    }
+    return promise
+      .then(defaultTopicTriggers => helpers.response.sendIndexData(res, defaultTopicTriggers))
+      .catch(err => helpers.sendErrorResponse(res, err));
+  };
 };

--- a/test/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.test.js
+++ b/test/lib/middleware/defaultTopicTriggers/index/defaultTopicTriggers-get.test.js
@@ -39,20 +39,41 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('getDefaultTopicTriggers should send helpers.defaultTopicTrigger.getAll result', async (t) => {
+test('getDefaultTopicTriggers should send helpers.defaultTopicTrigger.getAll result if req.query.cache is not false', async (t) => {
   const next = sinon.stub();
   const middleware = getDefaultTopicTriggers();
   sandbox.stub(helpers.defaultTopicTrigger, 'getAll')
     .returns(Promise.resolve(defaultTopicTriggerStubs));
+  sandbox.stub(helpers.defaultTopicTrigger, 'fetch')
+    .returns(Promise.resolve(true));
+
 
   // test
   await middleware(t.context.req, t.context.res, next);
   helpers.defaultTopicTrigger.getAll.should.have.been.called;
+  helpers.defaultTopicTrigger.fetch.should.not.have.been.called;
   helpers.response.sendIndexData
     .should.have.been.calledWith(t.context.res, defaultTopicTriggerStubs);
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
+test('getDefaultTopicTriggers should send helpers.defaultTopicTrigger.fetch result if req.query.cache is false', async (t) => {
+  const next = sinon.stub();
+  const middleware = getDefaultTopicTriggers();
+  sandbox.stub(helpers.defaultTopicTrigger, 'getAll')
+    .returns(Promise.resolve(defaultTopicTriggerStubs));
+  sandbox.stub(helpers.defaultTopicTrigger, 'fetch')
+    .returns(Promise.resolve(defaultTopicTriggerStubs));
+  t.context.req.query = { cache: 'false' };
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.defaultTopicTrigger.getAll.should.not.have.been.called;
+  helpers.defaultTopicTrigger.fetch.should.have.been.calledWith(t.context.req.query);
+  helpers.response.sendIndexData
+    .should.have.been.calledWith(t.context.res, defaultTopicTriggerStubs);
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
 
 test('getDefaultTopicTriggers should send errorResponse if helpers.defaultTopicTrigger.getAll fails', async (t) => {
   const next = sinon.stub();


### PR DESCRIPTION
#### What's this PR do?
Adds support for a `cache` query param set to `false` to fetch `defaultTopicTrigger` entries directly from Contentful, instead of from the cached `defaultTopicTriggers` cache entry for `all`, unblocking https://github.com/DoSomething/gambit-conversations/pull/398 from reloading Rivescript from Contentful upon the rivescript cache clear.

#### How should this be reviewed?
Verify that a `GET /defaultTopicTriggers?cache=false` request directly queries Contentful, and that excluding the query parameter still returns the cached list if exists (we'll still need this up until we turn on Redis caching in the next upcoming Conversations release)

#### Any background context you want to provide?
It'll be great to get rid of all of these cached lists of `defaultTopicTrigger` entries! It's also a part of what happens in #1082 -- a single misconfigured keyword can wipe out all endpoints because they rely on this cached list.

#### Relevant tickets
https://www.pivotaltracker.com/story/show/158037562

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
