### PR TITLE
Update superagent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gambit-campaigns",
-  "version": "5.11.0",
+  "version": "5.13.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -338,7 +338,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -9772,45 +9772,20 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "superagent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-2.3.0.tgz",
-      "integrity": "sha1-cDUpoHFOV+EjlZ3e+84ZOy5Q0RU=",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "requires": {
         "component-emitter": "1.2.1",
         "cookiejar": "2.1.2",
-        "debug": "2.6.9",
+        "debug": "3.1.0",
         "extend": "3.0.2",
-        "form-data": "1.0.0-rc4",
+        "form-data": "2.3.2",
         "formidable": "1.2.1",
         "methods": "1.1.2",
         "mime": "1.6.0",
         "qs": "6.5.2",
         "readable-stream": "2.3.6"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "form-data": {
-          "version": "1.0.0-rc4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-          "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
-          "requires": {
-            "async": "1.5.2",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.19"
-          }
-        }
       }
     },
     "superagent-use": {

--- a/package.json
+++ b/package.json
@@ -66,8 +66,7 @@
     "serve-favicon": "^2.5.0",
     "simple-oauth2": "^1.5.2",
     "stathat": "0.0.8",
-    "superagent": "^2.3.0",
-    "superagent-use": "^0.1.0",
+    "superagent": "^3.8.3",
     "throng": "^4.0.0",
     "underscore": "^1.9.0",
     "winston": "2.3.x"


### PR DESCRIPTION
#### What's this PR do?

Updates superagent to avoid low risk security warning, and removes unused `superagent-use` package.

#### How should this be reviewed?

Our `lib/phoenix` uses the package to query the DS Campaigns API, verify a `GET /campaigns` request works as expected

#### Checklist
- [ ] Tested on staging.