### PR TITLE
Check for draft webSignup references

### DIFF
--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -108,9 +108,12 @@ function getSummaryFromContentfulEntry(contentfulEntry) {
  * @return {Promise}
  */
 async function getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry, templateName) {
+  if (!contentfulEntry || !contentfulEntry.fields) {
+    return {};
+  }
   const topicEntry = contentfulEntry.fields.topic;
   const topic = topicEntry ? await helpers.topic
-    .getById(contentful.getContentfulIdFromContentfulEntry(topicEntry)) : {};
+    .getById(contentful.getContentfulIdFromContentfulEntry(contentfulEntry.fields.topic)) : {};
   return {
     text: contentful.getTextFromMessage(contentfulEntry),
     attachments: contentful.getAttachmentsFromContentfulEntry(contentfulEntry),

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -116,6 +116,12 @@ test('getMessageTemplateFromContentfulEntryAndTemplateName should call topic.get
   result.template.should.equal(messageTemplate);
 });
 
+test('getMessageTemplateFromContentfulEntryAndTemplateName result should be empty object if contentfulEntry undefined', async () => {
+  const result = await contentfulEntryHelper
+    .getMessageTemplateFromContentfulEntryAndTemplateName(null, stubs.getRandomWord());
+  result.should.deep.equal({});
+});
+
 test('getMessageTemplateFromContentfulEntryAndTemplateName should not call topic.getById if topic reference field undefined', async () => {
   sandbox.stub(helpers.topic, 'getById')
     .returns(fetchTopicResult);


### PR DESCRIPTION
#### What's this PR do?

Adds a check for existence of a `contentfulEntry` arg in `helpers.contentfulEntry. getMessageTemplateFromContentfulEntryAndTemplateName`. It can be set to null when a draft value is saved, which throws an error in production.

#### How should this be reviewed?

* Edit a test campaign's `webSignup` reference field to a draft entry, ignore the warning and publish. Execute an `GET /campaigns/:id?cache=false` request to verify errors are not thrown. I've been using a random DB campaign id [2299](https://app.contentful.com/spaces/owik07lyerdj/entries/68Oy1FcaR2EiaMieicaoom) to test, but we shouldn't be using any active campaigns we're collecting signups for 😬 

* Sanity check that `GET /topics/:id` returns expected results without any errors.

#### Any background context you want to provide?

Getting this in place to avoid any unexpected errors when rolling out the `webSignup` template field, which will deprecate our `webStartPhotoPost`, `webAskText` fields from the relevant types.

#### Relevant tickets
Fixes https://dosomething.slack.com/archives/C2C8NLNAY/p1536935393000100?thread_ts=1536933605.000100&cid=C2C8NLNAY

#### Checklist
- [x] Tested on staging.
