### PR TITLE
Refactors cache helper to single contentfulEntries cache

### DIFF
--- a/config/lib/helpers/cache.js
+++ b/config/lib/helpers/cache.js
@@ -1,24 +1,12 @@
 'use strict';
 
 module.exports = {
-  broadcasts: {
-    name: 'broadcasts',
-    ttl: parseInt(process.env.GAMBIT_BROADCASTS_CACHE_TTL, 10) || 3600,
-  },
-  campaignConfigs: {
-    name: 'campaignConfigs',
-    ttl: parseInt(process.env.GAMBIT_CAMPAIGN_CONFIGS_CACHE_TTL, 10) || 3600,
-  },
   campaigns: {
     name: 'campaigns',
     ttl: parseInt(process.env.GAMBIT_CAMPAIGNS_CACHE_TTL, 10) || 3600,
   },
-  defaultTopicTriggers: {
-    name: 'defaultTopicTriggers',
-    ttl: parseInt(process.env.GAMBIT_DEFAULT_TOPIC_TRIGGERS_CACHE_TTL, 10) || 3600,
-  },
-  topics: {
-    name: 'topics',
-    ttl: parseInt(process.env.GAMBIT_TOPICS_CACHE_TTL, 10) || 3600,
+  contentfulEntries: {
+    name: 'contentfulEntries',
+    ttl: parseInt(process.env.GAMBIT_CONTENTFUL_ENTRIES_CACHE_TTL, 10) || 3600,
   },
 };

--- a/config/lib/helpers/defaultTopicTrigger.js
+++ b/config/lib/helpers/defaultTopicTrigger.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  allDefaultTopicTriggersCacheKey: 'all',
+  allDefaultTopicTriggersCacheKey: 'allDefaultTopicTriggers',
 };

