### PR TITLE
Topic templates cleanup: part 1

### DIFF
--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const textFieldType = 'text';
 const transitionFieldType = 'transition';
 
 /**
@@ -60,10 +61,13 @@ module.exports = {
     },
     autoReply: {
       type: 'autoReply',
-      // TODO: Refactor templates as an object.
-      templates: [
-        'autoReply',
-      ],
+      templates: {
+        autoReply: {
+          fieldName: 'autoReply',
+          fieldType: textFieldType,
+          name: 'autoReply',
+        },
+      },
     },
     autoReplyBroadcast: {
       type: 'autoReplyBroadcast',
@@ -81,17 +85,17 @@ module.exports = {
     },
     photoPostConfig: {
       type: 'photoPostConfig',
+      // TODO: Refactor photoPostConfig in config/lib/helpers/topic here to DRY.
       postType: 'photo',
-      // TODO: Refactor topic config to define templates here and DRY.
     },
     textPostBroadcast: {
       type: 'textPostBroadcast',
+      broadcastable: true,
     },
     textPostConfig: {
       type: 'textPostConfig',
+      // TODO: Move textPostConfig in config/lib/helpers/topic here to DRY.
       postType: 'text',
-      broadcastable: true,
-      // TODO: Refactor topic config to define templates here and DRY.
     },
     // Legacy types:
     // Ideally we'd backfill all legacy entries as their new types, but we likely can't change the

--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const transitionFieldType = 'transition';
+
 /**
  * This maps the fields in our Contentful types into broadcast, topic, and defaultTopicTriggers.
  *
@@ -26,15 +28,30 @@ module.exports = {
     askVotingPlanStatus: {
       type: 'askVotingPlanStatus',
       broadcastable: true,
-      templates: [
-        'votingPlanStatusCantVote',
-        'votingPlanStatusNotVoting',
-        'votingPlanStatusVoted',
-      ],
+      templates: {
+        votingPlanStatusCantVote: {
+          fieldName: 'cantVoteTransition',
+          fieldType: transitionFieldType,
+          name: 'votingPlanStatusCantVote',
+        },
+        votingPlanStatusNotVoting: {
+          fieldName: 'notVotingTransition',
+          fieldType: transitionFieldType,
+          name: 'votingPlanStatusNotVoting',
+        },
+        votingPlanStatusVoted: {
+          fieldName: 'votedTransition',
+          fieldType: transitionFieldType,
+          name: 'votingPlanStatusVoted',
+        },
+      },
     },
     askYesNo: {
       type: 'askYesNo',
       broadcastable: true,
+      // TODO: Refactor templates as an object. We'll want new transition fields, but also need to
+      // backfill legacy saidYes, saidYesTopic, saidNo, and saidNoTopic fields.
+      // That or we define a new content type, as we can't easily rename our content type name.
       templates: [
         'saidYes',
         'saidNo',
@@ -43,6 +60,7 @@ module.exports = {
     },
     autoReply: {
       type: 'autoReply',
+      // TODO: Refactor templates as an object.
       templates: [
         'autoReply',
       ],
@@ -64,14 +82,16 @@ module.exports = {
     photoPostConfig: {
       type: 'photoPostConfig',
       postType: 'photo',
+      // TODO: Refactor topic config to define templates here and DRY.
     },
     textPostBroadcast: {
       type: 'textPostBroadcast',
-      broadcastable: true,
     },
     textPostConfig: {
       type: 'textPostConfig',
       postType: 'text',
+      broadcastable: true,
+      // TODO: Refactor topic config to define templates here and DRY.
     },
     // Legacy types:
     // Ideally we'd backfill all legacy entries as their new types, but we likely can't change the

--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const textFieldType = 'text';
-const transitionFieldType = 'transition';
+const templateFieldTypes = {
+  text: 'text',
+  transition: 'transition',
+};
 
 /**
  * This maps the fields in our Contentful types into broadcast, topic, and defaultTopicTriggers.
@@ -30,19 +32,22 @@ module.exports = {
       type: 'askVotingPlanStatus',
       broadcastable: true,
       templates: {
+        // These template names correspond to the macros that get executed if user matches a trigger
+        // within the ask_voting_plan_status topic in Gambit Conversations.
+        // @see https://github.com/DoSomething/gambit-conversations/blob/master/brain/topics/askVotingPlanStatus.rive
         votingPlanStatusCantVote: {
           fieldName: 'cantVoteTransition',
-          fieldType: transitionFieldType,
+          fieldType: templateFieldTypes.transition,
           name: 'votingPlanStatusCantVote',
         },
         votingPlanStatusNotVoting: {
           fieldName: 'notVotingTransition',
-          fieldType: transitionFieldType,
+          fieldType: templateFieldTypes.transition,
           name: 'votingPlanStatusNotVoting',
         },
         votingPlanStatusVoted: {
           fieldName: 'votedTransition',
-          fieldType: transitionFieldType,
+          fieldType: templateFieldTypes.transition,
           name: 'votingPlanStatusVoted',
         },
       },
@@ -64,7 +69,7 @@ module.exports = {
       templates: {
         autoReply: {
           fieldName: 'autoReply',
-          fieldType: textFieldType,
+          fieldType: templateFieldTypes.text,
           name: 'autoReply',
         },
       },
@@ -111,4 +116,5 @@ module.exports = {
       broadcastable: true,
     },
   },
+  templateFieldTypes,
 };

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -123,7 +123,7 @@ async function getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEn
 }
 
 /**
- * TODO: We need pass a parameter to force clearing cache for all topics.
+ * TODO: We need pass a parameter to force clearing cache for all topics within the templates.
  * @param {Object} contentfulEntry
  * @return {Promise}
  */
