### PR TITLE
Fixes campaign status per Phoenix API changes

### DIFF
--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -116,7 +116,7 @@ module.exports = {
    * @return {Boolean}
    */
   hasEnded: function hasEnded(campaign) {
-    const endDate = dateFns.parse(campaign.endDate.date);
+    const endDate = dateFns.parse(campaign.endDate);
     return dateFns.isPast(endDate);
   },
   /**

--- a/test/stubs/phoenix/campaign.json
+++ b/test/stubs/phoenix/campaign.json
@@ -8,11 +8,7 @@
     "title": "#SaveTheMascots",
     "slug": "savethemascots",
     "status": null,
-    "endDate": {
-      "date": "2018-04-30 23:59:00.000000",
-      "timezone_type": 1,
-      "timezone": "-05:00"
-    },
+    "endDate": "2018-04-30T05:00:00Z",
     "callToAction": "Tag your school to help us make every college campus tobacco-free!",
     "tagline": "Tag your school to help us make every college campus tobacco-free!",
     "blurb": "",


### PR DESCRIPTION
#### What's this PR do?

Updates the `parseStatus` campaign helper per breaking Phoenix API changes in https://github.com/DoSomething/phoenix-next/pull/1097 introduced in September.

#### How should this be reviewed?

Verify expected behavior: 

* A closed campaign like Give A Spit has a `closed `status (e.g. GET /v1/campaigns/2178?cache=false&apiKey=totallysecret)

* An open campaign like Escape The Vape has an `active` status (e.g. GET /v1/campaigns/8190?cache=false&apiKey=totallysecret)

#### Any background context you want to provide?

This bug was discovered while revitalizing the list of current campaign keywords in https://github.com/DoSomething/gambit-admin/pull/80.

#### Relevant tickets

https://github.com/DoSomething/gambit-admin/pull/80

#### Checklist
- [ ] Tested on staging.
