### PR TITLE
Fetch signups by campaignId, not campaignRunId

### DIFF
--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -90,7 +90,6 @@ signupSchema.statics.lookupByUserIdAndCampaignId = async function (userId, campa
   }
 };
 
-
 /**
  * Posts Signup to DS API and creates Signup model.
  * @param {object} req - Express request

--- a/config/lib/middleware/campaignActivity/map-request-params.js
+++ b/config/lib/middleware/campaignActivity/map-request-params.js
@@ -9,7 +9,6 @@ configVars.paramsMap = {
   keyword: 'keyword',
   broadcastId: 'broadcast_id',
   campaignId: 'campaignId',
-  campaignRunId: 'campaignRunId',
   postType: 'postType',
   text: 'incoming_message',
   mediaUrl: 'incoming_image_url',

--- a/config/lib/middleware/campaignActivity/required-params.js
+++ b/config/lib/middleware/campaignActivity/required-params.js
@@ -5,7 +5,6 @@ const configVars = {};
 configVars.containerProperty = 'body';
 configVars.requiredParams = [
   'campaignId',
-  'campaignRunId',
   'platform',
   'userId',
 ];

--- a/documentation/endpoints/campaignActivity.md
+++ b/documentation/endpoints/campaignActivity.md
@@ -20,7 +20,6 @@ Name | Type | Description
 --- | --- | ---
 `userId` | `string` | **Required.** 
 `campaignId` | `string` | **Required.** Campaign that the User has signed up for.
-`campaignRunId` | `string` | **Required.** Campaign Run that the User has signed up for.
 `postType` | `string` |  Optional -- type of campaign post to submit (when set to `text`) or begin (when set to `photo`) 
 `platform` | `string` | **Required.** Platform that message was sent from.
 `text` | `string` | Message text.

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -160,6 +160,7 @@ module.exports = {
       title: campaign.title,
       tagline: campaign.tagline,
       status: this.parseStatus(campaign),
+      // TODO: Remove this property once Conversations stops sending to /POST campaignActivity.
       currentCampaignRun: { id: Number(campaign.legacyCampaignRunId) },
       endDate: campaign.endDate,
     };

--- a/lib/helpers/campaignActivity.js
+++ b/lib/helpers/campaignActivity.js
@@ -46,7 +46,6 @@ module.exports = {
     const data = {
       source: req.platform,
       campaign_id: req.campaignId,
-      campaign_run_id: req.campaignRunId,
       northstar_id: req.userId,
     };
     return data;

--- a/lib/middleware/campaignActivity/signup-get.js
+++ b/lib/middleware/campaignActivity/signup-get.js
@@ -4,20 +4,16 @@ const helpers = require('../../helpers');
 const Signup = require('../../../app/models/Signup.js');
 
 module.exports = function getSignup() {
-  return (req, res, next) => { // eslint-disable-line arrow-body-style
-    // TODO: Our middleware test fails with 'helpers.sendErrorResponse.should.have.been.called' if
-    // we don't explicitly use return here.
-    return Signup.lookupCurrentSignupForReq(req)
-      .then((signup) => {
-        helpers.handleTimeout(req, res);
+  return (req, res, next) => Signup.lookupByUserIdAndCampaignId(req.userId, req.campaignId)
+    .then((signup) => {
+      helpers.handleTimeout(req, res);
 
-        if (signup) {
-          helpers.request.setSignup(req, signup);
-          helpers.request.setDraftSubmission(req, signup.draft_reportback_submission);
-        }
+      if (signup) {
+        helpers.request.setSignup(req, signup);
+        helpers.request.setDraftSubmission(req, signup.draft_reportback_submission);
+      }
 
-        return next();
-      })
-      .catch(err => helpers.sendErrorResponse(res, err));
-  };
+      return next();
+    })
+    .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const logger = require('winston');
 const { RogueClient } = require('@dosomething/gateway/server');
 
 let rogueClient;
@@ -29,16 +28,15 @@ function createPost(data) {
 function createSignup(data) {
   return getClient().Signups.create(data);
 }
+
 /**
- * getSignupsByUserIdAndCampaignRunId
+ * fetchSignups
  *
- * @param {string} userId
- * @param {number} campaignRunId
+ * @param {Object} query
  * @return {Promise}
  */
