### PR TITLE
Keyword transitions

### DIFF
--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -11,7 +11,7 @@ const templateFieldTypes = {
  * Content types with either a templates or postType property set are returned as topics.
  *
  * If the type contains a templates object, each property defines the Contentful field name and type
- * to use as a bot reply template fir the topic.
+ * to use as a template within the topic.
  * If the type contains a postType string property instead, its an older content type and its
  * templates are configured via config/lib/helpers/topic. Ideally we should consolidate, but it'd
  * take a bit of refactoring as the topic helper config contains default values for certain text

--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -9,8 +9,9 @@ const templateFieldTypes = {
  * This maps the fields in our Contentful types into broadcast, topic, and defaultTopicTriggers.
  *
  * Content types with either a templates or postType property set are returned as topics.
- * If the type contains a templates array, each array item should correspond to a single value text
- * field defined on the content type, which is used as a bot reply template in the topic.
+ *
+ * If the type contains a templates object, each property defines the Contentful field name and type
+ * to use as a bot reply template fir the topic.
  * If the type contains a postType string property instead, its an older content type and its
  * templates are configured via config/lib/helpers/topic. Ideally we should consolidate, but it'd
  * take a bit of refactoring as the topic helper config contains default values for certain text
@@ -21,6 +22,8 @@ const templateFieldTypes = {
  * exists, it will include the topic in the outbound message, indicating that the conversation topic
  * should be updated upon receiving the broadcast (otherwise, the broadcast itself can be used as a
  * topic if it has templates -- e.g. askYesNo)
+ *
+ * A transitionable content type requires a text field named "text" and a reference field "topic".
  */
 module.exports = {
   contentTypes: {
@@ -87,6 +90,10 @@ module.exports = {
       type: 'autoReplyBroadcast',
       broadcastable: true,
     },
+    autoReplyTransition: {
+      type: 'autoReplyTransition',
+      transitionable: true,
+    },
     defaultTopicTrigger: {
       type: 'defaultTopicTrigger',
     },
@@ -102,6 +109,10 @@ module.exports = {
       // TODO: Refactor photoPostConfig in config/lib/helpers/topic here to DRY.
       postType: 'photo',
     },
+    photoPostTransition: {
+      type: 'photoPostTransition',
+      transitionable: true,
+    },
     textPostBroadcast: {
       type: 'textPostBroadcast',
       broadcastable: true,
@@ -110,6 +121,10 @@ module.exports = {
       type: 'textPostConfig',
       // TODO: Move textPostConfig in config/lib/helpers/topic here to DRY.
       postType: 'text',
+    },
+    textPostTransition: {
+      type: 'textPostTransition',
+      transitionable: true,
     },
     // Legacy types:
     // Ideally we'd backfill all legacy entries as their new types, but we likely can't change the

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -80,7 +80,7 @@ function parseContentfulEntry(contentfulEntry) {
     return helpers.topic.parseTopicFromContentfulEntry(contentfulEntry);
   }
   if (helpers.defaultTopicTrigger.getContentTypes().includes(contentType)) {
-    return helpers.defaultTopicTrigger.parseDefaultTopicTriggerFromContentfulEntry(contentfulEntry);
+    return helpers.defaultTopicTrigger.parseDefaultTopicTrigger(contentfulEntry);
   }
 
   return Promise.resolve(null);

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -225,6 +225,15 @@ function isMessage(contentfulEntry) {
 }
 
 /**
+ * @param {Object} contentfulEntry
+ * @return {Boolean}
+ */
+function isTransitionable(contentfulEntry) {
+  const contentType = contentful.getContentTypeFromContentfulEntry(contentfulEntry);
+  return config.contentTypes[contentType].transitionable;
+}
+
+/**
  * @param {String} contentType
  * @param {String} templateName
  * @return {Boolean}
@@ -249,6 +258,7 @@ module.exports = {
   isDefaultTopicTrigger,
   isLegacyBroadcast,
   isMessage,
+  isTransitionable,
   isTransitionTemplate,
   parseContentfulEntry,
 };

--- a/lib/helpers/defaultTopicTrigger.js
+++ b/lib/helpers/defaultTopicTrigger.js
@@ -91,35 +91,42 @@ function getTriggersFromDefaultTopicTriggers(defaultTopicTriggers) {
  * triggers on the default topic.
  *
  * @param {Object} contentfulEntry - defaultTopicTrigger
- * @return {String}
+ * @return {Promise}
  */
-function parseDefaultTopicTriggerFromContentfulEntry(contentfulEntry) {
+async function parseDefaultTopicTriggerFromContentfulEntry(contentfulEntry) {
   const data = {
     id: contentful.getContentfulIdFromContentfulEntry(contentfulEntry),
     trigger: contentful.getTriggerTextFromDefaultTopicTrigger(contentfulEntry),
   };
 
   const responseEntry = contentful.getResponseEntryFromDefaultTopicTrigger(contentfulEntry);
+  // Check for draft entries that may not contain a response reference.
   if (!responseEntry) {
-    return Promise.resolve(null);
+    return null;
   }
 
   if (helpers.contentfulEntry.isDefaultTopicTrigger(responseEntry)) {
     data.redirect = contentful.getTriggerTextFromDefaultTopicTrigger(responseEntry);
-    return Promise.resolve(data);
+    return data;
   }
 
   if (helpers.contentfulEntry.isMessage(responseEntry)) {
     data.reply = contentful.getTextFromMessage(responseEntry);
-    return Promise.resolve(data);
+    return data;
   }
 
+  if (helpers.contentfulEntry.isTransitionable(responseEntry)) {
+    data.reply = contentful.getTextFromMessage(responseEntry);
+    data.topic = await helpers.topic
+      .fetchById(contentful.getContentfulIdFromContentfulEntry(responseEntry.fields.topic));
+    return data;
+  }
+
+  // TODO: This will be removed once all defaultTopicTriggers that reference topic entries (e.g.
+  // photoPost, textPost) are updated to reference transition entries (e.g. photoPostTransition).
   data.topicId = contentful.getContentfulIdFromContentfulEntry(responseEntry);
-  return helpers.topic.fetchById(data.topicId)
-    .then((topic) => {
-      data.topic = topic;
-      return data;
-    });
+  data.topic = await helpers.topic.fetchById(data.topicId);
+  return data;
 }
 
 module.exports = {

--- a/lib/helpers/defaultTopicTrigger.js
+++ b/lib/helpers/defaultTopicTrigger.js
@@ -22,7 +22,7 @@ function getContentTypes() {
 function fetch(query = {}) {
   return contentful.fetchByContentTypes(module.exports.getContentTypes(), query)
     .then(contentfulRes => Promise.map(contentfulRes.data, module.exports
-      .parseDefaultTopicTriggerFromContentfulEntry))
+      .parseDefaultTopicTrigger))
     // TODO: We need to modify the meta data too, as we're removing data items here.
     .then(defaultTopicTriggers => module.exports
       .removeInvalidDefaultTopicTriggers(defaultTopicTriggers));
@@ -30,7 +30,7 @@ function fetch(query = {}) {
 
 /**
  * Removes any null items that may be present from parsing draft Contentful entries.
- * @see parseDefaultTopicTriggerFromContentfulEntry
+ * @see parseDefaultTopicTrigger
  *
  * @param {Array}
  * @return {Array}
@@ -93,7 +93,7 @@ function getTriggersFromDefaultTopicTriggers(defaultTopicTriggers) {
  * @param {Object} contentfulEntry - defaultTopicTrigger
  * @return {Promise}
  */
-async function parseDefaultTopicTriggerFromContentfulEntry(contentfulEntry) {
+async function parseDefaultTopicTrigger(contentfulEntry) {
   const data = {
     id: contentful.getContentfulIdFromContentfulEntry(contentfulEntry),
     trigger: contentful.getTriggerTextFromDefaultTopicTrigger(contentfulEntry),
@@ -118,13 +118,14 @@ async function parseDefaultTopicTriggerFromContentfulEntry(contentfulEntry) {
   if (helpers.contentfulEntry.isTransitionable(responseEntry)) {
     data.reply = contentful.getTextFromMessage(responseEntry);
     data.topic = await helpers.topic
-      .fetchById(contentful.getContentfulIdFromContentfulEntry(responseEntry.fields.topic));
+      .getById(contentful.getContentfulIdFromContentfulEntry(responseEntry.fields.topic));
     return data;
   }
 
   // TODO: This will be removed once all defaultTopicTriggers that reference topic entries (e.g.
   // photoPost, textPost) are updated to reference transition entries (e.g. photoPostTransition).
   data.topicId = contentful.getContentfulIdFromContentfulEntry(responseEntry);
+  // Should this have been retrieiving topics from cache?
   data.topic = await helpers.topic.fetchById(data.topicId);
   return data;
 }
@@ -136,6 +137,6 @@ module.exports = {
   getByTopicId,
   getContentTypes,
   getTriggersFromDefaultTopicTriggers,
-  parseDefaultTopicTriggerFromContentfulEntry,
+  parseDefaultTopicTrigger,
   removeInvalidDefaultTopicTriggers,
 };

--- a/lib/helpers/defaultTopicTrigger.js
+++ b/lib/helpers/defaultTopicTrigger.js
@@ -124,9 +124,10 @@ async function parseDefaultTopicTrigger(contentfulEntry) {
 
   // TODO: This will be removed once all defaultTopicTriggers that reference topic entries (e.g.
   // photoPost, textPost) are updated to reference transition entries (e.g. photoPostTransition).
+  // The changeTopicTrigger code in Conversations will be deprecated as well once all entries are
+  // backfilled with transition entries.
   data.topicId = contentful.getContentfulIdFromContentfulEntry(responseEntry);
-  // Should this have been retrieiving topics from cache?
-  data.topic = await helpers.topic.fetchById(data.topicId);
+  data.topic = await helpers.topic.getById(data.topicId);
   return data;
 }
 

--- a/lib/helpers/defaultTopicTrigger.js
+++ b/lib/helpers/defaultTopicTrigger.js
@@ -21,8 +21,7 @@ function getContentTypes() {
  */
 function fetch(query = {}) {
   return contentful.fetchByContentTypes(module.exports.getContentTypes(), query)
-    .then(contentfulRes => Promise.map(contentfulRes.data, module.exports
-      .parseDefaultTopicTrigger))
+    .then(contentfulRes => Promise.map(contentfulRes.data, module.exports.parseDefaultTopicTrigger))
     // TODO: We need to modify the meta data too, as we're removing data items here.
     .then(defaultTopicTriggers => module.exports
       .removeInvalidDefaultTopicTriggers(defaultTopicTriggers));
@@ -66,24 +65,6 @@ function getAll() {
 function getAllWithCampaignTopics() {
   return module.exports.getAll().then(defaultTopicTriggers => defaultTopicTriggers
     .filter(trigger => trigger.topic && trigger.topic.campaign));
-}
-
-/**
- * @param {String} topicId
- * @return {Promise}
- */
-function getByTopicId(topicId) {
-  return module.exports.getAll()
-    .then(defaultTopicTriggers => defaultTopicTriggers
-      .filter(defaultTopicTrigger => defaultTopicTrigger.topicId === topicId));
-}
-
-/**
- * @param {Array} defaultTopicTriggers
- * @return {Array}
- */
-function getTriggersFromDefaultTopicTriggers(defaultTopicTriggers) {
-  return defaultTopicTriggers.map(defaultTopicTrigger => defaultTopicTrigger.trigger);
 }
 
 /**
@@ -135,9 +116,7 @@ module.exports = {
   fetch,
   getAll,
   getAllWithCampaignTopics,
-  getByTopicId,
   getContentTypes,
-  getTriggersFromDefaultTopicTriggers,
   parseDefaultTopicTrigger,
   removeInvalidDefaultTopicTriggers,
 };

--- a/lib/middleware/topics/single/topic-get.js
+++ b/lib/middleware/topics/single/topic-get.js
@@ -3,18 +3,7 @@
 const helpers = require('../../../helpers');
 
 module.exports = function getTopic() {
-  return (req, res) => {
-    const topicId = req.params.topicId;
-    return helpers.topic.getById(topicId, helpers.request.isCacheReset(req))
-      .then((topic) => {
-        req.data = topic;
-        return helpers.defaultTopicTrigger.getByTopicId(topicId);
-      })
-      .then((defaultTopicTriggers) => {
-        req.data.triggers = helpers.defaultTopicTrigger
-          .getTriggersFromDefaultTopicTriggers(defaultTopicTriggers);
-        return helpers.response.sendData(res, req.data);
-      })
-      .catch(err => helpers.sendErrorResponse(res, err));
-  };
+  return (req, res) => helpers.topic.getById(req.params.topicId, helpers.request.isCacheReset(req))
+    .then(topic => helpers.response.sendData(res, topic))
+    .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -17,6 +17,7 @@ const config = require('../../../config/lib/helpers/contentfulEntry');
 const askYesNoEntryFactory = require('../../utils/factories/contentful/askYesNo');
 const autoReplyFactory = require('../../utils/factories/contentful/autoReply');
 const autoReplyBroadcastFactory = require('../../utils/factories/contentful/autoReplyBroadcast');
+const autoReplyTransitionFactory = require('../../utils/factories/contentful/autoReplyTransition');
 const defaultTopicTriggerFactory = require('../../utils/factories/contentful/defaultTopicTrigger');
 const messageFactory = require('../../utils/factories/contentful/message');
 // Parsed factories
@@ -26,6 +27,7 @@ const broadcastFactory = require('../../utils/factories/broadcast');
 const askYesNoEntry = askYesNoEntryFactory.getValidAskYesNo();
 const autoReplyEntry = autoReplyFactory.getValidAutoReply();
 const autoReplyBroadcastEntry = autoReplyBroadcastFactory.getValidAutoReplyBroadcast();
+const autoReplyTransitionEntry = autoReplyTransitionFactory.getValidAutoReplyTransition();
 const defaultTopicTriggerEntry = defaultTopicTriggerFactory.getValidDefaultTopicTrigger();
 const messageEntry = messageFactory.getValidMessage();
 const fetchTopicResult = { id: stubs.getContentfulId() };
@@ -202,6 +204,12 @@ test('isDefaultTopicTrigger returns whether content type is defaultTopicTrigger'
 test('isMessage returns whether content type is message', (t) => {
   t.truthy(contentfulEntryHelper.isMessage(messageEntry));
   t.falsy(contentfulEntryHelper.isMessage(autoReplyEntry));
+});
+
+// isTransitionable
+test('isTransitionable returns whether content type is transitionable', (t) => {
+  t.truthy(contentfulEntryHelper.isTransitionable(autoReplyTransitionEntry));
+  t.falsy(contentfulEntryHelper.isTransitionable(autoReplyBroadcastEntry));
 });
 
 // isTransitionTemplate

--- a/test/lib/lib-helpers/defaultTopicTrigger.test.js
+++ b/test/lib/lib-helpers/defaultTopicTrigger.test.js
@@ -102,15 +102,6 @@ test('getAll returns fetch results if cache not set', async () => {
   result.should.deep.equal(fetchResult);
 });
 
-// getTriggersFromDefaultTopicTriggers
-test('getTriggersFromDefaultTopicTriggers returns array of trigger properties', () => {
-  const defaultTopicTriggers = [firstDefaultTopicTrigger, secondDefaultTopicTrigger];
-
-  const result = defaultTopicTriggerHelper
-    .getTriggersFromDefaultTopicTriggers(defaultTopicTriggers);
-  result.should.deep.equal([firstDefaultTopicTrigger.trigger, secondDefaultTopicTrigger.trigger]);
-});
-
 // parseDefaultTopicTrigger
 test('parseDefaultTopicTrigger returns null if entry response reference is falsy', async (t) => {
   sandbox.stub(contentful, 'getResponseEntryFromDefaultTopicTrigger')
@@ -120,7 +111,7 @@ test('parseDefaultTopicTrigger returns null if entry response reference is falsy
   t.is(result, null);
 });
 
-test('parseDefaultTopicTrigger returns object without topic if entry response is a message', async (t) => {
+test('parseDefaultTopicTrigger returns object without topic if entry response is a message', async () => {
   const messageEntry = messageEntryFactory.getValidMessage();
   const triggerText = stubs.getRandomMessageText();
   sandbox.stub(contentful, 'getTextFromMessage')

--- a/test/lib/lib-helpers/defaultTopicTrigger.test.js
+++ b/test/lib/lib-helpers/defaultTopicTrigger.test.js
@@ -12,14 +12,15 @@ const stubs = require('../../utils/stubs');
 const helpers = require('../../../lib/helpers');
 const config = require('../../../config/lib/helpers/defaultTopicTrigger');
 
-const defaultTopicTriggerContentfulFactory = require('../../utils/factories/contentful/defaultTopicTrigger');
+const defaultTopicTriggerEntryFactory = require('../../utils/factories/contentful/defaultTopicTrigger');
+const messageEntryFactory = require('../../utils/factories/contentful/message');
 const defaultTopicTriggerFactory = require('../../utils/factories/defaultTopicTrigger');
 const topicFactory = require('../../utils/factories/topic');
 
 const contentfulId = stubs.getContentfulId();
-const firstEntry = defaultTopicTriggerContentfulFactory.getValidDefaultTopicTrigger();
+const firstEntry = defaultTopicTriggerEntryFactory.getValidDefaultTopicTrigger();
 const firstDefaultTopicTrigger = defaultTopicTriggerFactory.getValidDefaultTopicTriggerWithReply();
-const secondEntry = defaultTopicTriggerContentfulFactory.getValidDefaultTopicTrigger();
+const secondEntry = defaultTopicTriggerEntryFactory.getValidDefaultTopicTrigger();
 const secondDefaultTopicTrigger = defaultTopicTriggerFactory.getValidDefaultTopicTriggerWithReply();
 
 // Module to test
@@ -111,6 +112,26 @@ test('getTriggersFromDefaultTopicTriggers returns array of trigger properties', 
 });
 
 // parseDefaultTopicTrigger
+test('parseDefaultTopicTrigger returns null if entry response reference is falsy', async (t) => {
+  sandbox.stub(contentful, 'getResponseEntryFromDefaultTopicTrigger')
+    .returns(null);
+
+  const result = await defaultTopicTriggerHelper.parseDefaultTopicTrigger(firstEntry);
+  t.is(result, null);
+});
+
+test('parseDefaultTopicTrigger returns object without topic if entry response is a message', async (t) => {
+  const messageEntry = messageEntryFactory.getValidMessage();
+  const triggerText = stubs.getRandomMessageText();
+  sandbox.stub(contentful, 'getTextFromMessage')
+    .returns(triggerText);
+  const triggerEntry = defaultTopicTriggerEntryFactory.getValidDefaultTopicTrigger(messageEntry);
+
+  const result = await defaultTopicTriggerHelper.parseDefaultTopicTrigger(triggerEntry);
+  result.reply.should.equal(triggerText);
+  result.should.not.have.property('topic');
+});
+
 test('parseDefaultTopicTrigger returns object with reply and topic if entry is transitionable', async () => {
   const topic = topicFactory.getValidTopic();
   const triggerText = stubs.getRandomMessageText();

--- a/test/lib/middleware/topics/single/topic-get.test.js
+++ b/test/lib/middleware/topics/single/topic-get.test.js
@@ -11,12 +11,9 @@ const underscore = require('underscore');
 
 const stubs = require('../../../../utils/stubs');
 const helpers = require('../../../../../lib/helpers');
-
-const defaultTopicTriggerFactory = require('../../../../utils/factories/defaultTopicTrigger');
 const topicFactory = require('../../../../utils/factories/topic');
 
 const topic = topicFactory.getValidTopic();
-const defaultTopicTrigger = defaultTopicTriggerFactory.getValidDefaultTopicTriggerWithTopic();
 
 chai.should();
 chai.use(sinonChai);
@@ -47,8 +44,6 @@ test('getTopic should inject a topic property set to getById result', async (t) 
   const middleware = getTopic();
   sandbox.stub(helpers.topic, 'getById')
     .returns(Promise.resolve(topic));
-  sandbox.stub(helpers.defaultTopicTrigger, 'getByTopicId')
-    .returns(Promise.resolve([defaultTopicTrigger]));
 
   // test
   await middleware(t.context.req, t.context.res, next);

--- a/test/utils/factories/contentful/autoReplyTransition.js
+++ b/test/utils/factories/contentful/autoReplyTransition.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const stubs = require('../../stubs');
+const autoReplyFactory = require('./autoReply');
+
+function getValidAutoReplyTransition(date = Date.now()) {
+  const data = {
+    sys: stubs.contentful.getSysWithTypeAndDate('autoReplyTransition', date),
+    fields: {
+      text: stubs.getRandomMessageText(),
+      attachments: stubs.contentful.getAttachments(),
+      topic: autoReplyFactory.getValidAutoReply(),
+    },
+  };
+  return data;
+}
+
+module.exports = {
+  getValidAutoReplyTransition,
+};

--- a/test/utils/factories/contentful/defaultTopicTrigger.js
+++ b/test/utils/factories/contentful/defaultTopicTrigger.js
@@ -1,22 +1,16 @@
 'use strict';
 
 const stubs = require('../../stubs');
+const autoReplyTransitionFactory = require('./autoReplyTransition');
 
-function getValidDefaultTopicTrigger() {
-  const data = {
-    sys: {
-      id: '51QDjTsMbmCcW804IUGaQg',
-      contentType: {
-        sys: {
-          id: 'defaultTopicTrigger',
-        },
-      },
-    },
+function getValidDefaultTopicTrigger(responseEntry) {
+  return {
+    sys: stubs.contentful.getSysWithTypeAndDate('defaultTopicTrigger'),
     fields: {
       trigger: stubs.getRandomWord(),
+      response: responseEntry || autoReplyTransitionFactory.getValidAutoReplyTransition(),
     },
   };
-  return data;
 }
 
 module.exports = {


### PR DESCRIPTION
#### What's this PR do?

Adds support to save `autoReplyTransition`, `photoPostTransition`, and `textPostTransition` entries in for the `response` reference field on a `defaultTopicTrigger` entry, allowing for keyword-specific start messaging. 

We'll manually create a new transition entry foreach  published `defaultTopicTrigger` entry that has a topic (e.g.`autoReply`, `photoPostConfig`, `textPostConfig`) saved to its `response` reference field, updating with the newly created corresponding new transition 

Also removes fetching default topic triggers for a topic in a `GET /topics/:id` request for simplicity sake. Similar to #1090 -- we can delegate finding `defaultTopicTriggers` via their transitions to Gambit Admin, as it's only for internal use.

#### How should this be reviewed?

I was testing on a draft trigger, `puppetsloth`, which is what broke staging today (https://github.com/DoSomething/gambit-campaigns/pull/1093#issuecomment-433495494). Upon staging deploy, I'll set the draft trigger's `response` to a transition entry -- which is what caused the `broadcastable` error, a config didn't exist for a `photoPostTransition` type in `config/lib/helpers/contentfulEntry`.


#### Any background context you want to provide?

Will book a hangout to walk through which keywords need to be ported over, as I think there are quite a bit we can likely archive... 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
