### PR TITLE
Topic templates cleanup: part 2

### DIFF
--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -55,14 +55,23 @@ module.exports = {
     askYesNo: {
       type: 'askYesNo',
       broadcastable: true,
-      // TODO: Refactor templates as an object. We'll want new transition fields, but also need to
-      // backfill legacy saidYes, saidYesTopic, saidNo, and saidNoTopic fields.
-      // That or we define a new content type, as we can't easily rename our content type name.
-      templates: [
-        'saidYes',
-        'saidNo',
-        'invalidAskYesNoResponse',
-      ],
+      templates: {
+        invalidAskYesNoResponse: {
+          fieldName: 'invalidAskYesNoResponse',
+          fieldType: templateFieldTypes.text,
+          name: 'invalidAskYesNoResponse',
+        },
+        saidNo: {
+          fieldName: 'noTransition',
+          fieldType: templateFieldTypes.transition,
+          name: 'saidNo',
+        },
+        saidYes: {
+          fieldName: 'yesTransition',
+          fieldType: templateFieldTypes.transition,
+          name: 'saidYes',
+        },
+      },
     },
     autoReply: {
       type: 'autoReply',

--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -61,15 +61,15 @@ module.exports = {
           fieldType: templateFieldTypes.text,
           name: 'invalidAskYesNoResponse',
         },
-        saidNo: {
-          fieldName: 'noTransition',
-          fieldType: templateFieldTypes.transition,
-          name: 'saidNo',
-        },
         saidYes: {
           fieldName: 'yesTransition',
           fieldType: templateFieldTypes.transition,
           name: 'saidYes',
+        },
+        saidNo: {
+          fieldName: 'noTransition',
+          fieldType: templateFieldTypes.transition,
+          name: 'saidNo',
         },
       },
     },

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -141,21 +141,16 @@ async function getTopicTemplates(contentfulEntry) {
   templateNames.forEach((templateName) => {
     const fieldName = templatesConfig[templateName].fieldName;
     const fieldValue = contentfulEntry.fields[fieldName];
-    if (module.exports.isTransitionTemplate(contentType, templateName)) {
-      // TODO: Pass cache clear parameter.
-      promises.push(module.exports.getMessageTemplate(fieldValue));
-    } else {
-      templates[templateName] = {
-        text: fieldValue,
-        topic: {},
-      };
-    }
+    const isTransition = module.exports.isTransitionTemplate(contentType, templateName);
+    const promise = isTransition ? module.exports.getMessageTemplate(fieldValue) : Promise.resolve({
+      text: fieldValue,
+      topic: {},
+    });
+    promises.push(promise);
   });
   const messageTemplates = await Promise.all(promises);
   templateNames.forEach((templateName, index) => {
-    if (module.exports.isTransitionTemplate(contentType, templateName)) {
-      templates[templateName] = messageTemplates[index];
-    }
+    templates[templateName] = messageTemplates[index];
   });
 
   // The first iteration of askYesNo did not use transition fields for saidYes and saidNo templates;

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -137,16 +137,13 @@ async function getTopicTemplates(contentfulEntry) {
   }
 
   const templateNames = Object.keys(templatesConfig);
-  const promises = [];
-  templateNames.forEach((templateName) => {
-    const fieldName = templatesConfig[templateName].fieldName;
-    const fieldValue = contentfulEntry.fields[fieldName];
+  const promises = templateNames.map((templateName) => {
+    const fieldValue = contentfulEntry.fields[templatesConfig[templateName].fieldName];
     const isTransition = module.exports.isTransitionTemplate(contentType, templateName);
-    const promise = isTransition ? module.exports.getMessageTemplate(fieldValue) : Promise.resolve({
+    return isTransition ? module.exports.getMessageTemplate(fieldValue) : Promise.resolve({
       text: fieldValue,
       topic: {},
     });
-    promises.push(promise);
   });
   const messageTemplates = await Promise.all(promises);
   templateNames.forEach((templateName, index) => {

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -151,23 +151,23 @@ async function getTopicTemplates(contentfulEntry) {
   });
 
   // The first iteration of askYesNo did not use transition fields for saidYes and saidNo templates;
-  // it had separate text and topic fields per template. This backfills entries created during that
-  // first iteration -- ideally we could run a migration to backfill with transition references and
-  // remove this code once complete.
+  // it had separate text and topic fields per template. This code block supports entries created
+  // during that first iteration -- ideally we could run a migration to backfill these entries with
+  // transition references created from the respective text and topic fields.
   if (module.exports.isAskYesNo(contentfulEntry)) {
     const fields = contentfulEntry.fields;
-    if (!templates.saidNo || !templates.saidNo.text) {
-      const saidNoTopicId = contentful.getContentfulIdFromContentfulEntry(fields.saidNoTopic);
-      templates.saidNo = {
-        text: fields.saidNo,
-        topic: saidNoTopicId ? await helpers.topic.getById(saidNoTopicId) : {},
-      };
-    }
     if (!templates.saidYes || !templates.saidYes.text) {
       const saidYesTopicId = contentful.getContentfulIdFromContentfulEntry(fields.saidYesTopic);
       templates.saidYes = {
         text: fields.saidYes,
         topic: saidYesTopicId ? await helpers.topic.getById(saidYesTopicId) : {},
+      };
+    }
+    if (!templates.saidNo || !templates.saidNo.text) {
+      const saidNoTopicId = contentful.getContentfulIdFromContentfulEntry(fields.saidNoTopic);
+      templates.saidNo = {
+        text: fields.saidNo,
+        topic: saidNoTopicId ? await helpers.topic.getById(saidNoTopicId) : {},
       };
     }
   }

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -171,7 +171,7 @@ async function getTopicTemplates(contentfulEntry) {
         topic: saidNoTopicId ? await helpers.topic.getById(saidNoTopicId) : {},
       };
     }
-    if (!templates.saidYes || !templates.saidNo.text) {
+    if (!templates.saidYes || !templates.saidYes.text) {
       const saidYesTopicId = contentful.getContentfulIdFromContentfulEntry(fields.saidYesTopic);
       templates.saidYes = {
         text: fields.saidYes,

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -158,7 +158,7 @@ async function getTopicTemplates(contentfulEntry) {
     }
   });
 
-  // The first iteration of askYesNo did not use transition fields for  saidYes, saidNo templates.
+  // The first iteration of askYesNo did not use transition fields for saidYes and saidNo templates;
   // it had separate text and topic fields per template. This backfills entries created during that
   // first iteration -- ideally we could run a migration to backfill with transition references and
   // remove this code once complete.

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -136,46 +136,59 @@ async function getTopicTemplates(contentfulEntry) {
     return templates;
   }
 
-  if (contentType !== config.contentTypes.askYesNo.type) {
-    const templateNames = Object.keys(templatesConfig);
-    const promises = [];
-    templateNames.forEach((templateName) => {
-      const fieldName = templatesConfig[templateName].fieldName;
-      const fieldValue = contentfulEntry.fields[fieldName];
-      if (module.exports.isTransitionTemplate(contentType, templateName)) {
-        // TODO: Pass cache clear parameter to refresh the transition topic.
-        promises.push(module.exports.getMessageTemplate(fieldValue));
-      } else {
-        templates[templateName] = {
-          text: fieldValue,
-          topic: {},
-        };
-      }
-    });
-    const messageTemplates = await Promise.all(promises);
-    templateNames.forEach((templateName, index) => {
-      if (module.exports.isTransitionTemplate(contentType, templateName)) {
-        templates[templateName] = messageTemplates[index];
-      }
-    });
-    return templates;
-  }
+  const templateNames = Object.keys(templatesConfig);
+  const promises = [];
+  templateNames.forEach((templateName) => {
+    const fieldName = templatesConfig[templateName].fieldName;
+    const fieldValue = contentfulEntry.fields[fieldName];
+    if (module.exports.isTransitionTemplate(contentType, templateName)) {
+      // TODO: Pass cache clear parameter.
+      promises.push(module.exports.getMessageTemplate(fieldValue));
+    } else {
+      templates[templateName] = {
+        text: fieldValue,
+        topic: {},
+      };
+    }
+  });
+  const messageTemplates = await Promise.all(promises);
+  templateNames.forEach((templateName, index) => {
+    if (module.exports.isTransitionTemplate(contentType, templateName)) {
+      templates[templateName] = messageTemplates[index];
+    }
+  });
 
-  const fields = contentfulEntry.fields;
-  /* eslint-disable */
-  // TODO: Disabling our linter probably isn't best way to handle this, find topics in parallel
-  // instead of serially per https://github.com/DoSomething/gambit-campaigns/pull/1088/files#r220969795
-  for (const fieldName of templatesConfig) {
-    const templateTopicEntry = fields[`${fieldName}Topic`];
-    templates[fieldName] = {
-      text: fields[fieldName],
-      topic: templateTopicEntry ? await helpers.topic
-        .getById(contentful.getContentfulIdFromContentfulEntry(templateTopicEntry)) : {},
-    };
+  // The first iteration of askYesNo did not use transition fields for  saidYes, saidNo templates.
+  // it had separate text and topic fields per template. This backfills entries created during that
+  // first iteration -- ideally we could run a migration to backfill with transition references and
+  // remove this code once complete.
+  if (module.exports.isAskYesNo(contentfulEntry)) {
+    const fields = contentfulEntry.fields;
+    if (!templates.saidNo || !templates.saidNo.text) {
+      const saidNoTopicId = contentful.getContentfulIdFromContentfulEntry(fields.saidNoTopic);
+      templates.saidNo = {
+        text: fields.saidNo,
+        topic: saidNoTopicId ? await helpers.topic.getById(saidNoTopicId) : {},
+      };
+    }
+    if (!templates.saidYes || !templates.saidNo.text) {
+      const saidYesTopicId = contentful.getContentfulIdFromContentfulEntry(fields.saidYesTopic);
+      templates.saidYes = {
+        text: fields.saidYes,
+        topic: saidYesTopicId ? await helpers.topic.getById(saidYesTopicId) : {},
+      };
+    }
   }
-  /* eslint-enable */
 
   return templates;
+}
+
+/**
+ * @param {Object} contentfulEntry
+ * @return {Boolean}
+ */
+function isAskYesNo(contentfulEntry) {
+  return contentful.isContentType(contentfulEntry, config.contentTypes.askYesNo.type);
 }
 
 /**
@@ -238,6 +251,7 @@ module.exports = {
   getMessageTemplate,
   getSummaryFromContentfulEntry,
   getTopicTemplates,
+  isAskYesNo,
   isAutoReply,
   isBroadcastable,
   isDefaultTopicTrigger,

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -174,6 +174,12 @@ test('getTopicTemplates should call topic.getById to set saidYes and saidNo topi
   result.saidNo.topic.should.deep.equal(fetchTopicResult);
 });
 
+// isAskYesNo
+test('isAskYesNo returns whether content type is askYesNo', (t) => {
+  t.truthy(contentfulEntryHelper.isAskYesNo(askYesNoEntry));
+  t.falsy(contentfulEntryHelper.isAskYesNo(autoReplyEntry));
+});
+
 // isAutoReply
 test('isAutoReply returns whether content type is autoReply', (t) => {
   t.falsy(contentfulEntryHelper.isAutoReply(askYesNoEntry));


### PR DESCRIPTION
#### What's this PR do?

Continuing part in #1091 -  this PR inspects newly added `yesTransition` and `noTransition` reference fields on the `askYesNo` type to render the `saidYes` and `saidNo` templates. It also supports existing `askYesNo` entries that won't have these fields set, inspecting the `saidYes`, `saidYesTopic`, `saidNo`, `saidNoTopic` field values as a backup.

#### How should this be reviewed?

The draft "Dev test askYesNo" entry has only the transition fields set and does not have the older fields set, should return non-empty `saidYes` and `saidNo` templates.

* https://gambit-admin-staging.herokuapp.com/broadcasts/5q56wA4uJ2SoAi6uAS4uYK

Any other askYesNo won't have the new fields set but should still return non-empty `saidYes` and `saidNo` templates:

*  https://gambit-admin-staging.herokuapp.com/broadcasts/296WVJhHQ8CMsuUyEsGo4s


#### Any background context you want to provide?

This aims to help error-proof broadcast setup, where the `saidYes` text content may not align with whatever the expected response is in the corresponding `saidYesTopic` field. By using a reference field limited to an `autoReplyTransition`, `photoPostTransition`, or `textPostTransition` types, we can set the help text for each topic accordingly (if this is a text post, our transition message should be asking the user whatever campaign ask that the the text post is for)

#### Relevant tickets
https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
