### PR TITLE
Updates mongoose to 4.13.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gambit-campaigns",
-  "version": "5.13.4",
+  "version": "5.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1965,11 +1965,6 @@
         "repeat-element": "1.1.2"
       }
     },
-    "bson": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-0.5.7.tgz",
-      "integrity": "sha1-DRH+CTbB/uAp4R9wY/XQqyQi6j4="
-    },
     "buf-compare": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
@@ -2908,7 +2903,7 @@
     },
     "es6-promise": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
       "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
     },
     "es6-promisify": {
@@ -4454,11 +4449,6 @@
         "os-tmpdir": "1.0.2"
       }
     },
-    "hooks-fixed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.2.0.tgz",
-      "integrity": "sha1-DSdy1NfWhf+SRHJKnwtbJVmqyWs="
-    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -5134,11 +5124,6 @@
       "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
       "dev": true
     },
-    "kareem": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.1.3.tgz",
-      "integrity": "sha1-CHdhDYh5w42mLR26/eThfyaS8EE="
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -5255,8 +5240,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -5523,130 +5507,142 @@
         "minimist": "0.0.8"
       }
     },
-    "mongodb": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.11.tgz",
-      "integrity": "sha1-qCiwNv5qQ3o15yOvX4F4HEl2MGw=",
+    "mongoose": {
+      "version": "4.13.17",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.13.17.tgz",
+      "integrity": "sha512-VGeSP5O3k9HUXsNm9AocdAlVbfaHV/RHgHc8Jfvwr0D0ZyzgJ3JJ+MKSmz+omicNOhBsmpBEL1zVHM2uIj8tDQ==",
       "requires": {
-        "es6-promise": "3.2.1",
-        "mongodb-core": "2.0.13",
-        "readable-stream": "2.1.5"
+        "async": "2.6.0",
+        "bson": "1.0.9",
+        "hooks-fixed": "2.0.2",
+        "kareem": "1.5.0",
+        "lodash.get": "4.4.2",
+        "mongodb": "2.2.34",
+        "mpath": "0.5.1",
+        "mpromise": "0.5.5",
+        "mquery": "2.3.3",
+        "ms": "2.0.0",
+        "muri": "1.3.0",
+        "regexp-clone": "0.0.1",
+        "sliced": "1.0.1"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.10"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+        },
+        "bson": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+          "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "hooks-fixed": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.2.tgz",
+          "integrity": "sha512-YurCM4gQSetcrhwEtpQHhQ4M7Zo7poNGqY4kQGeBS6eZtOcT3tnNs01ThFa0jYBByAiYt1MjMjP/YApG0EnAvQ=="
+        },
+        "kareem": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz",
+          "integrity": "sha1-4+QQHZ3P3imXadr0tNtk2JXRdEg="
+        },
+        "mongodb": {
+          "version": "2.2.34",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.34.tgz",
+          "integrity": "sha1-o09Zu+thdUrsQy3nLD/iFSakTBo=",
+          "requires": {
+            "es6-promise": "3.2.1",
+            "mongodb-core": "2.1.18",
+            "readable-stream": "2.2.7"
+          }
+        },
+        "mongodb-core": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.18.tgz",
+          "integrity": "sha1-TEYTm986HwMt7ZHbSfOO7AFlkFA=",
+          "requires": {
+            "bson": "1.0.9",
+            "require_optional": "1.0.1"
+          }
+        },
+        "mpath": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.1.tgz",
+          "integrity": "sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg=="
+        },
+        "mquery": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.3.tgz",
+          "integrity": "sha512-NC8L14kn+qxJbbJ1gbcEMDxF0sC3sv+1cbRReXXwVvowcwY1y9KoVZFq0ebwARibsadu8lx8nWGvm3V0Pf0ZWQ==",
+          "requires": {
+            "bluebird": "3.5.0",
+            "debug": "2.6.9",
+            "regexp-clone": "0.0.1",
+            "sliced": "0.0.5"
+          },
+          "dependencies": {
+            "sliced": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+              "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
+            }
+          }
+        },
+        "muri": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/muri/-/muri-1.3.0.tgz",
+          "integrity": "sha512-FiaFwKl864onHFFUV/a2szAl7X0fxVlSKNdhTf+BM8i8goEgYut8u5P9MqQqIYwvaMxjzVESsoEm/2kfkFH1rg=="
+        },
         "process-nextick-args": {
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "readable-stream": {
-          "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
           "requires": {
             "buffer-shims": "1.0.0",
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "1.0.0",
             "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
+            "string_decoder": "1.0.3",
             "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
-    "mongodb-core": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.0.13.tgz",
-      "integrity": "sha1-+TlLWI3ODleUguU9dNvH16nUUZw=",
-      "requires": {
-        "bson": "0.5.7",
-        "require_optional": "1.0.1"
-      }
-    },
-    "mongoose": {
-      "version": "4.6.8",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.6.8.tgz",
-      "integrity": "sha1-H7tptN6GI6Pj7mOolCWiJ8XSTak=",
-      "requires": {
-        "async": "2.1.2",
-        "bson": "0.5.7",
-        "hooks-fixed": "1.2.0",
-        "kareem": "1.1.3",
-        "mongodb": "2.2.11",
-        "mpath": "0.2.1",
-        "mpromise": "0.5.5",
-        "mquery": "2.0.0",
-        "ms": "0.7.1",
-        "muri": "1.1.1",
-        "regexp-clone": "0.0.1",
-        "sliced": "1.0.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
-          "integrity": "sha1-YSpKtF70KnDN6Aa62G7m2wR+g4U=",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "lodash": "4.17.10"
+            "safe-buffer": "5.1.2"
           }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         }
       }
-    },
-    "mpath": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.2.1.tgz",
-      "integrity": "sha1-Ok6Ck1mAHeljCcJ6ay4QLon56W4="
     },
     "mpromise": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
       "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY="
