### PR TITLE
Adds askVotingPlanStatus type

### DIFF
--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -23,6 +23,15 @@ module.exports = {
       type: 'askSubscriptionStatus',
       broadcastable: true,
     },
+    askVotingPlanStatus: {
+      type: 'askVotingPlanStatus',
+      broadcastable: true,
+      templates: [
+        'invalidVotingStatus',
+        'saidVoting',
+        'saidNotVoting',
+      ],
+    },
     askYesNo: {
       type: 'askYesNo',
       broadcastable: true,

--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -27,7 +27,7 @@ module.exports = {
       type: 'askVotingPlanStatus',
       broadcastable: true,
       templates: [
-        'invalidVotingStatus',
+        'invalidVotingPlanStatus',
         'saidVoting',
         'saidNotVoting',
       ],

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -137,33 +137,17 @@ async function getTopicTemplates(contentfulEntry) {
   }
 
   const fields = contentfulEntry.fields;
-  templateFieldNames.forEach((fieldName) => {
+  /* eslint-disable */
+  // TODO: Disabling our linter probably isn't best way to handle this...
+  for (const fieldName of templateFieldNames) {
+    const templateTopicRef = fields[`${fieldName}Topic`];
     result[fieldName] = {
       text: fields[fieldName],
-      topic: {},
+      topic: templateTopicRef ? await helpers.topic
+        .getById(contentful.getContentfulIdFromContentfulEntry(templateTopicRef)) : {},
     };
-  });
-
-  /**
-   * Check for template fields that can change topic.
-   * TODO: It'd be nice to set these dynamically via config/lib/contentfulEntry.
-   */
-  if (result.saidNo && fields.saidNoTopic) {
-    result.saidNo.topic = await helpers.topic
-      .getById(contentful.getContentfulIdFromContentfulEntry(fields.saidNoTopic));
   }
-  if (result.saidNotVoting && fields.saidNotVotingTopic) {
-    result.saidNotVoting.topic = await helpers.topic
-      .getById(contentful.getContentfulIdFromContentfulEntry(fields.saidNotVotingTopic));
-  }
-  if (result.saidVoting && fields.saidVotingTopic) {
-    result.saidVoting.topic = await helpers.topic
-      .getById(contentful.getContentfulIdFromContentfulEntry(fields.saidVotingTopic));
-  }
-  if (result.saidYes && fields.saidYesTopic) {
-    result.saidYes.topic = await helpers.topic
-      .getById(contentful.getContentfulIdFromContentfulEntry(fields.saidYesTopic));
-  }
+  /* eslint-enable */
 
   return result;
 }

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -136,23 +136,33 @@ async function getTopicTemplates(contentfulEntry) {
     return result;
   }
 
+  const fields = contentfulEntry.fields;
   templateFieldNames.forEach((fieldName) => {
     result[fieldName] = {
-      text: contentfulEntry.fields[fieldName],
+      text: fields[fieldName],
       topic: {},
     };
   });
 
-  // The saidYes template should include the topic saved to the saidYesTopic field.
-  if (result.saidYes && contentfulEntry.fields.saidYesTopic) {
-    result.saidYes.topic = await helpers.topic
-      .getById(contentful.getContentfulIdFromContentfulEntry(contentfulEntry.fields.saidYesTopic));
-  }
-
-  // The saidNo template should include the topic saved to the saidNoTopic field.
-  if (result.saidNo && contentfulEntry.fields.saidNoTopic) {
+  /**
+   * Check for template fields that can change topic.
+   * TODO: It'd be nice to set these dynamically via config/lib/contentfulEntry.
+   */
+  if (result.saidNo && fields.saidNoTopic) {
     result.saidNo.topic = await helpers.topic
-      .getById(contentful.getContentfulIdFromContentfulEntry(contentfulEntry.fields.saidNoTopic));
+      .getById(contentful.getContentfulIdFromContentfulEntry(fields.saidNoTopic));
+  }
+  if (result.saidNotVoting && fields.saidNotVotingTopic) {
+    result.saidNotVoting.topic = await helpers.topic
+      .getById(contentful.getContentfulIdFromContentfulEntry(fields.saidNotVotingTopic));
+  }
+  if (result.saidVoting && fields.saidVotingTopic) {
+    result.saidVoting.topic = await helpers.topic
+      .getById(contentful.getContentfulIdFromContentfulEntry(fields.saidVotingTopic));
+  }
+  if (result.saidYes && fields.saidYesTopic) {
+    result.saidYes.topic = await helpers.topic
+      .getById(contentful.getContentfulIdFromContentfulEntry(fields.saidYesTopic));
   }
 
   return result;

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -123,33 +123,33 @@ async function getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEn
 }
 
 /**
- * @param {Object}
- * @param {String}
+ * @param {Object} contentfulEntry
  * @return {Promise}
  */
 async function getTopicTemplates(contentfulEntry) {
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
   const templateFieldNames = config.contentTypes[contentType].templates;
-  const result = {};
+  const templates = {};
 
   if (!contentfulEntry || !templateFieldNames) {
-    return result;
+    return templates;
   }
 
   const fields = contentfulEntry.fields;
   /* eslint-disable */
-  // TODO: Disabling our linter probably isn't best way to handle this...
+  // TODO: Disabling our linter probably isn't best way to handle this, find topics in parallel
+  // instead of serially per https://github.com/DoSomething/gambit-campaigns/pull/1088/files#r220969795
   for (const fieldName of templateFieldNames) {
-    const templateTopicRef = fields[`${fieldName}Topic`];
-    result[fieldName] = {
+    const templateTopicEntry = fields[`${fieldName}Topic`];
+    templates[fieldName] = {
       text: fields[fieldName],
-      topic: templateTopicRef ? await helpers.topic
-        .getById(contentful.getContentfulIdFromContentfulEntry(templateTopicRef)) : {},
+      topic: templateTopicEntry ? await helpers.topic
+        .getById(contentful.getContentfulIdFromContentfulEntry(templateTopicEntry)) : {},
     };
   }
   /* eslint-enable */
 
-  return result;
+  return templates;
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?

Exposes entries with the newly askVotingPlanStatus content type created in Contentful as a broadcasts.

#### How should this be reviewed?

👀 , verify a GET `/v1/broadcasts/4LJn0P1LeoUauC0CkESYKE` request looks as expected

#### Any background context you want to provide?

Wasn't sure about the async forEach disabling lint approach to find the topic fields that correspond to template fields (e.g. `saidNo` template changes topic to `saidNoTopic`)

#### Relevant tickets
First steps for Make A Voting Plan

#### Checklist
- [x] Tested on staging.