@@ -226,7 +226,8 @@ function isMessage(contentfulEntry) {
  * @return {Boolean}
  */
 function isTransitionTemplate(contentType, templateName) {
-  return config.contentTypes[contentType].templates[templateName].fieldType === 'transition';
+  const templatesConfig = config.contentTypes[contentType].templates;
+  return templatesConfig[templateName].fieldType === config.templateFieldTypes.transition;
 }
 
 module.exports = {

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -136,18 +136,28 @@ async function getTopicTemplates(contentfulEntry) {
     return templates;
   }
 
-  if (contentType === config.contentTypes.askVotingPlanStatus.type) {
+  if (contentType !== config.contentTypes.askYesNo.type) {
     const templateNames = Object.keys(templatesConfig);
     const promises = [];
     templateNames.forEach((templateName) => {
       const fieldName = templatesConfig[templateName].fieldName;
-      // TODO: Pass cache clear parameter.
-      promises.push(module.exports
-        .getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry.fields[fieldName]));
+      const fieldValue = contentfulEntry.fields[fieldName];
+      if (module.exports.isTransitionTemplate(contentType, templateName)) {
+        // TODO: Pass cache clear parameter.
+        promises.push(module.exports
+          .getMessageTemplateFromContentfulEntryAndTemplateName(fieldValue));
+      } else {
+        templates[templateName] = {
+          text: fieldValue,
+          topic: {},
+        };
+      }
     });
     const messageTemplates = await Promise.all(promises);
     templateNames.forEach((templateName, index) => {
-      templates[templateName] = messageTemplates[index];
+      if (module.exports.isTransitionTemplate(contentType, templateName)) {
+        templates[templateName] = messageTemplates[index];
+      }
     });
     return templates;
   }
@@ -210,6 +220,15 @@ function isMessage(contentfulEntry) {
   return contentful.isContentType(contentfulEntry, config.contentTypes.message.type);
 }
 
+/**
+ * @param {String} contentType
+ * @param {String} templateName
+ * @return {Boolean}
+ */
+function isTransitionTemplate(contentType, templateName) {
+  return config.contentTypes[contentType].templates[templateName].fieldType === 'transition';
+}
+
 module.exports = {
   fetch,
   fetchById,
@@ -224,5 +243,6 @@ module.exports = {
   isDefaultTopicTrigger,
   isLegacyBroadcast,
   isMessage,
+  isTransitionTemplate,
   parseContentfulEntry,
 };

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -123,15 +123,32 @@ async function getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEn
 }
 
 /**
+ * TODO: We need pass a parameter to force clearing cache for all topics.
  * @param {Object} contentfulEntry
  * @return {Promise}
  */
 async function getTopicTemplates(contentfulEntry) {
   const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
-  const templateFieldNames = config.contentTypes[contentType].templates;
+  const templatesConfig = config.contentTypes[contentType].templates;
   const templates = {};
 
-  if (!contentfulEntry || !templateFieldNames) {
+  if (!contentfulEntry || !templatesConfig) {
+    return templates;
+  }
+
+  if (contentType === config.contentTypes.askVotingPlanStatus.type) {
+    const templateNames = Object.keys(templatesConfig);
+    const promises = [];
+    templateNames.forEach((templateName) => {
+      const fieldName = templatesConfig[templateName].fieldName;
+      // TODO: Pass cache clear parameter.
+      promises.push(module.exports
+        .getMessageTemplateFromContentfulEntryAndTemplateName(contentfulEntry.fields[fieldName]));
+    });
+    const messageTemplates = await Promise.all(promises);
+    templateNames.forEach((templateName, index) => {
+      templates[templateName] = messageTemplates[index];
+    });
     return templates;
   }
 
@@ -139,7 +156,7 @@ async function getTopicTemplates(contentfulEntry) {
   /* eslint-disable */
   // TODO: Disabling our linter probably isn't best way to handle this, find topics in parallel
   // instead of serially per https://github.com/DoSomething/gambit-campaigns/pull/1088/files#r220969795
-  for (const fieldName of templateFieldNames) {
+  for (const fieldName of templatesConfig) {
     const templateTopicEntry = fields[`${fieldName}Topic`];
     templates[fieldName] = {
       text: fields[fieldName],

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -10,6 +10,9 @@ const sinon = require('sinon');
 const contentful = require('../../../lib/contentful');
 const helpers = require('../../../lib/helpers');
 const stubs = require('../../utils/stubs');
+
+const config = require('../../../config/lib/helpers/contentfulEntry');
+
 // Contentful factories
 const askYesNoEntryFactory = require('../../utils/factories/contentful/askYesNo');
 const autoReplyFactory = require('../../utils/factories/contentful/autoReply');
@@ -193,4 +196,16 @@ test('isDefaultTopicTrigger returns whether content type is defaultTopicTrigger'
 test('isMessage returns whether content type is message', (t) => {
   t.truthy(contentfulEntryHelper.isMessage(messageEntry));
   t.falsy(contentfulEntryHelper.isMessage(autoReplyEntry));
+});
+
+// isTransitionTemplate
+test('isTransitionTemplate returns whether contentType config for templateName is a transition field', (t) => {
+  const askVotingPlanStatus = config.contentTypes.askVotingPlanStatus;
+  const autoReply = config.contentTypes.autoReply;
+  let templateName = askVotingPlanStatus.templates.votingPlanStatusVoted.name;
+  t.truthy(contentfulEntryHelper
+    .isTransitionTemplate(askVotingPlanStatus.type, templateName));
+  templateName = autoReply.templates.autoReply.name;
+  t.falsy(contentfulEntryHelper
+    .isTransitionTemplate(autoReply.type, templateName));
 });


### PR DESCRIPTION
#### What's this PR do?

Branching off of #1090, this PR modifies a `askVotingPlanStatus` broadcast/topic type to render templates based on new reference fields, which are limited to the new `autoReplyTransition`, `photoPostTransition`, and `textPostTransition` templates introduced in the work for #1076

#### How should this be reviewed?
Verify `GET /topics` or `GET /broadcasts` requests for `askVotingPlanStatus`, `askYesNo`, and `autoReply`types return expected responses (nothing breaks)

#### Any background context you want to provide?

Part 2 will refactor `askYesNo` templates with new `yesTransition` and `noTransition` reference fields, holding off on that here to help keep this reviewable.

#### Relevant tickets
The epic https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