-    },
-    "mquery": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.0.0.tgz",
-      "integrity": "sha1-tavIULkN/8PhCuSbS256R5dS3yI=",
-      "requires": {
-        "bluebird": "2.10.2",
-        "debug": "2.2.0",
-        "regexp-clone": "0.0.1",
-        "sliced": "0.0.5"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "2.10.2",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-          "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs="
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-        },
-        "sliced": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
-          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
-        }
-      }
     },
     "ms": {
       "version": "2.0.0",
@@ -5664,11 +5660,6 @@
         "arrify": "1.0.1",
         "minimatch": "3.0.4"
       }
-    },
-    "muri": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/muri/-/muri-1.1.1.tgz",
-      "integrity": "sha1-ZL2QTq+P+JYAyZREH608UZWQWsI="
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "express-sslify": "^1.2.0",
     "file-exists": "^4.0.0",
     "html-entities": "^1.1.1",
-    "mongoose": "4.6.8",
+    "mongoose": "^4.13.17",
     "newrelic": "4.7.0",
     "path": "~0.4.9",
     "redis": "^2.8.0",

--- a/server.js
+++ b/server.js
@@ -99,6 +99,11 @@ function start(processId) {
     })
     .catch((error) => {
       logger.error(`Gambit could not connect to port:${config.port} env:${config.environment}.`);
+      /**
+       * Note: Mongoose throws an error about the signups collection defining its own _id. Earlier
+       * versions allowed this - we may likely move draft submissions into a new collection in
+       * Conversations, porting over the relevant middleware for creating text and photo posts.
+       */
       logger.error(error.message);
     });
 }


### PR DESCRIPTION
#### What's this PR do?

Updates to the latest legacy version of Mongoose, to update the `bson` dependency.  The upgrade path to 5.x needs extra love for the config, so holding off on that for now.

The newer version of 4.x complains about how the `signups` collection defines its own `_id`, matching the numeric id of a Rogue signup.

#### How should this be reviewed?

Create a signup and photo post on staging, verify a signup and multiple posts are created.

#### Any background context you want to provide?

As far as fixing the `signups` collection, I'm leaning towards porting the `POST /campaignActivity` functionality into Gambit Conversations, as the database is only really used for collecting the various fields in a photo post. We could build something like a `draftSubmissions` table in Conversations that could support photo posts, but also various Typeform posts, like a[ DSS email subscription typeform.
](https://github.com/DoSomething/gambit-conversations/blob/3.8.4/brain/topics/dss/dssSubscribe.rive)

#### Relevant tickets

https://www.pivotaltracker.com/story/show/159237720

#### Checklist
- [ ] Tested on staging.