--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -19,7 +19,7 @@ const photoPostDefaultText = {
 };
 
 module.exports = {
-  allTopicsCacheKey: 'all',
+  allTopicsCacheKey: 'allTopics',
   defaultPostType: 'photo',
   /*
    * Maps each content type with a map of templateNames and its corresponding field name and

--- a/lib/helpers/cache.js
+++ b/lib/helpers/cache.js
@@ -6,24 +6,12 @@ const redisClient = require('../../config/redis')();
 const config = require('../../config/lib/helpers/cache');
 
 const redisEngine = new RedisEngine(redisClient);
-const broadcastsCache = new Cacheman(config.broadcasts.name, {
-  ttl: config.broadcasts.ttl,
-  engine: redisEngine,
-});
 const campaignsCache = new Cacheman(config.campaigns.name, {
   ttl: config.campaigns.ttl,
   engine: redisEngine,
 });
-const campaignConfigsCache = new Cacheman(config.campaignConfigs.name, {
-  ttl: config.campaignConfigs.ttl,
-  engine: redisEngine,
-});
-const defaultTopicTriggersCache = new Cacheman(config.defaultTopicTriggers.name, {
-  ttl: config.defaultTopicTriggers.ttl,
-  engine: redisEngine,
-});
-const topicsCache = new Cacheman(config.topics.name, {
-  ttl: config.topics.ttl,
+const parsedContentfulEntriesCache = new Cacheman(config.contentfulEntries.name, {
+  ttl: config.contentfulEntries.ttl,
   engine: redisEngine,
 });
 
@@ -34,18 +22,18 @@ function parseSetCacheResponse(res) {
 module.exports = {
   broadcasts: {
     get: function get(id) {
-      return broadcastsCache.get(id);
+      return parsedContentfulEntriesCache.get(id);
     },
     set: function set(id, data) {
-      return broadcastsCache.set(id, data).then(res => parseSetCacheResponse(res));
+      return parsedContentfulEntriesCache.set(id, data).then(res => parseSetCacheResponse(res));
     },
   },
   campaignConfigs: {
     get: function get(id) {
-      return campaignConfigsCache.get(`${id}`);
+      return parsedContentfulEntriesCache.get(`${id}`);
     },
     set: function set(id, data) {
-      return campaignConfigsCache.set(`${id}`, data).then(res => parseSetCacheResponse(res));
+      return parsedContentfulEntriesCache.set(`${id}`, data).then(res => parseSetCacheResponse(res));
     },
   },
   campaigns: {
@@ -58,18 +46,18 @@ module.exports = {
   },
   defaultTopicTriggers: {
     get: function get(id) {
-      return defaultTopicTriggersCache.get(id);
+      return parsedContentfulEntriesCache.get(id);
     },
     set: function set(id, data) {
-      return defaultTopicTriggersCache.set(id, data).then(res => parseSetCacheResponse(res));
+      return parsedContentfulEntriesCache.set(id, data).then(res => parseSetCacheResponse(res));
     },
   },
   topics: {
     get: function get(id) {
-      return topicsCache.get(id);
+      return parsedContentfulEntriesCache.get(id);
     },
     set: function set(id, data) {
-      return topicsCache.set(id, data).then(res => parseSetCacheResponse(res));
+      return parsedContentfulEntriesCache.set(id, data).then(res => parseSetCacheResponse(res));
     },
   },
 };

--- a/test/lib/lib-helpers/cache.test.js
+++ b/test/lib/lib-helpers/cache.test.js
@@ -15,9 +15,11 @@ const cacheHelper = rewire('../../../lib/helpers/cache');
 
 // stubs
 const stubs = require('../../utils/stubs');
+const campaignConfigFactory = require('../../utils/factories/contentful/campaign');
 const defaultTopicTriggerFactory = require('../../utils/factories/defaultTopicTrigger');
 
 const campaign = stubs.getPhoenixCampaign();
+const campaignConfig = campaignConfigFactory.getValidCampaign();
 const campaignId = stubs.getCampaignId();
 const contentfulId = stubs.getContentfulId();
 const defaultTopicTrigger = defaultTopicTriggerFactory.getValidDefaultTopicTriggerWithReply();
@@ -28,7 +30,48 @@ const sandbox = sinon.sandbox.create();
 test.afterEach(() => {
   sandbox.restore();
   cacheHelper.__set__('campaignsCache', undefined);
-  cacheHelper.__set__('defaultTopicTriggersCache', undefined);
+  cacheHelper.__set__('parsedContentfulEntriesCache', undefined);
+});
+
+/**
+ * broadcasts
+ */
+test('broadcasts.get should return object when cache exists', async () => {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
+    get: () => Promise.resolve(topic),
+  });
+  const result = await cacheHelper.broadcasts.get(contentfulId);
+  result.should.deep.equal(topic);
+});
+
+test('broadcasts.get should return falsy when cache undefined', async (t) => {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
+    get: () => Promise.resolve(null),
+  });
+  const result = await cacheHelper.broadcasts.get(contentfulId);
+  t.falsy(result);
+});
+
+test('broadcasts.get should throw when cache set fails', async (t) => {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
+    get: () => Promise.reject(new Error()),
+  });
+  await t.throws(cacheHelper.broadcasts.get(contentfulId));
+});
+
+test('broadcasts.set should return an object', async () => {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
+    set: () => Promise.resolve(JSON.stringify(topic)),
+  });
+  const result = await cacheHelper.broadcasts.set(contentfulId);
+  result.should.deep.equal(topic);
+});
+
+test('broadcasts.set should throw when cache set fails', async (t) => {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
+    set: () => Promise.reject(new Error()),
+  });
+  await t.throws(cacheHelper.broadcasts.set(contentfulId));
 });
 
 /**
@@ -73,10 +116,51 @@ test('campaigns.set should throw when cache set fails', async (t) => {
 });
 
 /**
+ * campaignConfigs
+ */
+test('campaignConfigs.get should return object when cache exists', async () => {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
+    get: () => Promise.resolve(campaignConfig),
+  });
+  const result = await cacheHelper.campaignConfigs.get(campaignId);
+  result.should.deep.equal(campaignConfig);
+});
+
+test('campaignConfigs.get should return falsy when cache undefined', async (t) => {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
+    get: () => Promise.resolve(null),
+  });
+  const result = await cacheHelper.campaignConfigs.get(campaignId);
+  t.falsy(result);
+});
+
+test('campaignConfigs.get should throw when cache set fails', async (t) => {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
+    get: () => Promise.reject(new Error()),
+  });
+  await t.throws(cacheHelper.campaignConfigs.get(campaignId));
+});
+
+test('campaignConfigs.set should return an object', async () => {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
+    set: () => Promise.resolve(JSON.stringify(topic)),
+  });
+  const result = await cacheHelper.campaignConfigs.set(campaignId);
+  result.should.deep.equal(topic);
+});
+
+test('campaignConfigs.set should throw when cache set fails', async (t) => {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
+    set: () => Promise.reject(new Error()),
+  });
+  await t.throws(cacheHelper.campaignConfigs.set(campaignId));
+});
+
+/**
  * defaultTopicTriggers
  */
 test('defaultTopicTriggers.get should return object when cache exists', async () => {
-  cacheHelper.__set__('defaultTopicTriggersCache', {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
     get: () => Promise.resolve(defaultTopicTrigger),
   });
   const result = await cacheHelper.defaultTopicTriggers.get(contentfulId);
@@ -84,7 +168,7 @@ test('defaultTopicTriggers.get should return object when cache exists', async ()
 });
 
 test('defaultTopicTriggers.get should return falsy when cache undefined', async (t) => {
-  cacheHelper.__set__('defaultTopicTriggersCache', {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
     get: () => Promise.resolve(null),
   });
   const result = await cacheHelper.defaultTopicTriggers.get(contentfulId);
@@ -92,14 +176,14 @@ test('defaultTopicTriggers.get should return falsy when cache undefined', async 
 });
 
 test('defaultTopicTriggers.get should throw when cache set fails', async (t) => {
-  cacheHelper.__set__('defaultTopicTriggersCache', {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
     get: () => Promise.reject(new Error()),
   });
   await t.throws(cacheHelper.defaultTopicTriggers.get(contentfulId));
 });
 
 test('defaultTopicTriggers.set should return an object', async () => {
-  cacheHelper.__set__('defaultTopicTriggersCache', {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
     set: () => Promise.resolve(JSON.stringify(defaultTopicTrigger)),
   });
   const result = await cacheHelper.defaultTopicTriggers.set(contentfulId);
@@ -107,7 +191,7 @@ test('defaultTopicTriggers.set should return an object', async () => {
 });
 
 test('defaultTopicTriggers.set should throw when cache set fails', async (t) => {
-  cacheHelper.__set__('defaultTopicTriggersCache', {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
     set: () => Promise.reject(new Error()),
   });
   await t.throws(cacheHelper.defaultTopicTriggers.set(contentfulId));
@@ -117,7 +201,7 @@ test('defaultTopicTriggers.set should throw when cache set fails', async (t) => 
  * topics
  */
 test('topics.get should return object when cache exists', async () => {
-  cacheHelper.__set__('topicsCache', {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
     get: () => Promise.resolve(topic),
   });
   const result = await cacheHelper.topics.get(contentfulId);
@@ -125,7 +209,7 @@ test('topics.get should return object when cache exists', async () => {
 });
 
 test('topics.get should return falsy when cache undefined', async (t) => {
-  cacheHelper.__set__('topicsCache', {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
     get: () => Promise.resolve(null),
   });
   const result = await cacheHelper.topics.get(contentfulId);
@@ -133,14 +217,14 @@ test('topics.get should return falsy when cache undefined', async (t) => {
 });
 
 test('topics.get should throw when cache set fails', async (t) => {
-  cacheHelper.__set__('topicsCache', {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
     get: () => Promise.reject(new Error()),
   });
   await t.throws(cacheHelper.topics.get(contentfulId));
 });
 
 test('topics.set should return an object', async () => {
-  cacheHelper.__set__('topicsCache', {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
     set: () => Promise.resolve(JSON.stringify(topic)),
   });
   const result = await cacheHelper.topics.set(contentfulId);
@@ -148,7 +232,7 @@ test('topics.set should return an object', async () => {
 });
 
 test('topics.set should throw when cache set fails', async (t) => {
-  cacheHelper.__set__('topicsCache', {
+  cacheHelper.__set__('parsedContentfulEntriesCache', {
     set: () => Promise.reject(new Error()),
   });
   await t.throws(cacheHelper.topics.set(contentfulId));


### PR DESCRIPTION
#### What's this PR do?
Goes [KISS](https://en.wikipedia.org/wiki/KISS_principle) to cache all Contentful queries with a single `contentfulEntriesCache` instance as an easy fix for #1085. 

#### How should this be reviewed?

Using an askYesNo entry id, could verify following steps:

* GET /topics/:id - cache miss
* GET /broadcasts/:id - cache hit
* GET broadcasts/:id?cache=true - cache reset
* GET /topics/:id - cache hit

Also verify expected caching behavior for `GET /posts` and `GET /defaultTopicTriggers` index requests.

#### Any background context you want to provide?

Aiming to eventually deprecate the use of caching the index request responses, by delegating the responsibility of nested linked items within responses to [GraphQL](https://github.com/dosomething/graphql).

#### Relevant tickets
Fixes #1085 

#### Checklist
- [ ] Tested on staging.