-function getSignupsByUserIdAndCampaignRunId(userId, campaignRunId) {
-  logger.debug(`rogue.fetchActivity userId=${userId} campaignRunId=${campaignRunId}`);
-  return getClient().Signups.getByUserIdAndCampaignRunId(userId, campaignRunId);
+function fetchSignups(query) {
+  return getClient().Signups.index(query);
 }
 
 function getConfig() {
@@ -50,5 +48,5 @@ module.exports = {
   getClient,
   createPost,
   createSignup,
-  getSignupsByUserIdAndCampaignRunId,
+  fetchSignups,
 };

--- a/test/lib/lib-helpers/campaignActivity.test.js
+++ b/test/lib/lib-helpers/campaignActivity.test.js
@@ -38,7 +38,6 @@ test.beforeEach((t) => {
   t.context.req.userId = stubs.getUserId();
   t.context.req.incoming_message = mockMessageText;
   t.context.req.campaignId = stubs.getCampaignId();
-  t.context.req.campaignRunId = stubs.getCampaignRunId();
   t.context.req.platform = stubs.getPlatform();
   t.context.req.signup = mockSignup;
 });
@@ -74,7 +73,6 @@ test('createTextPostFromReq calls createPost with getCreateTextPostPayloadFromRe
 test('getDefaultCreatePayloadFromReq returns an object', (t) => {
   const result = activityHelper.getDefaultCreatePayloadFromReq(t.context.req);
   result.campaign_id.should.equal(t.context.req.campaignId);
-  result.campaign_run_id.should.equal(t.context.req.campaignRunId);
   result.northstar_id.should.equal(t.context.req.userId);
   result.source.should.equal(t.context.req.platform);
 });

--- a/test/lib/middleware/campaignActivity/signup-get.test.js
+++ b/test/lib/middleware/campaignActivity/signup-get.test.js
@@ -56,7 +56,8 @@ test('getSignup should call setSignup and setDraftSubmission on lookup success',
   // setup
   const next = sinon.stub();
   const middleware = getSignup();
-  sandbox.stub(Signup, 'lookupCurrentSignupForReq').returns(signupLookupStub);
+  sandbox.stub(Signup, 'lookupByUserIdAndCampaignId')
+    .returns(signupLookupStub);
 
   // test
   await middleware(t.context.req, t.context.res, next);
@@ -71,7 +72,8 @@ test('getSignup should resolve to false if a Signup was not found', async (t) =>
   // setup
   const next = sinon.stub();
   const middleware = getSignup();
-  sandbox.stub(Signup, 'lookupCurrentSignupForReq').returns(signupLookupNotFoundStub);
+  sandbox.stub(Signup, 'lookupByUserIdAndCampaignId')
+    .returns(signupLookupNotFoundStub);
 
   // test
   await middleware(t.context.req, t.context.res, next);
@@ -84,8 +86,10 @@ test('getSignup should resolve to false if a Signup was not found', async (t) =>
 test('getSignup should call sendErrorResponse when an error occurs', async (t) => {
   // setup
   const next = sinon.stub();
-  sandbox.stub(Signup, 'lookupCurrentSignupForReq').returns(signupLookupFailStub);
-  sandbox.stub(helpers, 'sendErrorResponse').returns(sendErrorResponseStub);
+  sandbox.stub(Signup, 'lookupByUserIdAndCampaignId')
+    .returns(signupLookupFailStub);
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(sendErrorResponseStub);
   const middleware = getSignup();
 
   // test

--- a/test/lib/rogue.test.js
+++ b/test/lib/rogue.test.js
@@ -10,6 +10,7 @@ const rewire = require('rewire');
 const Promise = require('bluebird');
 
 const stubs = require('../../test/utils/stubs');
+const signupFactory = require('../../test/utils/factories/signup');
 
 chai.should();
 chai.use(sinonChai);
@@ -50,13 +51,14 @@ test('rogue.createSignup() should call rogueClient.Signups.create()', () => {
   client.Signups.create.should.have.been.called;
 });
 
-test('rogue.getSignupsByUserIdAndCampaignRunId() should call rogueClient.Signups.getByUserIdAndCampaignRunId()', () => {
+test('rogue.fetchSignups() should call rogueClient.Signups.index()', async () => {
   const client = rogue.getClient();
-  sandbox.stub(client.Signups, 'getByUserIdAndCampaignRunId')
-    .returns(Promise.resolve(true));
+  const query = { northstar_id: stubs.getUserId() };
+  const signup = signupFactory.getValidSignup();
+  sandbox.stub(client.Signups, 'index')
+    .returns(Promise.resolve([signup]));
 
-  rogue.getSignupsByUserIdAndCampaignRunId(
-    stubs.getUserId(),
-    stubs.getCampaignRunId());
-  client.Signups.getByUserIdAndCampaignRunId.should.have.been.called;
+  const result = await rogue.fetchSignups(query);
+  client.Signups.index.should.have.been.calledWith(query);
+  result.should.deep.equal([signup]);
 });

--- a/test/utils/factories/topic.js
+++ b/test/utils/factories/topic.js
@@ -15,8 +15,10 @@ function getValidTopic() {
       id: stubs.getCampaignId(),
       title: stubs.getRandomName(),
       status: 'active',
+      // TODO: This will be removed.
+      // @see lib/helpers/campaign.parseCampaign
       currentCampaignRun: {
-        id: stubs.getCampaignRunId(),
+        id: stubs.getCampaignId(),
       },
     },
     templates: {

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -122,9 +122,6 @@ module.exports = {
   getCampaignId: function getCampaignId() {
     return 2299;
   },
-  getCampaignRunId: function getCampaignRunId() {
-    return 6677;
-  },
   getBroadcastId: function getBroadcastId() {
     return this.getContentfulId();
   },


### PR DESCRIPTION
#### What's this PR do?

Fixes double signups bug reported in https://github.com/DoSomething/gambit-conversations/pull/437#issuecomment-438021632 by checking for signups by user and campaign, instead of campaign run -- [matching the logic in Gambit Conversations.](https://github.com/DoSomething/gambit-conversations/blob/8964834378f5862e85fabf7fd77c99ca52ea1ed2/lib/helpers/user.js#L100)

#### How should this be reviewed?

Verify that after sending a keyword or saying yes to an `askYesNo` with a `saidYes` topic campaign, a signup is created once, and not duplicated for subsequent user messages.

#### Any background context you want to provide?

Was hoping to move most of the signup and post logic into Gambit Conversations to avoid maintaining two separate apps sending data to Rogue, since Conversations integrates with Rogue for voting plans. Ideally we'll deprecate the `POST /campaignActivity` endpoint completely to avoid needing two separate Mongo databases, but likely for this sprint we'll still need the gambit-campaigns DB to save draft submissions for a photo post.

#### Relevant tickets
* https://www.pivotaltracker.com/story/show/161494958
* Fixes bug reported in https://github.com/DoSomething/gambit-conversations/pull/437#issuecomment-438021632

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
