### PR TITLE
Removes fetching triggers in GET /topics index queries

### DIFF
--- a/documentation/endpoints/topics.md
+++ b/documentation/endpoints/topics.md
@@ -80,7 +80,6 @@ curl http://localhost:5000/v1/topics?skip=5
           "topic": {}
         }
       },
-      "triggers": []
     },
     {
       "id": "2X4r3fZrTGA2mGemowgiEI",
@@ -118,7 +117,6 @@ curl http://localhost:5000/v1/topics?skip=5
           "topic": {}
         }
       },
-      "triggers": [],
     },
     {
       "id": "3peS2Oye08o6OwUMAEcS2c",
@@ -144,9 +142,6 @@ curl http://localhost:5000/v1/topics?skip=5
         },
         ...
       },
-      "triggers": [
-        "mascot",
-      ]
     },
     ...
   ],

--- a/lib/middleware/topics/index/topics-get.js
+++ b/lib/middleware/topics/index/topics-get.js
@@ -7,14 +7,6 @@ module.exports = function getTopics() {
     .then((fetchTopicResult) => {
       req.data = fetchTopicResult.data;
       req.meta = fetchTopicResult.meta;
-      const promises = req.data.map(topic => helpers.defaultTopicTrigger.getByTopicId(topic.id));
-      return Promise.all(promises);
-    })
-    .then((defaultTopicTriggersByTopic) => {
-      defaultTopicTriggersByTopic.forEach((result, index) => {
-        req.data[index].triggers = helpers.defaultTopicTrigger
-          .getTriggersFromDefaultTopicTriggers(result);
-      });
       return helpers.response.sendIndexData(res, req.data, req.meta);
     })
     .catch(err => helpers.sendErrorResponse(res, err));

--- a/test/lib/middleware/topics/index/topics-get.test.js
+++ b/test/lib/middleware/topics/index/topics-get.test.js
@@ -38,26 +38,16 @@ test.afterEach((t) => {
 test('getTopics should send helpers.topic.fetch result', async (t) => {
   const next = sinon.stub();
   const middleware = getTopics();
-  const triggers = [stubs.getRandomWord()];
-  const firstTopic = topicFactory.getValidTopic();
-  const secondTopic = topicFactory.getValidTopic();
-  const topics = [firstTopic, secondTopic];
+  const topics = [topicFactory.getValidTopic(), topicFactory.getValidTopic()];
   const fetchResult = stubs.contentful.getFetchByContentTypesResultWithArray(topics);
   sandbox.stub(helpers.topic, 'fetch')
     .returns(Promise.resolve(fetchResult));
-  sandbox.stub(helpers.defaultTopicTrigger, 'getByTopicId')
-    .returns(Promise.resolve(fetchResult));
-  sandbox.stub(helpers.defaultTopicTrigger, 'getTriggersFromDefaultTopicTriggers')
-    .returns(triggers);
   const queryParams = { skip: 20 };
   t.context.req.query = queryParams;
 
   // test
   await middleware(t.context.req, t.context.res, next);
   helpers.topic.fetch.should.have.been.calledWith(queryParams);
-  helpers.defaultTopicTrigger.getByTopicId.should.have.been.calledWith(firstTopic.id);
-  helpers.defaultTopicTrigger.getByTopicId.should.have.been.calledWith(secondTopic.id);
-
   helpers.response.sendIndexData
     .should.have.been.calledWith(t.context.res, fetchResult.data, fetchResult.meta);
   helpers.sendErrorResponse.should.not.have.been.called;


### PR DESCRIPTION
#### What's this PR do?

When the redis cache is empty, a `GET /topics` index query will time out with seemingly infinite nested getting/caching queries for campaigns when getting the defaultTopicTriggers for each result item. We eventually recover because the data begins to cache, but this PR simplifies it all by removes the call to get or fetch defaultTopicTriggers entirely during a `GET /topics` request, no longer including a `triggers` property in each result item.

This changes only affects Gambit Admin and it isn't such an issue anymore now that we're revamping the Campaigns page to make individual queries to the `GET /contentfulEntries` endpoint (https://github.com/DoSomething/gambit-admin/pull/76). To avoid building out extra code for custom queries on our end -- I'd prefer we start exposing our Gambit content via [GraphQL](https://github.com/dosomething/graphql) instead. We're overdue for updating the `CampaignDetail` component in Gambit Admin to make a ` GET /contentfulEnties` request to this app instead of `GET /topics` to display lists of topics by campaign , as the `GET /topics` query isn't not paging through results or by campaignId (Gambit Admin filters topics by campaignId on the client side, so we may be missing older topics belonging to the campaign ID in later pages of `/GET topics` results)


#### How should this be reviewed?

Conversations doesn't ever this hit this `GET /topics` endpoint, so no review needed there. Could do quick 👀 in Gambit Admin staging to verify that the [Campaign List](https://gambit-admin-staging.herokuapp.com/campaigns) and [Campaign Detail](https://gambit-admin-staging.herokuapp.com/campaigns/8226) don't break. Note that for the Campaign Detail, we won't see the `lock` keyword associated with the topic (we'll address that in Gambit Admin)

#### Any background context you want to provide?

Now that https://github.com/DoSomething/gambit-conversations/pull/423 is merged and ready to deploy, we can consider removing the list of topics in the response of data of a `GET /campaigns/:id` request, as it won't be necessary for Conversations functionality -- and can be better handled via GraphQL and/or caching within Gambit Admin

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
